### PR TITLE
ecflow_ui: put quotes around variable to handle whitespaces

### DIFF
--- a/Viewer/ecflowUI/scripts/ecflow_ui.in
+++ b/Viewer/ecflowUI/scripts/ecflow_ui.in
@@ -375,8 +375,8 @@ exe=${EXE_DIR}/ecflow_ui.x
 
 if [ $ECFLOWUI_BT != "no" ]
 then
-    catchsegv $exe
+    catchsegv "$exe"
 else
-    ${exe}
+    "$exe"
 fi
 


### PR DESCRIPTION
A small fix for starting ecflow_ui when its path contains whitespaces.

Executing `ecflow_ui` script installed in `/Volumes/Macintosh HD/opt/miniconda3/bin/` results in an error

    % cd /Volumes/Macintosh\ HD/opt/miniconda3/bin
    % ./ecflow_ui
    Macintosh: EXIT on ERROR (line 387), exit status 1, starting 'cleanup'
    Last 50 lines of log file:
    /Volumes/Macintosh HD/opt/miniconda3/bin/ecflow_ui: line 386: /Volumes/Macintosh: No such file or directory

Caused by missing quotes at line 386. Instead of

    exe=${EXE_DIR}/ecflow_ui.x
    ...
    ${exe}
 
changed to

    exe=${EXE_DIR}/ecflow_ui.x
    ...
    "$exe"
 
With the quotes, `ecflow_ui` starts correctly.
