### PR TITLE
Check for return code when starting http server

### DIFF
--- a/Http/src/HttpServer.cpp
+++ b/Http/src/HttpServer.cpp
@@ -49,7 +49,7 @@ void read_environment() {
         opts.tokens_file = std::string(getenv("ECF_RESTAPI_TOKENS_FILE"));
     }
     if (getenv("ECF_RESTAPI_CERT_DIRECTORY") != nullptr) {
-        opts.tokens_file = std::string(getenv("ECF_RESTAPI_CERT_DIRECTORY"));
+        opts.cert_directory = std::string(getenv("ECF_RESTAPI_CERT_DIRECTORY"));
     }
     if (getenv("ECF_RESTAPI_MAX_UPDATE_INTERVAL") != nullptr) {
         opts.max_polling_interval = atoi(getenv("ECF_RESTAPI_MAX_UPDATE_INTERVAL"));

--- a/Http/src/HttpServer.cpp
+++ b/Http/src/HttpServer.cpp
@@ -195,7 +195,10 @@ void start_server(httplib::Server& http_server) {
         printf("%s server listening on port %d\n", proto.c_str(), opts.port);
 
     try {
-        http_server.listen("0.0.0.0", opts.port);
+        bool ret = http_server.listen("0.0.0.0", opts.port);
+        if (ret == false) {
+            throw std::runtime_error("Failed to bind to port " + std::to_string(opts.port));
+        }
     }
     catch (const std::exception& e) {
         if (opts.verbose)
@@ -221,10 +224,12 @@ void HttpServer::run() {
         apply_listeners(dynamic_cast<httplib::Server&>(http_server));
         start_server(http_server);
     }
+    else
 #endif
+    {
+        httplib::Server http_server;
 
-    httplib::Server http_server;
-
-    apply_listeners(http_server);
-    start_server(http_server);
+        apply_listeners(http_server);
+        start_server(http_server);
+    }
 }


### PR DESCRIPTION
If binding to a port fails in SSL mode, a non-SSL version of the server should not be started.

Also includes a bug fix for ECF_RESTAPI_CERT_DIRECTORY