### PR TITLE
ECFLOW-1790: Default to 2048-bit dh keys

### DIFF
--- a/Base/src/Openssl.cpp
+++ b/Base/src/Openssl.cpp
@@ -177,7 +177,18 @@ std::string Openssl::certificates_dir() const
 std::string Openssl::pem() const
 {
    std::string str = certificates_dir();
-   if (ssl_ == "1") { str += "dh1024.pem"; return str;}
+   if (ssl_ == "1") {
+      // assume 2048-bit dh key, but accept 1024-bit for
+      // backwards-compatibility (note: openssl might
+      // not accept it, depending on the version used)
+      str += "dh2048.pem";
+
+      if (!fs::exists(str)) {
+         return certificates_dir() + "dh1024.pem";
+      }
+      return str;
+   }
+
    str += ssl_;
    str += ".pem";
    return str;
@@ -222,7 +233,7 @@ const char* Openssl::ssl_info() {
             "The certificates can be shared if you have multiple servers running on\n"
             "the same machine. In this case use ECF_SSL=1, then\n"
             "ecflow_server expects the following files in $HOME/.ecflowrc/ssl\n\n"
-            "   - dh1024.pem\n"
+            "   - dh2048.pem\n"
             "   - server.crt\n"
             "   - server.key\n"
             "   - server.passwd (optional) if this exists it must contain the pass phrase used to create server.key\n\n"
@@ -256,8 +267,8 @@ const char* Openssl::ssl_info() {
             "     > openssl req -new -key server.key -out server.csr # Generate Certificate Signing Request(CSR)\n"
             "- Generate a self signed certificate CRT, by using the CSR and private key.\n\n"
             "     > openssl x509 -req -days 3650 -in server.csr -signkey server.key -out server.crt\n\n"
-            "- Generate dhparam file. ecFlow expects 1024 key.\n"
-            "     > openssl dhparam -out dh1024.pem 1024"
+            "- Generate dhparam file. ecFlow expects 2048 key.\n"
+            "     > openssl dhparam -out dh2048.pem 2048"
             ;
 }
 

--- a/SCRATCH/src/server.cpp
+++ b/SCRATCH/src/server.cpp
@@ -106,7 +106,7 @@ public:
     context_.set_password_callback(boost::bind(&server::get_password, this));
     context_.use_certificate_chain_file("server.crt");
     context_.use_private_key_file("server.key", boost::asio::ssl::context::pem);
-    context_.use_tmp_dh_file("dh1024.pem");
+    context_.use_tmp_dh_file("dh2048.pem");
 
     session* new_session = new session(io_service_, context_);
     acceptor_.async_accept(new_session->socket(),

--- a/Server/doc/openssl.ddoc
+++ b/Server/doc/openssl.ddoc
@@ -64,8 +64,8 @@ openssl x509 -req -days 3650 -in server.csr -signkey server.key -out server.crt
   openssl x509  -in server.crt -signkey server.key -x509toreq -out server.csr
 
 
-# Generate dhparam file, Using 512 causes Handshake failed: dh key too small 
-openssl dhparam -out dh1024.pem 1024
+# Generate dhparam file, Using 512/1024 causes Handshake failed: dh key too small
+openssl dhparam -out dh2048.pem 2048
 
 
 # Copy to the install area.


### PR DESCRIPTION
RHEL8 requires at least 2048-bit dh key in it's
default crypto configuration, to prevent Log Jam
attacks.

Openssl is also slowly moving towards accepting
only bigger keys, the current minimum length being
768 bits.

In ecFlow by default try to use a 2048-bit dh key.
For backwards compatibility fall back to a 1024-bit key,
even if that might mean that Openssl might reject it.

For more information see 'Logjam' security vulnerability

https://weakdh.org