### PR TITLE
boost_build.sh fails on Debian due to hardcoded /usr/lib64

### DIFF
--- a/build_scripts/boost_build.sh
+++ b/build_scripts/boost_build.sh
@@ -7,7 +7,7 @@
 ## granted to it by virtue of its status as an intergovernmental organisation 
 ## nor does it submit to any jurisdiction. 
 
-set -x
+set -ex
 #set -u
 
 # Only uncomment for debugging this script
@@ -290,8 +290,7 @@ EOF
 
    echo "ECF_PYTHON2 = [ os.environ ECF_PYTHON2 ] ;"  >>  $SITE_CONFIG_LOCATION
    
-   which python3
-   if [ "$?" = "0" ] ; then
+   if which python3; then
       
       python_version=$(python3 -c 'import sys;print(sys.version_info[0],sys.version_info[1],sep="")')
       if [[ ${BOOST_NUMERIC_VERSION} -le 1670 ]] ; then
@@ -309,8 +308,7 @@ EOF
       ./b2 --debug-configuration toolset=$tool link=shared,static variant=release "$CXXFLAGS" stage --layout=$layout threading=multi --with-python -d2 -j4
    fi
 
-   which python
-   if [ "$?" = "0" ] ; then
+   if which python; then
       export ECF_PYTHON2=1 # so that we use ' using python ......'
       echo 'if $(ECF_PYTHON2) {'                                                         >> $SITE_CONFIG_LOCATION
       

--- a/build_scripts/site_config/site-config-Linux64.jam
+++ b/build_scripts/site_config/site-config-Linux64.jam
@@ -82,9 +82,8 @@ lib boost_chrono          : : <variant>release <link>shared <file>$(BOOST_ROOT)/
 
 # ===============================================================================
 # force all exe to link with crypt 
-lib crypt : : <file>/usr/lib64/libcrypt.so ;
+lib crypt ;
 explicit crypt ; 
-
 
 #
 # Notice: we don't add  requirements <library>pthread , because
@@ -106,8 +105,8 @@ using testing ;
 # these functions are used by OpenSSL internally & thus -ldl is an
 # indirect dependency when using -lcrypto(on Linux) Because we linking
 # with static version of crypto, need to explicitly link against indirect dependencies.
-lib libssl    : : <file>/usr/lib64/libssl.so ;
-lib libcrypto : : <file>/usr/lib64/libcrypto.so ;
+lib libssl ;
+lib libcrypto ;
 lib dl        : : <link>shared ;      # this dependency for using libcrypto, i.e dlopen,dlclose etc, when using static libcrypto
 alias openssl_libs : libssl libcrypto dl ;
 

--- a/build_scripts/site_config/site-config-Linux64.jam
+++ b/build_scripts/site_config/site-config-Linux64.jam
@@ -105,10 +105,10 @@ using testing ;
 # these functions are used by OpenSSL internally & thus -ldl is an
 # indirect dependency when using -lcrypto(on Linux) Because we linking
 # with static version of crypto, need to explicitly link against indirect dependencies.
-lib libssl ;
-lib libcrypto ;
+lib ssl ;
+lib crypto ;
 lib dl        : : <link>shared ;      # this dependency for using libcrypto, i.e dlopen,dlclose etc, when using static libcrypto
-alias openssl_libs : libssl libcrypto dl ;
+alias openssl_libs : ssl crypto dl ;
 
 # ==================== INSTALL =====================================================ß
 constant ECFLOW_INSTALL_PREFIX : /usr/local/apps ; 


### PR DESCRIPTION
Ciao!

Several lines in `build_scripts/site_config/site-config-Linux64.jam` refer to system libraries using hardcoded paths, e.g.:

    lib crypt : : <file>/usr/lib64/libcrypt.so

This is causing `boost_build.sh` script to fail on my system (Linux Mint 20):

    error: at /home/blaz/dev/ecflow/boost_1_71_0/tools/build/src/kernel/modules.jam:107
    error: Unable to find file or target named
    error:     '/usr/lib64/libcrypt.so'

This is because there is no `/usr/lib64/` directory. Debian and its derivatives have `/usr/lib/x86_64-linux-gnu/` instead.
Not sure why explicit paths are being used in these .jam files - maybe there is a good reason!

Replacing explicit [`<file>...`](https://boostorg.github.io/build/manual/develop/index.html#bbv2.tasks.libraries) with the cross-platform `<name>...` seems to fix the issue for me

    lib crypt : : <name>crypt ;

This can be further abbreviated to:

    lib crypt ;

I've also added `set -e` (abort on first error) in `boost_build.sh`, otherwise the script continued despite b2 build errors.

I should also mention that I've deliberately misspelled "libssl" library name in the .jam file to see what happens. Unlike misspelled "libcrypt", wrong libssl name didn't cause any apparent errors during building or testing stage so I'm not entirely sure how these build instructions work in case of ssl libraries and how to test if they're correct.