### PR TITLE
Use Boost::<targets> to configure Server test

### DIFF
--- a/Server/CMakeLists.txt
+++ b/Server/CMakeLists.txt
@@ -94,15 +94,22 @@ target_clangformat(ecflow_server)
 # ================================================================================                         
 # TEST
 # libboost_unit_test_framework  undefined reference to `clock_gettime', ${LIBRT} needed for boost 1.71
-ecbuild_add_test( TARGET       u_server
-                  SOURCES      test/TestServerEnvironment.cpp 
-                               test/TestServer1.cpp
-                  INCLUDES     src ${Boost_INCLUDE_DIRS}
-                  LIBS         libserver ${OPENSSL_LIBRARIES}
-                               ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_TEST_EXEC_MONITOR_LIBRARY} ${LIBRT}
-                  DEFINITIONS  ${BOOST_TEST_DYN_LINK}
-                  TEST_DEPENDS u_base
-              )
+ecbuild_add_test(
+  TARGET
+    u_server
+  INCLUDES
+    src
+  SOURCES
+    test/TestServerEnvironment.cpp
+    test/TestServer1.cpp
+  LIBS
+    libserver
+    $<$<BOOL:${OPENSSL_FOUND}>:OpenSSL::SSL>
+  DEFINITIONS
+    ${BOOST_TEST_DYN_LINK}
+  TEST_DEPENDS
+    u_base
+)
 
 target_clangformat(u_server CONDITION ENABLE_TESTS)
 

--- a/Server/test/TestServerEnvironment.cpp
+++ b/Server/test/TestServerEnvironment.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "CheckPt.hpp"
 #include "Ecf.hpp"


### PR DESCRIPTION
This effectively switches the build strategy to use header-only Boost.test, and by doing so avoid a crash that occurs when using Boost 1.78 on Fedora 37.