### PR TITLE
Remove duplicate trigger from node attribute table

### DIFF
--- a/docs/ug/user_manual/node_attribute_overview.rst
+++ b/docs/ug/user_manual/node_attribute_overview.rst
@@ -123,15 +123,6 @@ Node attribute overview
      - N/A
      -
      -
-   * - :term:`trigger`
-     - 
-     - ❎
-     - 
-     -
-     -
-     - N/A
-     -
-     -
    * - :term:`complete`
      - 
      - ❎


### PR DESCRIPTION
Hi,

I am searching for something in the ecFlow docs, and reading/reviewing while doing so. I think the `trigger` node entry is duplicated in this table? 

![image](https://user-images.githubusercontent.com/304786/204803333-b7f86623-78b3-4ead-bf30-e027d87dd473.png)

Didn't have time to re-generate the docs locally though, sorry.

Cheers,
-Bruno