### PR TITLE
Rtd remove sytem packages

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,4 +4,3 @@ python:
   version: 3.8
   install:
     - requirements: docs/requirements.txt
-  system_packages: true

--- a/ACore/src/ecflow_version.h
+++ b/ACore/src/ecflow_version.h
@@ -2,15 +2,15 @@
 #define ecflow_version_config_h
 
 // clang-format off
-#define ECFLOW_VERSION   "5.11.3"
+#define ECFLOW_VERSION   "5.11.4"
 #define ECFLOW_RELEASE   "5"
 #define ECFLOW_MAJOR     "11"
-#define ECFLOW_MINOR     "3"
+#define ECFLOW_MINOR     "4"
 
 // available but not used
-// PROJECT_VERSION=5.11.3
+// PROJECT_VERSION=5.11.4
 // PROJECT_VERSION_MAJOR=5
 // PROJECT_VERSION_MINOR=11
-// PROJECT_VERSION_PATCH=3
+// PROJECT_VERSION_PATCH=4
 
 #endif 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 find_package( ecbuild 3.4 REQUIRED HINTS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../ecbuild ) # Before project()  
 
 # this will generate variables, see ACore/ecflow_version.h.in
-project( ecflow LANGUAGES CXX VERSION 5.11.3 )
+project( ecflow LANGUAGES CXX VERSION 5.11.4 )
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
 

--- a/Pyext/ecflow/__init__.py
+++ b/Pyext/ecflow/__init__.py
@@ -15,6 +15,6 @@ from .ecflow import *
 The ecFlow python module
 """
 
-__version__ = '5.11.3'
+__version__ = '5.11.4'
 
 # http://stackoverflow.com/questions/13040646/how-do-i-create-documentation-with-pydoc

--- a/docs/release_notes/index.rst
+++ b/docs/release_notes/index.rst
@@ -4,6 +4,7 @@ Release notes
 .. toctree::
     :maxdepth: 1
 
+    version_5.11.4
     version_5.11.3
     version_5.11.2
     version_5.11.1

--- a/docs/release_notes/version_5.11.4.rst
+++ b/docs/release_notes/version_5.11.4.rst
@@ -1,0 +1,16 @@
+.. _version_5.11.4:
+
+Version 5.11.4 updates
+////////////////////
+
+
+Version 5.11.4
+==============
+
+* `Released <https://confluence.ecmwf.int/display/ECFLOW/Releases>`__\  on 2023-10-10
+
+
+General
+-------
+
+- **Fix**: Correct the finding of the logserver script

--- a/tools/ecflow_logserver.sh
+++ b/tools/ecflow_logserver.sh
@@ -100,10 +100,10 @@ prognum=$((base+username))
 #prognum=35502
 
 PROG=$(which $0)
-#PROG_PATH=$(readlink -f $PROG)
-PROG_PATH=$(readlink $PROG)
-#PATH_NAME=$ecflow_DIR/bin
-PATH_NAME=./
+PROG_PATH=$(readlink -f $PROG)
+PATH_NAME=$ecflow_DIR/bin
+#PROG_PATH=$(readlink $PROG)
+#PATH_NAME=./
 
 export LOGPORT=$prognum
 LOGDIR=$(dirname $LOGFILE)


### PR DESCRIPTION
This is required so that we can continue to build documentation on ReadTheDocs - see https://blog.readthedocs.com/drop-support-system-packages/.