### PR TITLE
Create abstraction around conversion facilities ECFLOW-1922

### DIFF
--- a/ACore/src/Converter.hpp
+++ b/ACore/src/Converter.hpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#ifndef ECFLOW_CORE_CONVERTER_HPP
+#define ECFLOW_CORE_CONVERTER_HPP
+
+#include <string>
+#include <utility>
+
+#include <boost/lexical_cast.hpp>
+
+namespace ecf {
+
+struct bad_conversion : public std::runtime_error
+{
+    explicit bad_conversion(const char* m) : std::runtime_error(m) {}
+    explicit bad_conversion(const std::string& m) : std::runtime_error(m) {}
+};
+
+namespace details {
+
+template <typename To, typename From>
+inline static auto try_lexical_convert(From&& v) {
+    try {
+        return boost::lexical_cast<To>(v);
+    }
+    catch (const boost::bad_lexical_cast& e) {
+        throw bad_conversion(e.what());
+    }
+}
+
+template <typename To>
+struct converter_traits
+{
+    template <typename From>
+    inline static auto convert(From&& v) {
+        return try_lexical_convert<To>(std::forward<From>(v));
+    }
+};
+
+template <>
+struct converter_traits<std::string>
+{
+    template <typename From>
+    inline static auto convert(From&& v) {
+
+        if constexpr (std::is_same_v<From, char>) {
+            return std::string{v};
+        }
+        else if constexpr (std::is_same_v<std::remove_cv_t<From>, const char*>) {
+            return std::string(v);
+        }
+        else if constexpr (std::is_integral_v<From> || std::is_floating_point_v<From>) {
+            return std::to_string(v);
+        }
+
+        return try_lexical_convert<std::string>(std::forward<From>(v));
+    }
+};
+
+} // namespace details
+
+template <typename To, typename From>
+inline auto convert_to(From v) {
+    using namespace ecf::details;
+    return converter_traits<To>::convert(v);
+}
+
+} // namespace ecf
+
+#endif

--- a/ACore/src/EcfPortLock.hpp
+++ b/ACore/src/EcfPortLock.hpp
@@ -23,8 +23,8 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/operations.hpp>
-#include <boost/lexical_cast.hpp>
 
+#include "Converter.hpp"
 #include "File.hpp"
 
 namespace ecf {
@@ -32,7 +32,7 @@ namespace ecf {
 class EcfPortLock {
 public:
     static bool is_free(int port, bool debug = false) {
-        std::string the_port = boost::lexical_cast<std::string>(port);
+        std::string the_port = ecf::convert_to<std::string>(port);
         if (boost::filesystem::exists(port_file(the_port))) {
             if (debug)
                 std::cout << "  EcfPortLock::is_free(" << port << ") returning FALSE\n ";

--- a/ACore/src/Extract.cpp
+++ b/ACore/src/Extract.cpp
@@ -18,7 +18,8 @@
 #include <stdexcept>
 
 #include <boost/date_time/posix_time/time_formatters.hpp> // requires boost date and time lib
-#include <boost/lexical_cast.hpp>
+
+#include "Converter.hpp"
 
 // #define DEBUG_PARSER 1
 
@@ -73,9 +74,9 @@ bool Extract::split_get_second(const std::string& str, std::string& ret, char se
 int Extract::theInt(const std::string& token, const std::string& errorMsg) {
     int the_int = -1;
     try {
-        the_int = boost::lexical_cast<int>(token);
+        the_int = ecf::convert_to<int>(token);
     }
-    catch (boost::bad_lexical_cast& e) {
+    catch (const ecf::bad_conversion&) {
         throw std::runtime_error(errorMsg);
     }
     return the_int;

--- a/ACore/src/PasswdFile.cpp
+++ b/ACore/src/PasswdFile.cpp
@@ -18,8 +18,8 @@
 #include <iostream>
 
 #include <boost/algorithm/string/trim.hpp>
-#include <boost/lexical_cast.hpp>
 
+#include "Converter.hpp"
 #include "File.hpp"
 #include "PasswordEncryption.hpp"
 #include "Str.hpp"
@@ -227,9 +227,9 @@ bool PasswdFile::validateVersionNumber(const std::string& line, std::string& err
         }
 
         try {
-            auto major = boost::lexical_cast<int>(versionNumberTokens[0]);
-            auto minor = boost::lexical_cast<int>(versionNumberTokens[1]);
-            auto part  = boost::lexical_cast<int>(versionNumberTokens[2]);
+            auto major = ecf::convert_to<int>(versionNumberTokens[0]);
+            auto minor = ecf::convert_to<int>(versionNumberTokens[1]);
+            auto part  = ecf::convert_to<int>(versionNumberTokens[2]);
             if (major < 4) {
                 errorMsg += "Only passwd files with a version >= 4.5.0 is supported\n";
                 return false;
@@ -243,7 +243,7 @@ bool PasswdFile::validateVersionNumber(const std::string& line, std::string& err
                 return false;
             }
         }
-        catch (boost::bad_lexical_cast&) {
+        catch (const ecf::bad_conversion&) {
             errorMsg += "Invalid version number \n";
             return false;
         }
@@ -268,9 +268,9 @@ bool PasswdFile::add_user(std::vector<std::string>& tokens, std::string& error_m
     }
 
     try {
-        boost::lexical_cast<int>(tokens[2]);
+        ecf::convert_to<int>(tokens[2]);
     }
-    catch (boost::bad_lexical_cast&) {
+    catch (const ecf::bad_conversion&) {
         error_msg += "Port number must be integer's\n";
         return false;
     }

--- a/ACore/src/Pid.cpp
+++ b/ACore/src/Pid.cpp
@@ -18,14 +18,14 @@
 #include <stdexcept>
 #include <unistd.h> // for getpid
 
-#include <boost/lexical_cast.hpp>
+#include "Converter.hpp"
 
 std::string Pid::getpid() {
     std::string pid;
     try {
-        pid = boost::lexical_cast<std::string>(::getpid());
+        pid = ecf::convert_to<std::string>(::getpid());
     }
-    catch (boost::bad_lexical_cast& e) {
+    catch (const ecf::bad_conversion&) {
         throw std::runtime_error("Pid::getpid(): Could not convert PID to a string\n");
     }
     return pid;

--- a/ACore/src/Str.cpp
+++ b/ACore/src/Str.cpp
@@ -13,9 +13,10 @@
 //
 // Description : This class is used as a helper class
 //============================================================================
+
 #include "Str.hpp"
 
-#include <boost/lexical_cast.hpp>
+#include "Converter.hpp"
 
 using namespace std;
 
@@ -529,9 +530,9 @@ bool Str::valid_name(const std::string& name) {
 int Str::to_int(const std::string& the_str, int error_return) {
     if (the_str.find_first_of(Str::NUMERIC(), 0) != std::string::npos) {
         try {
-            return boost::lexical_cast<int>(the_str);
+            return ecf::convert_to<int>(the_str);
         }
-        catch (boost::bad_lexical_cast&) {
+        catch (const ecf::bad_conversion&) {
         }
     }
     return error_return;

--- a/ACore/src/Str.hpp
+++ b/ACore/src/Str.hpp
@@ -114,10 +114,13 @@ public:
     static bool valid_name(const std::string& name, std::string& msg);
     static bool valid_name(const std::string& name);
 
-    /// Use this function when you are not sure if string is convertible to an integer.
-    /// This function will check if string has a numeric first & hence faster than
-    /// using boost::lexical_cast< int > alone. Will trap any exception
-    /// will return numeric_limits<int>::max() for invalid conversions
+    /// This function checks if the given string actually has any digits before attempting the conversion;
+    /// this approach is faster than using ecf::convert_to<int> directly (and thus always attempt to
+    /// perform the conversion).
+    /// Use this function when it is not possible to ensure the string is convertible to an integer (e.g. user input).
+    ///
+    /// This function return the given `error_return` (by default, numeric_limits<int>::max()),
+    /// in cases where the conversion is invalid.
     static int to_int(const std::string&, int error_return = std::numeric_limits<int>::max());
 
     /// Truncate the input string at the start/end if exceeds max_lines_ newlines

--- a/ACore/src/TimeSlot.cpp
+++ b/ACore/src/TimeSlot.cpp
@@ -17,8 +17,7 @@
 
 #include <ostream>
 
-#include <boost/lexical_cast.hpp>
-
+#include "Converter.hpp"
 #include "Serialization.hpp"
 #include "Str.hpp"
 
@@ -72,12 +71,12 @@ void TimeSlot::write(std::string& ret) const {
 
     if (h_ < 10)
         ret += "0";
-    ret += boost::lexical_cast<std::string>(h_);
+    ret += ecf::convert_to<std::string>(h_);
 
     ret += Str::COLON();
     if (m_ < 10)
         ret += "0";
-    ret += boost::lexical_cast<std::string>(m_);
+    ret += ecf::convert_to<std::string>(m_);
 }
 
 boost::posix_time::time_duration TimeSlot::duration() const {

--- a/ACore/src/Version.cpp
+++ b/ACore/src/Version.cpp
@@ -12,14 +12,15 @@
 //
 // Description :
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+
 #include "Version.hpp"
 
 #include <sstream>
 
-#include <boost/lexical_cast.hpp>
 #include <boost/version.hpp>
 #include <cereal/version.hpp>
 
+#include "Converter.hpp"
 #include "ecflow_version.h"
 
 namespace ecf {
@@ -81,20 +82,20 @@ std::string Version::description() {
 
 std::string Version::version() {
     std::string ret = "ecflow_";
-    ret += boost::lexical_cast<std::string>(ECFLOW_RELEASE);
+    ret += ecf::convert_to<std::string>(ECFLOW_RELEASE);
     ret += "_";
-    ret += boost::lexical_cast<std::string>(ECFLOW_MAJOR);
+    ret += ecf::convert_to<std::string>(ECFLOW_MAJOR);
     ret += "_";
-    ret += boost::lexical_cast<std::string>(ECFLOW_MINOR);
+    ret += ecf::convert_to<std::string>(ECFLOW_MINOR);
     return ret;
 }
 
 std::string Version::raw() {
-    std::string ret = boost::lexical_cast<std::string>(ECFLOW_RELEASE);
+    std::string ret = ecf::convert_to<std::string>(ECFLOW_RELEASE);
     ret += ".";
-    ret += boost::lexical_cast<std::string>(ECFLOW_MAJOR);
+    ret += ecf::convert_to<std::string>(ECFLOW_MAJOR);
     ret += ".";
-    ret += boost::lexical_cast<std::string>(ECFLOW_MINOR);
+    ret += ecf::convert_to<std::string>(ECFLOW_MINOR);
     return ret;
 }
 
@@ -111,7 +112,7 @@ std::string Version::compiler() {
 #if defined(_AIX)
     ss << "aix " << __IBMCPP__;
 #elif defined(HPUX)
-    ss << "aCC " << __HP_aCC;        // type aCC +help, this will show compiler manual, search for Predefined Macros
+    ss << "aCC " << __HP_aCC; // type aCC +help, this will show compiler manual, search for Predefined Macros
 #else
     #if defined(__clang__)
     //  To find the list of defines for clang use:

--- a/ACore/src/WhiteListFile.cpp
+++ b/ACore/src/WhiteListFile.cpp
@@ -12,14 +12,15 @@
 //
 // Description : Parser for white list file
 //============================================================================
+
 #include "WhiteListFile.hpp"
 
 #include <iostream>
 #include <vector>
 
 #include <boost/algorithm/string/trim.hpp>
-#include <boost/lexical_cast.hpp>
 
+#include "Converter.hpp"
 #include "File.hpp"
 #include "Str.hpp"
 #include "User.hpp"
@@ -356,9 +357,9 @@ bool WhiteListFile::validateVersionNumber(const std::string& line, std::string& 
         }
 
         try {
-            auto major = boost::lexical_cast<int>(versionNumberTokens[0]);
-            auto minor = boost::lexical_cast<int>(versionNumberTokens[1]);
-            auto part  = boost::lexical_cast<int>(versionNumberTokens[2]);
+            auto major = ecf::convert_to<int>(versionNumberTokens[0]);
+            auto minor = ecf::convert_to<int>(versionNumberTokens[1]);
+            auto part  = ecf::convert_to<int>(versionNumberTokens[2]);
             if (major < 4) {
                 errorMsg += "Only white list files with a version >= 4.4.5 is supported\n";
                 return false;
@@ -372,7 +373,7 @@ bool WhiteListFile::validateVersionNumber(const std::string& line, std::string& 
                 return false;
             }
         }
-        catch (boost::bad_lexical_cast&) {
+        catch (const ecf::bad_conversion&) {
             errorMsg += "Invalid version number \n";
             return false;
         }

--- a/ACore/src/perf_timer.hpp
+++ b/ACore/src/perf_timer.hpp
@@ -18,8 +18,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/lexical_cast.hpp>
-
 // remove when we use c++17
 template <typename F, typename... Args>
 auto invoke(F f, Args&&... args) -> decltype(std::ref(f)(std::forward<Args>(args)...)) {

--- a/ACore/test/TestCalendar.cpp
+++ b/ACore/test/TestCalendar.cpp
@@ -21,6 +21,7 @@
 
 #include "Cal.hpp"
 #include "Calendar.hpp"
+#include "Converter.hpp"
 #include "Str.hpp"
 #include "TimeSeries.hpp"
 
@@ -537,7 +538,7 @@ BOOST_AUTO_TEST_CASE(test_calendar_julian) {
         long boost_julian               = cal_date.julian_day();
 
         std::string iso_string          = to_iso_string(cal_date);
-        auto date_as_long               = boost::lexical_cast<long>(iso_string);
+        auto date_as_long               = ecf::convert_to<long>(iso_string);
         long ecmwf_julian               = Cal::date_to_julian(date_as_long);
 
         BOOST_CHECK_MESSAGE(boost_julian == ecmwf_julian,

--- a/ACore/test/TestClassDataMemberInit.cpp
+++ b/ACore/test/TestClassDataMemberInit.cpp
@@ -16,7 +16,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 using namespace boost;
@@ -82,14 +81,6 @@ BOOST_AUTO_TEST_SUITE(CoreTestSuite)
 
 BOOST_AUTO_TEST_CASE(test_class_data_member_init) {
     cout << "ACore:: ...test_class_data_member_init \n";
-
-    //    // MyType needs noexcept on move copy constructor, during vec resize.
-    //	std::vector<MyType> vec;
-    //	for(int i =0; i < 4; i++) {
-    //		//vec.push_back(MyType(boost::lexical_cast<string>(i)));
-    //		vec.emplace_back(boost::lexical_cast<string>(i));
-    //		cout << vec.size() << " " << vec.capacity() << endl;
-    //	}
 
     {
         MyType type("ABC");

--- a/ACore/test/TestCommandLine.cpp
+++ b/ACore/test/TestCommandLine.cpp
@@ -15,10 +15,10 @@
 
 #include <iostream>
 
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "CommandLine.hpp"
+#include "Converter.hpp"
 
 using namespace boost;
 using namespace std;
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(test_command_line_with_2_args) {
 BOOST_AUTO_TEST_CASE(test_command_line_with_10_args) {
     std::vector<std::string> theArgs(10);
     for (int i = 0; i < 10; i++) {
-        theArgs.push_back("arg"s + lexical_cast<string>(i));
+        theArgs.push_back("arg"s + ecf::convert_to<std::string>(i));
     }
     doCheck(theArgs);
 }

--- a/ACore/test/TestConverter.cpp
+++ b/ACore/test/TestConverter.cpp
@@ -15,11 +15,28 @@
 
 #include "Converter.hpp"
 
+/*
+ * The following dummy classes are defined to support test `can_use_custom_conversion_traits` and confirms that
+ * customization point ::ecf::converter_traits<From, To>::convert(...) can be provided.
+ */
+struct Widget
+{
+};
+struct Gizmo
+{
+};
+
+template <>
+struct ::ecf::converter_traits<Widget, Gizmo>
+{
+    inline static Gizmo convert(const Widget&) { return Gizmo{}; }
+};
+
 BOOST_AUTO_TEST_SUITE(CoreTestSuite)
 
 BOOST_AUTO_TEST_SUITE(Converter)
 
-BOOST_AUTO_TEST_CASE(test_convert_from_numeric_to_string) {
+BOOST_AUTO_TEST_CASE(can_convert_from_numeric_to_string) {
     BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(0), "0");
     BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(123), "123");
     BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(123L), "123");
@@ -32,14 +49,14 @@ BOOST_AUTO_TEST_CASE(test_convert_from_numeric_to_string) {
     BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(-3.5), "-3.5");
 }
 
-BOOST_AUTO_TEST_CASE(test_convert_from_string_to_numeric) {
+BOOST_AUTO_TEST_CASE(can_convert_from_string_to_numeric) {
     BOOST_CHECK_EQUAL(ecf::convert_to<int>("-0"), 0);
     BOOST_CHECK_EQUAL(ecf::convert_to<int>("-123"), -123);
     BOOST_CHECK_EXCEPTION(ecf::convert_to<int>("s"), ecf::bad_conversion, [](const auto& e) { return true; });
     BOOST_CHECK_EXCEPTION(ecf::convert_to<int>('c'), ecf::bad_conversion, [](const auto& e) { return true; });
 
-    BOOST_CHECK_EQUAL(ecf::convert_to<unsigned int>("-0"), 0);
-    BOOST_CHECK_EQUAL(ecf::convert_to<unsigned int>("-123"), -123);
+    BOOST_CHECK_EQUAL(ecf::convert_to<unsigned int>("-0"), 0U);
+    BOOST_CHECK_EQUAL(ecf::convert_to<unsigned int>("-123"), static_cast<unsigned int>(-123));
     BOOST_CHECK_EXCEPTION(ecf::convert_to<unsigned int>("s"), ecf::bad_conversion, [](const auto& e) { return true; });
     BOOST_CHECK_EXCEPTION(ecf::convert_to<unsigned int>('c'), ecf::bad_conversion, [](const auto& e) { return true; });
 
@@ -54,10 +71,15 @@ BOOST_AUTO_TEST_CASE(test_convert_from_string_to_numeric) {
     BOOST_CHECK_EQUAL(ecf::convert_to<double>("-3.5"), -3.5);
 }
 
-BOOST_AUTO_TEST_CASE(test_convert_from_object_to_string) {
+BOOST_AUTO_TEST_CASE(can_convert_from_boost_object_to_string) {
     BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(boost::gregorian::greg_day{23}), "23");
     BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(boost::gregorian::greg_month{2}), "Feb");
     BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(boost::gregorian::greg_year{2000}), "2000");
+}
+
+BOOST_AUTO_TEST_CASE(can_use_custom_conversion_traits) {
+    // By compiling, the following expression confirms that a Widget can be converted to a Gizmo.
+    ecf::convert_to<Gizmo>(Widget{});
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/ACore/test/TestConverter.cpp
+++ b/ACore/test/TestConverter.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include <iostream>
+
+#include <boost/date_time/gregorian/gregorian.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "Converter.hpp"
+
+BOOST_AUTO_TEST_SUITE(CoreTestSuite)
+
+BOOST_AUTO_TEST_SUITE(Converter)
+
+BOOST_AUTO_TEST_CASE(test_convert_from_numeric_to_string) {
+    BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(0), "0");
+    BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(123), "123");
+    BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(123L), "123");
+    BOOST_CHECK_EQUAL(ecf::convert_to<std::string>('c'), "c");
+    BOOST_CHECK_EQUAL(ecf::convert_to<std::string>("s"), "s");
+
+    BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(0.0), "0");
+    BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(0.00), "0");
+    BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(1.0), "1");
+    BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(-3.5), "-3.5");
+}
+
+BOOST_AUTO_TEST_CASE(test_convert_from_string_to_numeric) {
+    BOOST_CHECK_EQUAL(ecf::convert_to<int>("-0"), 0);
+    BOOST_CHECK_EQUAL(ecf::convert_to<int>("-123"), -123);
+    BOOST_CHECK_EXCEPTION(ecf::convert_to<int>("s"), ecf::bad_conversion, [](const auto& e) { return true; });
+    BOOST_CHECK_EXCEPTION(ecf::convert_to<int>('c'), ecf::bad_conversion, [](const auto& e) { return true; });
+
+    BOOST_CHECK_EQUAL(ecf::convert_to<unsigned int>("-0"), 0);
+    BOOST_CHECK_EQUAL(ecf::convert_to<unsigned int>("-123"), -123);
+    BOOST_CHECK_EXCEPTION(ecf::convert_to<unsigned int>("s"), ecf::bad_conversion, [](const auto& e) { return true; });
+    BOOST_CHECK_EXCEPTION(ecf::convert_to<unsigned int>('c'), ecf::bad_conversion, [](const auto& e) { return true; });
+
+    BOOST_CHECK_EQUAL(ecf::convert_to<long>("-0"), 0);
+    BOOST_CHECK_EQUAL(ecf::convert_to<long>(-123), -123);
+    BOOST_CHECK_EXCEPTION(ecf::convert_to<long>("s"), ecf::bad_conversion, [](const auto& e) { return true; });
+    BOOST_CHECK_EXCEPTION(ecf::convert_to<long>('c'), ecf::bad_conversion, [](const auto& e) { return true; });
+
+    BOOST_CHECK_EQUAL(ecf::convert_to<double>("0.0"), 0);
+    BOOST_CHECK_EQUAL(ecf::convert_to<double>("0.00"), 0);
+    BOOST_CHECK_EQUAL(ecf::convert_to<double>("1.0"), 1);
+    BOOST_CHECK_EQUAL(ecf::convert_to<double>("-3.5"), -3.5);
+}
+
+BOOST_AUTO_TEST_CASE(test_convert_from_object_to_string) {
+    BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(boost::gregorian::greg_day{23}), "23");
+    BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(boost::gregorian::greg_month{2}), "Feb");
+    BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(boost::gregorian::greg_year{2000}), "2000");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/ACore/test/TestConverter.cpp
+++ b/ACore/test/TestConverter.cpp
@@ -27,7 +27,7 @@ struct Gizmo
 };
 
 template <>
-struct ::ecf::converter_traits<Widget, Gizmo>
+struct ecf::converter_traits<Widget, Gizmo>
 {
     inline static Gizmo convert(const Widget&) { return Gizmo{}; }
 };

--- a/ACore/test/TestFile.cpp
+++ b/ACore/test/TestFile.cpp
@@ -19,8 +19,9 @@
 #include <string>
 
 #include <boost/filesystem/operations.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
+
+#include "Converter.hpp"
 
 // #define FILE_PERF_CHECK_IMPLEMENTATIONS 1;
 #ifdef FILE_PERF_CHECK_IMPLEMENTATIONS
@@ -187,7 +188,7 @@ BOOST_AUTO_TEST_CASE(test_file_backwardSearch) {
     std::string path     = rootPath;
     std::string dir      = "dir";
     for (int i = 0; i < 6; i++) {
-        path += "/" + dir + boost::lexical_cast<std::string>(i);
+        path += "/" + dir + ecf::convert_to<std::string>(i);
     }
     // Should have test/data/dir0/dir1/dir3/dir3/dir4/dir5
     //         or  ACore/test/data/dir0/dir1/dir3/dir3/dir4/dir5
@@ -243,7 +244,7 @@ BOOST_AUTO_TEST_CASE(test_file_backwardSearch) {
 
     // Remove the test dir. Comment out for debugging
     for (int i = 0; i < 6; i++) {
-        path = rootPath + "/" + dir + boost::lexical_cast<std::string>(i);
+        path = rootPath + "/" + dir + ecf::convert_to<std::string>(i);
         BOOST_CHECK_MESSAGE(File::removeDir(path), "Failed to remove dir " << path);
     }
 }
@@ -262,7 +263,7 @@ BOOST_AUTO_TEST_CASE(test_file_forwardSearch) {
         if (i == 5)
             path += "/task";
         else
-            path += "/" + dir + boost::lexical_cast<std::string>(i);
+            path += "/" + dir + ecf::convert_to<std::string>(i);
     }
     // Should have test/data/dir0/dir1/dir3/dir3/dir4/task
     //         or  ACore/test/data/dir0/dir1/dir3/dir3/dir4/task

--- a/ACore/test/TestPerfTimer.cpp
+++ b/ACore/test/TestPerfTimer.cpp
@@ -12,9 +12,10 @@
 //
 // Description
 //============================================================================
-#include <boost/lexical_cast.hpp>
+
 #include <boost/test/unit_test.hpp>
 
+#include "Converter.hpp"
 #include "perf_timer.hpp"
 
 using namespace boost;
@@ -26,7 +27,7 @@ static void func(int const count = 100000) {
     // std::cout << " func : count " << count << "\n";
     for (int i = 0; i < count; i++) {
         std::string s = std::string("fred");
-        s += boost::lexical_cast<std::string>(i);
+        s += ecf::convert_to<std::string>(i);
     }
 }
 

--- a/ACore/test/TestSanitizerAS.cpp
+++ b/ACore/test/TestSanitizerAS.cpp
@@ -14,7 +14,6 @@
 //============================================================================
 #include <iostream>
 
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 using namespace boost;

--- a/ACore/test/TestSanitizerUB.cpp
+++ b/ACore/test/TestSanitizerUB.cpp
@@ -14,7 +14,6 @@
 //============================================================================
 #include <iostream>
 
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 using namespace boost;

--- a/ACore/test/TestStr.cpp
+++ b/ACore/test/TestStr.cpp
@@ -12,15 +12,12 @@
 //
 // Description :
 //============================================================================
+
 #include <algorithm>
 #include <iostream>
 #include <string>
-// #include <fstream>
 
 #include <boost/test/unit_test.hpp>
-// #include <boost/timer/timer.hpp>
-// #include <boost/lexical_cast.hpp>
-// #include <boost/algorithm/string.hpp>
 
 #include "Str.hpp"
 #include "StringSplitter.hpp"
@@ -719,10 +716,10 @@ BOOST_AUTO_TEST_CASE(test_str_less_greater) {
 //{
 //	// 12.2
 //	try {
-//		int number = boost::lexical_cast< int >( str );
+//		int number = ecf::convert_to<int>( str );
 //		numberRes.push_back( number );
 //	}
-//	catch ( boost::bad_lexical_cast& ) {
+//	catch (const ecf::bad_conversion&) {
 //		stringRes.push_back( str );
 //	}
 // }
@@ -734,10 +731,10 @@ BOOST_AUTO_TEST_CASE(test_str_less_greater) {
 //	// 0.6
 //	if ( str.find_first_of( Str::NUMERIC(), 0 ) == 0 ) {
 //		try {
-//			int number = boost::lexical_cast< int >( str );
+//			int number = ecf::convert_to<int>( str );
 //			numberRes.push_back( number );
 //		}
-//		catch ( boost::bad_lexical_cast& ) {
+//		catch (const ecf::bad_conversion&) {
 //			stringRes.push_back( str );
 //		}
 //	}
@@ -772,7 +769,7 @@ BOOST_AUTO_TEST_CASE(test_str_less_greater) {
 //  	std::vector<int> expectedNumberRes;
 //	for(size_t i=0; i < the_size; i++) { stringTokens.push_back("astring");}
 //	for(size_t i=0; i < the_size; i++) {
-//		numberTokens.push_back(boost::lexical_cast<string>(i));
+//		numberTokens.push_back(ecf::convert_to<std::string>(i));
 //		expectedNumberRes.push_back(i);
 //    }
 //
@@ -865,9 +862,9 @@ BOOST_AUTO_TEST_CASE(test_str_less_greater) {
 //    {
 //       boost::timer::cpu_timer timer; // measures CPU, replace with cpu_timer with boost > 1.51, measures cpu &
 //       elapsed for(size_t i =0; i < the_size; i++) {
-//          std::string s = boost::lexical_cast<std::string>(i);
+//          std::string s = ecf::convert_to<std::string>(i);
 //       }
-//       cout << "Time for int to string using boost::lexical_cast  elapsed time = " <<
+//       cout << "Time for int to string using ecf::convert_to elapsed time = " <<
 //       timer.format(3,Str::cpu_timer_format()) << "\n";
 //    }
 // }

--- a/ACore/test/TestVersioning.hpp
+++ b/ACore/test/TestVersioning.hpp
@@ -7,8 +7,8 @@
 // granted to it by virtue of its status as an intergovernmental organisation
 // nor does it submit to any jurisdiction.
 //
-#include <boost/lexical_cast.hpp>
 
+#include "Converter.hpp"
 #include "SerializationTest.hpp"
 
 /// To simulate changing of data model over time, we will
@@ -92,7 +92,7 @@ private:
             // Change data member type: int(version0)--->string(version1)
             int the_old_hour = 0;
             ar& the_old_hour;
-            hour_ = boost::lexical_cast<std::string>(the_old_hour);
+            hour_ = ecf::convert_to<std::string>(the_old_hour);
         }
         else {
             ar& hour_;

--- a/ANattr/src/AutoArchiveAttr.cpp
+++ b/ANattr/src/AutoArchiveAttr.cpp
@@ -16,6 +16,7 @@
 #include "AutoArchiveAttr.hpp"
 
 #include "Calendar.hpp"
+#include "Converter.hpp"
 #include "Indentor.hpp"
 #include "Log.hpp"
 #include "Serialization.hpp"
@@ -46,7 +47,7 @@ std::string AutoArchiveAttr::toString() const {
 void AutoArchiveAttr::write(std::string& ret) const {
     ret += "autoarchive ";
     if (days_) {
-        ret += boost::lexical_cast<std::string>(time_.hour() / 24);
+        ret += ecf::convert_to<std::string>(time_.hour() / 24);
         if (idle_)
             ret += " -i";
         return;

--- a/ANattr/src/AutoCancelAttr.cpp
+++ b/ANattr/src/AutoCancelAttr.cpp
@@ -16,6 +16,7 @@
 #include "AutoCancelAttr.hpp"
 
 #include "Calendar.hpp"
+#include "Converter.hpp"
 #include "Indentor.hpp"
 #include "Log.hpp"
 #include "Serialization.hpp"
@@ -46,7 +47,7 @@ std::string AutoCancelAttr::toString() const {
 void AutoCancelAttr::write(std::string& ret) const {
     ret += "autocancel ";
     if (days_) {
-        ret += boost::lexical_cast<std::string>(time_.hour() / 24);
+        ret += ecf::convert_to<std::string>(time_.hour() / 24);
         return;
     }
 

--- a/ANattr/src/ClockAttr.cpp
+++ b/ANattr/src/ClockAttr.cpp
@@ -15,9 +15,8 @@
 
 #include "ClockAttr.hpp"
 
-#include <boost/lexical_cast.hpp>
-
 #include "Calendar.hpp"
+#include "Converter.hpp"
 #include "DateAttr.hpp"
 #include "Ecf.hpp"
 #include "Indentor.hpp"
@@ -84,18 +83,18 @@ void ClockAttr::write(std::string& ss) const {
     }
 
     if (day_ != 0) {
-        ss += boost::lexical_cast<std::string>(day_);
+        ss += ecf::convert_to<std::string>(day_);
         ss += ".";
-        ss += boost::lexical_cast<std::string>(month_);
+        ss += ecf::convert_to<std::string>(month_);
         ss += ".";
-        ss += boost::lexical_cast<std::string>(year_);
+        ss += ecf::convert_to<std::string>(year_);
         ss += " ";
     }
 
     if (gain_ != 0) {
         if (positiveGain_)
             ss += "+";
-        ss += boost::lexical_cast<std::string>(gain_);
+        ss += ecf::convert_to<std::string>(gain_);
     }
 }
 

--- a/ANattr/src/CronAttr.cpp
+++ b/ANattr/src/CronAttr.cpp
@@ -12,6 +12,7 @@
 //
 // Description :
 //============================================================================
+
 #include "CronAttr.hpp"
 
 #include <sstream>
@@ -19,11 +20,11 @@
 
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/date_time/posix_time/time_formatters.hpp> // requires boost date and time lib
-#include <boost/lexical_cast.hpp>
 #include <boost/token_functions.hpp>
 #include <boost/tokenizer.hpp>
 
 #include "Calendar.hpp"
+#include "Converter.hpp"
 #include "Ecf.hpp"
 #include "Indentor.hpp"
 #include "PrintStyle.hpp"
@@ -139,7 +140,7 @@ void CronAttr::write(std::string& ret) const {
     if (!weekDays_.empty()) {
         ret += "-w ";
         for (size_t i = 0; i < weekDays_.size(); ++i) {
-            ret += boost::lexical_cast<std::string>(weekDays_[i]);
+            ret += ecf::convert_to<std::string>(weekDays_[i]);
             if (i != weekDays_.size() - 1)
                 ret += ",";
         }
@@ -152,7 +153,7 @@ void CronAttr::write(std::string& ret) const {
         if (weekDays_.empty())
             ret += "-w ";
         for (size_t i = 0; i < last_week_days_of_month_.size(); ++i) {
-            ret += boost::lexical_cast<std::string>(last_week_days_of_month_[i]);
+            ret += ecf::convert_to<std::string>(last_week_days_of_month_[i]);
             ret += 'L';
             if (i != last_week_days_of_month_.size() - 1)
                 ret += ",";
@@ -163,7 +164,7 @@ void CronAttr::write(std::string& ret) const {
     if (!daysOfMonth_.empty()) {
         ret += "-d ";
         for (size_t i = 0; i < daysOfMonth_.size(); ++i) {
-            ret += boost::lexical_cast<std::string>(daysOfMonth_[i]);
+            ret += ecf::convert_to<std::string>(daysOfMonth_[i]);
             if (i != daysOfMonth_.size() - 1)
                 ret += ",";
         }
@@ -180,7 +181,7 @@ void CronAttr::write(std::string& ret) const {
     if (!months_.empty()) {
         ret += "-m ";
         for (size_t i = 0; i < months_.size(); ++i) {
-            ret += boost::lexical_cast<std::string>(months_[i]);
+            ret += ecf::convert_to<std::string>(months_[i]);
             if (i != months_.size() - 1)
                 ret += ",";
         }
@@ -672,10 +673,10 @@ std::vector<int> extract_month(size_t& index, const std::vector<std::string>& li
             continue;
 
         try {
-            auto theInt = boost::lexical_cast<int>(theIntToken);
+            auto theInt = ecf::convert_to<int>(theIntToken);
             theIntVec.push_back(theInt);
         }
-        catch (boost::bad_lexical_cast&) {
+        catch (const ecf::bad_conversion&) {
             std::stringstream ss;
             ss << "Invalid cron option: " << option;
             throw std::runtime_error(ss.str());
@@ -714,15 +715,15 @@ void extract_days_of_week(size_t& index,
                     ss << "Invalid cron option: " << option << " " << theIntToken;
                     throw std::runtime_error(ss.str());
                 }
-                auto theInt = boost::lexical_cast<int>(theIntToken[0]);
+                auto theInt = ecf::convert_to<int>(theIntToken[0]);
                 last_week_days_of_month.push_back(theInt);
             }
             else {
-                auto theInt = boost::lexical_cast<int>(theIntToken);
+                auto theInt = ecf::convert_to<int>(theIntToken);
                 days_of_week.push_back(theInt);
             }
         }
-        catch (boost::bad_lexical_cast&) {
+        catch (const ecf::bad_conversion&) {
             std::stringstream ss;
             ss << "Invalid cron option: " << option;
             throw std::runtime_error(ss.str());
@@ -758,11 +759,11 @@ void extract_days_of_month(size_t& index,
             if (theIntToken == "L")
                 last_day_of_month = true;
             else {
-                auto theInt = boost::lexical_cast<int>(theIntToken);
+                auto theInt = ecf::convert_to<int>(theIntToken);
                 days_of_month.push_back(theInt);
             }
         }
-        catch (boost::bad_lexical_cast&) {
+        catch (const ecf::bad_conversion&) {
             std::stringstream ss;
             ss << "Invalid cron option: " << option;
             throw std::runtime_error(ss.str());

--- a/ANattr/src/DateAttr.cpp
+++ b/ANattr/src/DateAttr.cpp
@@ -21,6 +21,7 @@
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 
 #include "Calendar.hpp"
+#include "Converter.hpp"
 #include "Ecf.hpp"
 #include "Extract.hpp"
 #include "Indentor.hpp"
@@ -255,21 +256,21 @@ void DateAttr::write(std::string& ret) const {
     if (day_ == 0)
         ret += "*.";
     else {
-        ret += boost::lexical_cast<std::string>(day_);
+        ret += ecf::convert_to<std::string>(day_);
         ret += ".";
     }
 
     if (month_ == 0)
         ret += "*.";
     else {
-        ret += boost::lexical_cast<std::string>(month_);
+        ret += ecf::convert_to<std::string>(month_);
         ret += ".";
     }
 
     if (year_ == 0)
         ret += "*";
     else
-        ret += boost::lexical_cast<std::string>(year_);
+        ret += ecf::convert_to<std::string>(year_);
 }
 
 std::string DateAttr::dump() const {

--- a/ANattr/src/NodeAttr.cpp
+++ b/ANattr/src/NodeAttr.cpp
@@ -18,8 +18,7 @@
 #include <sstream>
 #include <stdexcept>
 
-#include <boost/lexical_cast.hpp>
-
+#include "Converter.hpp"
 #include "Ecf.hpp"
 #include "Indentor.hpp"
 #include "PrintStyle.hpp"
@@ -82,11 +81,11 @@ Event::Event(const std::string& eventName, bool iv) : n_(eventName), v_(iv), iv_
     // Test for numeric, and then casting, is ****faster***** than relying on exception alone
     if (eventName.find_first_of(Str::NUMERIC()) == 0) {
         try {
-            number_ = boost::lexical_cast<int>(eventName);
+            number_ = ecf::convert_to<int>(eventName);
             n_.clear();
             return;
         }
-        catch (boost::bad_lexical_cast&) {
+        catch (const ecf::bad_conversion&) {
             // cast failed, a real string, carry on
         }
     }
@@ -202,7 +201,7 @@ void Event::write(std::string& ret) const {
     if (number_ == std::numeric_limits<int>::max())
         ret += n_;
     else {
-        ret += boost::lexical_cast<std::string>(number_);
+        ret += ecf::convert_to<std::string>(number_);
         ret += " ";
         ret += n_;
     }
@@ -301,7 +300,7 @@ void Meter::print(std::string& os) const {
     if (!PrintStyle::defsStyle()) {
         if (v_ != min_) {
             os += " # ";
-            os += boost::lexical_cast<std::string>(v_);
+            os += ecf::convert_to<std::string>(v_);
         }
     }
     os += "\n";
@@ -317,11 +316,11 @@ void Meter::write(std::string& ret) const {
     ret += "meter ";
     ret += n_;
     ret += " ";
-    ret += boost::lexical_cast<std::string>(min_);
+    ret += ecf::convert_to<std::string>(min_);
     ret += " ";
-    ret += boost::lexical_cast<std::string>(max_);
+    ret += ecf::convert_to<std::string>(max_);
     ret += " ";
-    ret += boost::lexical_cast<std::string>(cc_);
+    ret += ecf::convert_to<std::string>(cc_);
 }
 
 std::string Meter::dump() const {

--- a/ANattr/src/QueueAttr.cpp
+++ b/ANattr/src/QueueAttr.cpp
@@ -17,8 +17,7 @@
 
 #include <stdexcept>
 
-#include <boost/lexical_cast.hpp>
-
+#include "Converter.hpp"
 #include "Ecf.hpp"
 #include "Extract.hpp"
 #include "Indentor.hpp"
@@ -62,7 +61,7 @@ void QueueAttr::print(std::string& os) const {
     write(os);
     if (!PrintStyle::defsStyle()) {
         os += " # ";
-        os += boost::lexical_cast<std::string>(currentIndex_);
+        os += ecf::convert_to<std::string>(currentIndex_);
         for (auto i : state_vec_) {
             os += " ";
             os += NState::toString(i);
@@ -93,9 +92,9 @@ std::string QueueAttr::value() const {
 int QueueAttr::index_or_value() const {
     if (currentIndex_ >= 0 && currentIndex_ < static_cast<int>(theQueue_.size())) {
         try {
-            return boost::lexical_cast<int>(theQueue_[currentIndex_]);
+            return ecf::convert_to<int>(theQueue_[currentIndex_]);
         }
-        catch (boost::bad_lexical_cast&) {
+        catch (ecf::bad_conversion&) {
             // Ignore and return currentIndex_
         }
     }
@@ -165,7 +164,7 @@ std::string QueueAttr::no_of_aborted() const {
             count++;
     }
     if (count != 0)
-        return boost::lexical_cast<std::string>(count);
+        return ecf::convert_to<std::string>(count);
     return std::string();
 }
 

--- a/ANattr/src/RepeatAttr.cpp
+++ b/ANattr/src/RepeatAttr.cpp
@@ -19,9 +19,9 @@
 #include <stdexcept>
 
 #include <boost/date_time/posix_time/time_formatters.hpp> // requires boost date and time lib
-#include <boost/lexical_cast.hpp>
 
 #include "Cal.hpp"
+#include "Converter.hpp"
 #include "Ecf.hpp"
 #include "Indentor.hpp"
 #include "Log.hpp"
@@ -145,14 +145,14 @@ RepeatDate::RepeatDate(const std::string& variable, int start, int end, int delt
         throw std::runtime_error("Invalid Repeat date: the delta cannot be zero" + ss.str());
     }
 
-    std::string theStart = boost::lexical_cast<std::string>(start);
+    std::string theStart = ecf::convert_to<std::string>(start);
     if (theStart.size() != 8) {
         std::stringstream ss;
         ss << "repeat " << variable << " " << start << " " << end << " " << delta;
         throw std::runtime_error("Invalid Repeat date: The start is not a valid date. Please use yyyymmdd format." +
                                  ss.str());
     }
-    std::string theEnd = boost::lexical_cast<std::string>(end);
+    std::string theEnd = ecf::convert_to<std::string>(end);
     if (theEnd.size() != 8) {
         std::stringstream ss;
         ss << "repeat " << variable << " " << start << " " << end << " " << delta;
@@ -256,14 +256,14 @@ void RepeatDate::update_repeat_genvar_value() const {
             int month        = the_date.month();
             int year         = the_date.year();
 
-            yyyy_.set_value(boost::lexical_cast<std::string>(year));
-            mm_.set_value(boost::lexical_cast<std::string>(month));
-            dom_.set_value(boost::lexical_cast<std::string>(day_of_month));
-            dow_.set_value(boost::lexical_cast<std::string>(day_of_week));
+            yyyy_.set_value(ecf::convert_to<std::string>(year));
+            mm_.set_value(ecf::convert_to<std::string>(month));
+            dom_.set_value(ecf::convert_to<std::string>(day_of_month));
+            dow_.set_value(ecf::convert_to<std::string>(day_of_week));
 
             long last_value = last_valid_value();
             long julian     = Cal::date_to_julian(last_value);
-            julian_.set_value(boost::lexical_cast<std::string>(julian));
+            julian_.set_value(ecf::convert_to<std::string>(julian));
         }
         catch (std::exception& e) {
             std::stringstream ss;
@@ -327,15 +327,15 @@ void RepeatDate::write(std::string& ret) const {
     ret += "repeat date ";
     ret += name_;
     ret += " ";
-    ret += boost::lexical_cast<std::string>(start_);
+    ret += ecf::convert_to<std::string>(start_);
     ret += " ";
-    ret += boost::lexical_cast<std::string>(end_);
+    ret += ecf::convert_to<std::string>(end_);
     ret += " ";
-    ret += boost::lexical_cast<std::string>(delta_);
+    ret += ecf::convert_to<std::string>(delta_);
 
     if (!PrintStyle::defsStyle() && (value_ != start_)) {
         ret += " # ";
-        ret += boost::lexical_cast<std::string>(value_);
+        ret += ecf::convert_to<std::string>(value_);
     }
 }
 
@@ -365,22 +365,22 @@ bool RepeatDate::operator==(const RepeatDate& rhs) const {
 }
 
 std::string RepeatDate::valueAsString() const {
-    /// will throw a boost::bad_lexical_cast& if value is not convertible to a string
+    /// will throw an ecf::bad_conversion if value is not convertible to a string
     try {
-        return boost::lexical_cast<std::string>(last_valid_value());
+        return ecf::convert_to<std::string>(last_valid_value());
     }
-    catch (boost::bad_lexical_cast&) {
+    catch (const ecf::bad_conversion&) {
         LOG_ASSERT(false, "RepeatDate::valueAsString(): could not convert value " << value_ << " to a string");
     }
     return string();
 }
 
 std::string RepeatDate::value_as_string(int index) const {
-    /// will throw a boost::bad_lexical_cast& if value is not convertible to a string
+    /// will throw an ecf::bad_conversion if value is not convertible to a string
     try {
-        return boost::lexical_cast<std::string>(index);
+        return ecf::convert_to<std::string>(index);
     }
-    catch (boost::bad_lexical_cast&) {
+    catch (const ecf::bad_conversion&) {
     }
     return string();
 }
@@ -393,9 +393,9 @@ std::string RepeatDate::next_value_as_string() const {
     val = Cal::julian_to_date(julian);
 
     try {
-        return boost::lexical_cast<std::string>(valid_value(val));
+        return ecf::convert_to<std::string>(valid_value(val));
     }
-    catch (boost::bad_lexical_cast&) {
+    catch (const ecf::bad_conversion&) {
     }
     return string();
 }
@@ -408,9 +408,9 @@ std::string RepeatDate::prev_value_as_string() const {
     val = Cal::julian_to_date(julian);
 
     try {
-        return boost::lexical_cast<std::string>(valid_value(val));
+        return ecf::convert_to<std::string>(valid_value(val));
     }
-    catch (boost::bad_lexical_cast&) {
+    catch (const ecf::bad_conversion&) {
     }
     return string();
 }
@@ -431,9 +431,9 @@ void RepeatDate::change(const std::string& newdate) {
 
     long the_new_date = 0;
     try {
-        the_new_date = boost::lexical_cast<long>(newdate);
+        the_new_date = ecf::convert_to<long>(newdate);
     }
-    catch (boost::bad_lexical_cast&) {
+    catch (const ecf::bad_conversion&) {
         std::stringstream ss;
         ss << "RepeatDate::change: " << toString() << " The new date(" << newdate << ") is not convertible to an long";
         throw std::runtime_error(ss.str());
@@ -507,7 +507,7 @@ RepeatDateList::RepeatDateList(const std::string& variable, const std::vector<in
         throw std::runtime_error("RepeatDateList: " + variable + " is empty");
 
     for (int i : list_) {
-        std::string date_i = boost::lexical_cast<std::string>(i);
+        std::string date_i = ecf::convert_to<std::string>(i);
         if (date_i.size() != 8) {
             std::stringstream ss;
             ss << "Invalid Repeat datelist : " << variable << " the date " << i
@@ -588,14 +588,14 @@ void RepeatDateList::update_repeat_genvar_value() const {
             int month        = the_date.month();
             int year         = the_date.year();
 
-            yyyy_.set_value(boost::lexical_cast<std::string>(year));
-            mm_.set_value(boost::lexical_cast<std::string>(month));
-            dom_.set_value(boost::lexical_cast<std::string>(day_of_month));
-            dow_.set_value(boost::lexical_cast<std::string>(day_of_week));
+            yyyy_.set_value(ecf::convert_to<std::string>(year));
+            mm_.set_value(ecf::convert_to<std::string>(month));
+            dom_.set_value(ecf::convert_to<std::string>(day_of_month));
+            dow_.set_value(ecf::convert_to<std::string>(day_of_week));
 
             long last_value = last_valid_value();
             long julian     = Cal::date_to_julian(last_value);
-            julian_.set_value(boost::lexical_cast<std::string>(julian));
+            julian_.set_value(ecf::convert_to<std::string>(julian));
         }
         catch (std::exception& e) {
             std::stringstream ss;
@@ -629,12 +629,12 @@ void RepeatDateList::write(std::string& ret) const {
     ret += name_;
     for (int date : list_) {
         ret += " \"";
-        ret += boost::lexical_cast<std::string>(date);
+        ret += ecf::convert_to<std::string>(date);
         ret += "\"";
     }
     if (!PrintStyle::defsStyle() && (currentIndex_ != 0)) {
         ret += " # ";
-        ret += boost::lexical_cast<std::string>(currentIndex_);
+        ret += ecf::convert_to<std::string>(currentIndex_);
     }
 }
 
@@ -703,19 +703,19 @@ void RepeatDateList::setToLastValue() {
 }
 
 std::string RepeatDateList::valueAsString() const {
-    return boost::lexical_cast<std::string>(last_valid_value());
+    return ecf::convert_to<std::string>(last_valid_value());
 }
 
 std::string RepeatDateList::value_as_string(int index) const {
     if (list_.empty())
         return string("0");
     if (index >= 0 && index < static_cast<int>(list_.size())) {
-        return boost::lexical_cast<std::string>(list_[index]);
+        return ecf::convert_to<std::string>(list_[index]);
     }
     if (index < 0)
-        return boost::lexical_cast<std::string>(list_[0]);
+        return ecf::convert_to<std::string>(list_[0]);
     if (index >= static_cast<int>(list_.size()))
-        return boost::lexical_cast<std::string>(list_[list_.size() - 1]);
+        return ecf::convert_to<std::string>(list_[list_.size() - 1]);
     return std::string();
 }
 
@@ -741,7 +741,7 @@ void RepeatDateList::change(const std::string& newValue) {
     // See if if matches one of the dates
     int new_val = 0;
     try {
-        new_val = boost::lexical_cast<int>(newValue);
+        new_val = ecf::convert_to<int>(newValue);
     }
     catch (...) {
         std::stringstream ss;
@@ -874,9 +874,9 @@ void RepeatInteger::increment() {
 void RepeatInteger::change(const std::string& newValue) {
     long the_new_value = 0;
     try {
-        the_new_value = boost::lexical_cast<long>(newValue);
+        the_new_value = ecf::convert_to<long>(newValue);
     }
-    catch (boost::bad_lexical_cast&) {
+    catch (const ecf::bad_conversion&) {
         std::stringstream ss;
         ss << "RepeatInteger::change:" << toString() << " The new value(" << newValue
            << ") is not convertible to an long";
@@ -925,17 +925,17 @@ void RepeatInteger::write(std::string& ret) const {
     ret += "repeat integer ";
     ret += name_;
     ret += " ";
-    ret += boost::lexical_cast<std::string>(start_);
+    ret += ecf::convert_to<std::string>(start_);
     ret += " ";
-    ret += boost::lexical_cast<std::string>(end_);
+    ret += ecf::convert_to<std::string>(end_);
     if (delta_ != 1) {
         ret += " ";
-        ret += boost::lexical_cast<std::string>(delta_);
+        ret += ecf::convert_to<std::string>(delta_);
     }
 
     if (!PrintStyle::defsStyle() && (value_ != start_)) {
         ret += " # ";
-        ret += boost::lexical_cast<std::string>(value_);
+        ret += ecf::convert_to<std::string>(value_);
     }
 }
 
@@ -995,22 +995,22 @@ bool RepeatInteger::operator==(const RepeatInteger& rhs) const {
 }
 
 std::string RepeatInteger::valueAsString() const {
-    /// will throw a boost::bad_lexical_cast& if value is not convertible to a string
+    /// will throw an ecf::bad_conversion if value is not convertible to a string
     try {
-        return boost::lexical_cast<std::string>(last_valid_value());
+        return ecf::convert_to<std::string>(last_valid_value());
     }
-    catch (boost::bad_lexical_cast&) {
+    catch (const ecf::bad_conversion&) {
         LOG_ASSERT(false, "");
     }
     return string();
 }
 
 std::string RepeatInteger::value_as_string(int index) const {
-    /// will throw a boost::bad_lexical_cast& if value is not convertible to a string
+    /// will throw an ecf::bad_conversion if value is not convertible to a string
     try {
-        return boost::lexical_cast<std::string>(index);
+        return ecf::convert_to<std::string>(index);
     }
-    catch (boost::bad_lexical_cast&) {
+    catch (const ecf::bad_conversion&) {
     }
     return string();
 }
@@ -1019,9 +1019,9 @@ std::string RepeatInteger::next_value_as_string() const {
     long val = last_valid_value();
     val += delta_;
     try {
-        return boost::lexical_cast<std::string>(valid_value(val));
+        return ecf::convert_to<std::string>(valid_value(val));
     }
-    catch (boost::bad_lexical_cast&) {
+    catch (const ecf::bad_conversion&) {
     }
     return string();
 }
@@ -1030,9 +1030,9 @@ std::string RepeatInteger::prev_value_as_string() const {
     long val = last_valid_value();
     val -= delta_;
     try {
-        return boost::lexical_cast<std::string>(valid_value(val));
+        return ecf::convert_to<std::string>(valid_value(val));
     }
-    catch (boost::bad_lexical_cast&) {
+    catch (const ecf::bad_conversion&) {
     }
     return string();
 }
@@ -1073,7 +1073,7 @@ void RepeatEnumerated::write(std::string& ret) const {
     }
     if (!PrintStyle::defsStyle() && (currentIndex_ != 0)) {
         ret += " # ";
-        ret += boost::lexical_cast<std::string>(currentIndex_);
+        ret += ecf::convert_to<std::string>(currentIndex_);
     }
 }
 
@@ -1096,9 +1096,9 @@ void RepeatEnumerated::increment() {
 long RepeatEnumerated::value() const {
     if (currentIndex_ >= 0 && currentIndex_ < static_cast<int>(theEnums_.size())) {
         try {
-            return boost::lexical_cast<int>(theEnums_[currentIndex_]);
+            return ecf::convert_to<int>(theEnums_[currentIndex_]);
         }
-        catch (boost::bad_lexical_cast&) {
+        catch (const ecf::bad_conversion&) {
             // Ignore and return currentIndex_
         }
     }
@@ -1109,18 +1109,18 @@ long RepeatEnumerated::last_valid_value() const {
     if (!theEnums_.empty()) {
         if (currentIndex_ < 0) {
             try {
-                return boost::lexical_cast<int>(theEnums_[0]);
+                return ecf::convert_to<int>(theEnums_[0]);
             }
-            catch (boost::bad_lexical_cast&) { /* Ignore and return first index */
+            catch (const ecf::bad_conversion&) { /* Ignore and return first index */
             }
             return 0;
         }
         if (currentIndex_ >= static_cast<int>(theEnums_.size())) {
 
             try {
-                return boost::lexical_cast<int>(theEnums_[theEnums_.size() - 1]);
+                return ecf::convert_to<int>(theEnums_[theEnums_.size() - 1]);
             }
-            catch (boost::bad_lexical_cast&) { /* Ignore and return last index */
+            catch (const ecf::bad_conversion&) { /* Ignore and return last index */
             }
             return static_cast<long>(theEnums_.size() - 1);
         }
@@ -1200,11 +1200,11 @@ void RepeatEnumerated::change(const std::string& newValue) {
 
     // If the value is convertible to an integer, treat as an index
     try {
-        auto the_new_value = boost::lexical_cast<long>(newValue);
+        auto the_new_value = ecf::convert_to<long>(newValue);
         changeValue(the_new_value); // can throw if out of range
         return;
     }
-    catch (boost::bad_lexical_cast&) {
+    catch (const ecf::bad_conversion&) {
     }
 
     std::stringstream ss;
@@ -1299,7 +1299,7 @@ void RepeatString::write(std::string& ret) const {
     }
     if (!PrintStyle::defsStyle() && (currentIndex_ != 0)) {
         ret += " # ";
-        ret += boost::lexical_cast<std::string>(value());
+        ret += ecf::convert_to<std::string>(value());
     }
 }
 
@@ -1388,11 +1388,11 @@ void RepeatString::change(const std::string& newValue) {
 
     // If the value is convertible to an integer, treat as an index
     try {
-        long the_new_value = boost::lexical_cast<int>(newValue);
+        long the_new_value = ecf::convert_to<int>(newValue);
         changeValue(the_new_value);
         return;
     }
-    catch (boost::bad_lexical_cast&) {
+    catch (const ecf::bad_conversion&) {
     }
 
     std::stringstream ss;
@@ -1446,7 +1446,7 @@ bool RepeatDay::compare(RepeatBase* rb) const {
 
 void RepeatDay::write(std::string& ret) const {
     ret += "repeat day ";
-    ret += boost::lexical_cast<std::string>(step_);
+    ret += ecf::convert_to<std::string>(step_);
 }
 
 std::string RepeatDay::dump() const {

--- a/ANattr/src/VerifyAttr.cpp
+++ b/ANattr/src/VerifyAttr.cpp
@@ -17,8 +17,7 @@
 
 #include <sstream>
 
-#include <boost/lexical_cast.hpp>
-
+#include "Converter.hpp"
 #include "Ecf.hpp"
 #include "Indentor.hpp"
 #include "NState.hpp"
@@ -42,7 +41,7 @@ void VerifyAttr::print(std::string& os) const {
     os += toString();
     if (!PrintStyle::defsStyle()) {
         os += " # ";
-        os += boost::lexical_cast<std::string>(actual_);
+        os += ecf::convert_to<std::string>(actual_);
     }
     os += "\n";
 }

--- a/ANattr/src/Zombie.cpp
+++ b/ANattr/src/Zombie.cpp
@@ -16,6 +16,7 @@
 #include "Zombie.hpp"
 
 #include "Calendar.hpp"
+#include "Converter.hpp"
 #include "Serialization.hpp"
 
 using namespace ecf;
@@ -278,11 +279,11 @@ void Zombie::pretty_print(const std::vector<Zombie>& zombies, std::vector<std::s
         type_width              = std::max(type_width, z.type_str().size());
         password_width          = std::max(password_width, z.jobs_password().size());
         rid_width               = std::max(rid_width, z.process_or_remote_id().size());
-        std::string no_of_calls = boost::lexical_cast<std::string>(z.calls());
+        std::string no_of_calls = ecf::convert_to<std::string>(z.calls());
         calls_width             = std::max(calls_width, no_of_calls.size());
         host_width              = std::max(host_width, z.host().size());
 
-        std::string try_no_int  = boost::lexical_cast<std::string>(z.try_no());
+        std::string try_no_int  = ecf::convert_to<std::string>(z.try_no());
         tryno_width             = std::max(tryno_width, try_no_int.size());
         child_type_width        = std::max(child_type_width, Child::to_string(z.last_child_cmd()).size());
         user_action_width       = std::max(user_action_width, z.user_action_str().size());

--- a/ANattr/src/ZombieAttr.cpp
+++ b/ANattr/src/ZombieAttr.cpp
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <stdexcept>
 
+#include <boost/type_traits.hpp>
 #include <boost/token_functions.hpp>
 #include <boost/tokenizer.hpp>
 

--- a/ANattr/src/ZombieAttr.cpp
+++ b/ANattr/src/ZombieAttr.cpp
@@ -18,10 +18,10 @@
 #include <cassert>
 #include <stdexcept>
 
-#include <boost/lexical_cast.hpp>
 #include <boost/token_functions.hpp>
 #include <boost/tokenizer.hpp>
 
+#include "Converter.hpp"
 #include "Indentor.hpp"
 #include "Serialization.hpp"
 #include "Str.hpp"
@@ -111,7 +111,7 @@ void ZombieAttr::write(std::string& ret) const {
     ret += Str::COLON();
     ret += Child::to_string(child_cmds_);
     ret += Str::COLON();
-    ret += boost::lexical_cast<std::string>(zombie_lifetime_);
+    ret += ecf::convert_to<std::string>(zombie_lifetime_);
 }
 
 bool ZombieAttr::fob(ecf::Child::CmdType child_cmd) const {
@@ -269,9 +269,9 @@ ZombieAttr ZombieAttr::create(const std::string& string_to_parse) {
     int zombie_lifetime = -1;
     if (!lifetime.empty()) {
         try {
-            zombie_lifetime = boost::lexical_cast<int>(lifetime);
+            zombie_lifetime = ecf::convert_to<int>(lifetime);
         }
-        catch (boost::bad_lexical_cast&) {
+        catch (const ecf::bad_conversion&) {
             throw std::runtime_error("ZombieAttr::create failed: Zombie life time must be convertible to an integer " +
                                      lifetime + string(":") + string_to_parse);
         }

--- a/ANattr/test/TestRepeat.cpp
+++ b/ANattr/test/TestRepeat.cpp
@@ -17,10 +17,10 @@
 #include <stdexcept>
 
 #include <boost/date_time/posix_time/time_formatters.hpp> // requires boost date and time lib
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "Cal.hpp"
+#include "Converter.hpp"
 #include "RepeatAttr.hpp"
 
 using namespace std;
@@ -716,7 +716,7 @@ BOOST_AUTO_TEST_CASE(test_repeat_date_change_value) {
         BOOST_CHECK_MESSAGE(rep.valid(), "expected valid at start ");
 
         while (rep.valid()) {
-            rep2.change(boost::lexical_cast<std::string>(rep.value()));
+            rep2.change(ecf::convert_to<std::string>(rep.value()));
             BOOST_CHECK_MESSAGE(rep.value() == rep2.value(),
                                 "expected same value, but found " << rep.value() << "  " << rep2.value());
             rep.increment();
@@ -728,7 +728,7 @@ BOOST_AUTO_TEST_CASE(test_repeat_date_change_value) {
         BOOST_CHECK_MESSAGE(rep.valid(), "expected valid at start ");
 
         while (rep.valid()) {
-            rep2.change(boost::lexical_cast<std::string>(rep.value()));
+            rep2.change(ecf::convert_to<std::string>(rep.value()));
             BOOST_CHECK_MESSAGE(rep.value() == rep2.value(),
                                 "expected same value, but found " << rep.value() << "  " << rep2.value());
             rep.increment();
@@ -791,14 +791,14 @@ BOOST_AUTO_TEST_CASE(test_repeat_date_errors) {
 }
 
 static void check_date(int start, int end, int delta) {
-    boost::gregorian::date bdate(from_undelimited_string(boost::lexical_cast<std::string>(start)));
+    boost::gregorian::date bdate(from_undelimited_string(ecf::convert_to<std::string>(start)));
 
     Repeat rep(RepeatDate("YMD", start, end, delta));
     Repeat rep2(RepeatDate("YMD", start, end, delta));
     while (rep.valid()) {
 
         // xref repeat date with boost date, essentially checking bdate with rep
-        string str_value = boost::lexical_cast<std::string>(rep.value());
+        string str_value = ecf::convert_to<std::string>(rep.value());
         boost::gregorian::date date2(from_undelimited_string(str_value));
         BOOST_CHECK_MESSAGE(bdate == date2, "expected same value, but found " << bdate << "  " << date2);
 
@@ -872,7 +872,7 @@ BOOST_AUTO_TEST_CASE(test_repeat_date_generated_variables) {
     {
         const Variable& var = rep.find_gen_variable("YMD_JULIAN");
         BOOST_CHECK_MESSAGE(!var.empty(), "Did not find generated variable YMD_JULIAN");
-        std::string expected = boost::lexical_cast<std::string>(Cal::date_to_julian(20090916));
+        std::string expected = ecf::convert_to<std::string>(Cal::date_to_julian(20090916));
         BOOST_CHECK_MESSAGE(var.theValue() == expected, "expected " << expected << " but found " << var.theValue());
     }
 }
@@ -939,13 +939,13 @@ BOOST_AUTO_TEST_CASE(test_repeat_date_generated_variables2) {
     expected_day_of_week.emplace_back("5");
 
     std::vector<std::string> expected_julian;
-    expected_julian.push_back(boost::lexical_cast<std::string>(Cal::date_to_julian(20161231)));
-    expected_julian.push_back(boost::lexical_cast<std::string>(Cal::date_to_julian(20170101)));
-    expected_julian.push_back(boost::lexical_cast<std::string>(Cal::date_to_julian(20170102)));
-    expected_julian.push_back(boost::lexical_cast<std::string>(Cal::date_to_julian(20170103)));
-    expected_julian.push_back(boost::lexical_cast<std::string>(Cal::date_to_julian(20170104)));
-    expected_julian.push_back(boost::lexical_cast<std::string>(Cal::date_to_julian(20170105)));
-    expected_julian.push_back(boost::lexical_cast<std::string>(Cal::date_to_julian(20170106)));
+    expected_julian.push_back(ecf::convert_to<std::string>(Cal::date_to_julian(20161231)));
+    expected_julian.push_back(ecf::convert_to<std::string>(Cal::date_to_julian(20170101)));
+    expected_julian.push_back(ecf::convert_to<std::string>(Cal::date_to_julian(20170102)));
+    expected_julian.push_back(ecf::convert_to<std::string>(Cal::date_to_julian(20170103)));
+    expected_julian.push_back(ecf::convert_to<std::string>(Cal::date_to_julian(20170104)));
+    expected_julian.push_back(ecf::convert_to<std::string>(Cal::date_to_julian(20170105)));
+    expected_julian.push_back(ecf::convert_to<std::string>(Cal::date_to_julian(20170106)));
 
     for (int i = 0; i < 7; i++) {
 

--- a/ANode/parser/src/EventParser.cpp
+++ b/ANode/parser/src/EventParser.cpp
@@ -17,8 +17,7 @@
 
 #include <stdexcept>
 
-#include <boost/lexical_cast.hpp>
-
+#include "Converter.hpp"
 #include "DefsStructureParser.hpp"
 #include "Node.hpp"
 #include "Str.hpp"
@@ -52,7 +51,7 @@ bool EventParser::doParse(const std::string& line, std::vector<std::string>& lin
         //   event 1 eventName
         //   event 2 eventNamea
         try {
-            number = boost::lexical_cast<int>(lineTokens[1]);
+            number = ecf::convert_to<int>(lineTokens[1]);
             if (lineTokens.size() >= 3 && lineTokens[2][0] != '#') {
                 name = lineTokens[2];
                 // event 1 eventName set
@@ -65,7 +64,7 @@ bool EventParser::doParse(const std::string& line, std::vector<std::string>& lin
                     initial_value = true;
             }
         }
-        catch (boost::bad_lexical_cast&) {
+        catch (const ecf::bad_conversion&) {
             name = lineTokens[1];
             if (lineTokens.size() >= 3 && lineTokens[2] == "set")
                 initial_value = true;

--- a/ANode/parser/src/RepeatParser.cpp
+++ b/ANode/parser/src/RepeatParser.cpp
@@ -17,6 +17,7 @@
 
 #include <stdexcept>
 
+#include "Converter.hpp"
 #include "DefsStructureParser.hpp"
 #include "Extract.hpp"
 #include "Node.hpp"
@@ -70,9 +71,9 @@ bool RepeatParser::doParse(const std::string& line, std::vector<std::string>& li
 
             int date = 0;
             try {
-                date = boost::lexical_cast<int>(theEnum);
+                date = ecf::convert_to<int>(theEnum);
             }
-            catch (boost::bad_lexical_cast&) {
+            catch (const ecf::bad_conversion&) {
                 throw std::runtime_error("RepeatParser::doParse: repeat datelist " + name +
                                          ", invalid date : " + theEnum);
             }

--- a/ANode/parser/src/VerifyParser.cpp
+++ b/ANode/parser/src/VerifyParser.cpp
@@ -17,6 +17,7 @@
 
 #include <stdexcept>
 
+#include "Converter.hpp"
 #include "DefsStructureParser.hpp"
 #include "Extract.hpp"
 #include "Node.hpp"
@@ -59,9 +60,9 @@ bool VerifyParser::doParse(const std::string& line, std::vector<std::string>& li
             if (lineTokens.size() >= 4) {
                 if (lineTokens[2] == "#") {
                     try {
-                        actual = boost::lexical_cast<int>(lineTokens[3]);
+                        actual = ecf::convert_to<int>(lineTokens[3]);
                     }
-                    catch (boost::bad_lexical_cast& e) { /* ignore could be other comment */
+                    catch (const ecf::bad_conversion&) { /* ignore could be other comment */
                     }
                 }
             }

--- a/ANode/parser/test/TestMigration.cpp
+++ b/ANode/parser/test/TestMigration.cpp
@@ -12,11 +12,13 @@
 //
 // Description :
 //============================================================================
+
 #include <iostream>
 #include <string>
 
 #include <boost/test/unit_test.hpp>
 
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "Family.hpp"
 #include "Flag.hpp"
@@ -531,11 +533,11 @@ BOOST_AUTO_TEST_CASE(test_state_edit_history_pruning2) {
     // Create edit history for today, this should not be affected by pruning
     date todays_date_in_utc = day_clock::universal_day();
     std::string history     = "MSG:[07:36:05 ";
-    history += boost::lexical_cast<string>(todays_date_in_utc.day());
+    history += ecf::convert_to<std::string>(todays_date_in_utc.day());
     history += ".";
-    history += boost::lexical_cast<string>(todays_date_in_utc.month());
+    history += ecf::convert_to<std::string>(todays_date_in_utc.month());
     history += ".";
-    history += boost::lexical_cast<string>(todays_date_in_utc.year());
+    history += ecf::convert_to<std::string>(todays_date_in_utc.year());
     history += "] --requeue force /s1  :maj";
 
     Defs defs;

--- a/ANode/src/Defs.cpp
+++ b/ANode/src/Defs.cpp
@@ -20,6 +20,7 @@
 
 #include "AbstractObserver.hpp"
 #include "CalendarUpdateParams.hpp"
+#include "Converter.hpp"
 #include "DefsDelta.hpp"
 #include "DefsStructureParser.hpp" /// The reason why Parser code moved into Defs, avoid cyclic dependency
 #include "Ecf.hpp"
@@ -701,11 +702,11 @@ void Defs::write_state(std::string& os) const {
     }
     if (state_change_no_ != 0) {
         os += " state_change:";
-        os += boost::lexical_cast<std::string>(state_change_no_);
+        os += ecf::convert_to<std::string>(state_change_no_);
     }
     if (modify_change_no_ != 0) {
         os += " modify_change:";
-        os += boost::lexical_cast<std::string>(modify_change_no_);
+        os += ecf::convert_to<std::string>(modify_change_no_);
     }
     if (server().get_state() != ServerState::default_state()) {
         os += " server_state:";
@@ -714,7 +715,7 @@ void Defs::write_state(std::string& os) const {
 
     // This only works when the full defs is requested, otherwise zero as defs is fabricated for handles
     os += " cal_count:";
-    os += boost::lexical_cast<std::string>(updateCalendarCount_);
+    os += ecf::convert_to<std::string>(updateCalendarCount_);
     os += "\n";
 
     // This read by the DefsParser
@@ -873,9 +874,9 @@ void Defs::read_history(const std::string& line, const std::vector<std::string>&
                 Str::split(date, vec, ".");
                 if (vec.size() == 3) {
                     try {
-                        int day   = boost::lexical_cast<int>(vec[0]);
-                        int month = boost::lexical_cast<int>(vec[1]);
-                        int year  = boost::lexical_cast<int>(vec[2]);
+                        int day   = ecf::convert_to<int>(vec[0]);
+                        int month = ecf::convert_to<int>(vec[1]);
+                        int year  = ecf::convert_to<int>(vec[2]);
 
                         boost::gregorian::date node_log_date(year, month, day);
                         boost::gregorian::date_duration duration = todays_date_in_utc - node_log_date;
@@ -1652,11 +1653,11 @@ void Defs::order(Node* immediateChild, NOrder::Order ord) {
         case NOrder::ALPHA: {
             std::sort(suiteVec_.begin(), suiteVec_.end(), [](const suite_ptr& a, const suite_ptr& b) {
                 try {
-                    int a_as_int = boost::lexical_cast<int>(a->name());
-                    int b_as_int = boost::lexical_cast<int>(b->name());
+                    int a_as_int = ecf::convert_to<int>(a->name());
+                    int b_as_int = ecf::convert_to<int>(b->name());
                     return a_as_int < b_as_int;
                 }
-                catch (boost::bad_lexical_cast&) {
+                catch (const ecf::bad_conversion&) {
                 }
 
                 return Str::caseInsLess(a->name(), b->name());

--- a/ANode/src/EcfFile.cpp
+++ b/ANode/src/EcfFile.cpp
@@ -25,6 +25,7 @@
 #include <sys/stat.h>
 #include <sys/wait.h> // for waitpid
 
+#include "Converter.hpp"
 #include "Ecf.hpp"
 #include "File.hpp"
 #include "JobsParam.hpp"
@@ -1109,7 +1110,7 @@ const std::string& EcfFile::doCreateJobFile(JobsParam& jobsParam) const {
             job_output_size += jobLines_[i].size();
         job_output_size += jobLines_size; // take into account new lines for each line of output
         job_size_ = "job_size:";
-        job_size_ += boost::lexical_cast<std::string>(job_output_size);
+        job_size_ += ecf::convert_to<std::string>(job_output_size);
         return job_size_;
     }
 

--- a/ANode/src/ExprAst.cpp
+++ b/ANode/src/ExprAst.cpp
@@ -18,6 +18,7 @@
 #include <iostream>
 
 #include "Cal.hpp"
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "ExprAstVisitor.hpp"
 #include "Indentor.hpp"
@@ -1588,7 +1589,7 @@ std::string AstFlag::why_expression(bool html) const {
             ret += "(?)";
         else {
             ret += "(";
-            ret += boost::lexical_cast<std::string>(ref_node->flag().is_set(flag_));
+            ret += ecf::convert_to<std::string>(ref_node->flag().is_set(flag_));
             ret += ")";
         }
     }
@@ -1676,7 +1677,7 @@ std::string AstVariable::why_expression(bool html) const {
         if (!ref_node)
             ret += "(?)";
         ret += "(";
-        ret += boost::lexical_cast<std::string>(theValue);
+        ret += ecf::convert_to<std::string>(theValue);
         ret += ")";
     }
     else {
@@ -1815,7 +1816,7 @@ std::string AstParentVariable::why_expression(bool html) const {
         if (!ref_node)
             ret += "(?)";
         ret += "(";
-        ret += boost::lexical_cast<std::string>(theValue);
+        ret += ecf::convert_to<std::string>(theValue);
         ret += ")";
     }
     else {

--- a/ANode/src/ExprParser.cpp
+++ b/ANode/src/ExprParser.cpp
@@ -34,7 +34,6 @@
 
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/cast.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/spirit/include/classic.hpp>
 #include <boost/spirit/include/classic_actor.hpp>
 #include <boost/spirit/include/classic_ast.hpp>
@@ -44,6 +43,7 @@
 #include <boost/spirit/include/classic_tree_to_xml.hpp>
 #include <boost/spirit/include/phoenix1_binders.hpp>
 
+#include "Converter.hpp"
 #include "ExprAst.hpp"
 #include "ExprDuplicate.hpp"
 #include "Indentor.hpp"
@@ -778,7 +778,7 @@ Ast* createAst(const tree_iter_t& i, const std::map<parser_id, std::string>& rul
 
         string thevalue(i->value.begin(), i->value.end());
         boost::algorithm::trim(thevalue); // don't know why we get leading/trailing spaces
-        auto theInt = boost::lexical_cast<int>(thevalue);
+        auto theInt = ecf::convert_to<int>(thevalue);
         return new AstInteger(theInt);
     }
     else if (i->value.id() == ExpressionGrammer::node_state_aborted_ID) {
@@ -1155,8 +1155,8 @@ bool SimpleExprParser::doParse() {
         }
         else {
             try {
-                auto left     = boost::lexical_cast<int>(tokens[0]);
-                auto right    = boost::lexical_cast<int>(tokens[1]);
+                auto left     = ecf::convert_to<int>(tokens[0]);
+                auto right    = ecf::convert_to<int>(tokens[1]);
                 ast_          = std::make_unique<AstTop>();
                 Ast* someRoot = new AstEqual();
                 someRoot->addChild(new AstInteger(left));
@@ -1166,7 +1166,7 @@ bool SimpleExprParser::doParse() {
                 //               "'\n";
                 return true;
             }
-            catch (boost::bad_lexical_cast& e) {
+            catch (const ecf::bad_conversion&) {
                 //            cout << "simple INT FAILED expr : " << expr_ << " `" << tokens[0] << "' = '"
                 //                     << tokens[1] << "'\n";
             }

--- a/ANode/src/InLimit.cpp
+++ b/ANode/src/InLimit.cpp
@@ -17,8 +17,7 @@
 
 #include <stdexcept>
 
-#include <boost/lexical_cast.hpp>
-
+#include "Converter.hpp"
 #include "Indentor.hpp"
 #include "Limit.hpp"
 #include "PrintStyle.hpp"
@@ -120,9 +119,9 @@ void InLimit::print(std::string& os) const {
             Limit* the_limit = limit();
             if (the_limit) {
                 os += " # referenced limit(value) ";
-                os += boost::lexical_cast<std::string>(the_limit->theLimit());
+                os += ecf::convert_to<std::string>(the_limit->theLimit());
                 os += "(";
-                os += boost::lexical_cast<std::string>(the_limit->value());
+                os += ecf::convert_to<std::string>(the_limit->value());
                 os += ")";
             }
         }
@@ -152,7 +151,7 @@ void InLimit::write(std::string& ret) const {
     }
     if (tokens_ != 1) {
         ret += " ";
-        ret += boost::lexical_cast<std::string>(tokens_);
+        ret += ecf::convert_to<std::string>(tokens_);
     }
 }
 

--- a/ANode/src/Limit.cpp
+++ b/ANode/src/Limit.cpp
@@ -17,6 +17,7 @@
 
 #include <stdexcept>
 
+#include "Converter.hpp"
 #include "Ecf.hpp"
 #include "Indentor.hpp"
 #include "PrintStyle.hpp"
@@ -93,7 +94,7 @@ void Limit::print(std::string& os) const {
     if (!PrintStyle::defsStyle()) {
         if (value_ != 0) {
             os += " # ";
-            os += boost::lexical_cast<std::string>(value_);
+            os += ecf::convert_to<std::string>(value_);
             for (const auto& path : paths_) {
                 os += " ";
                 os += path;
@@ -113,7 +114,7 @@ void Limit::write(std::string& ret) const {
     ret += "limit ";
     ret += n_;
     ret += " ";
-    ret += boost::lexical_cast<std::string>(lim_);
+    ret += ecf::convert_to<std::string>(lim_);
 }
 
 void Limit::decrement(int tokens, const std::string& abs_node_path) {

--- a/ANode/src/NodeAdd.cpp
+++ b/ANode/src/NodeAdd.cpp
@@ -12,13 +12,13 @@
 //
 // Description :
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
-#include <stdexcept>
 
-#include <boost/lexical_cast.hpp>
+#include <stdexcept>
 
 #include "AutoArchiveAttr.hpp"
 #include "AutoCancelAttr.hpp"
 #include "AutoRestoreAttr.hpp"
+#include "Converter.hpp"
 #include "Ecf.hpp"
 #include "Expression.hpp"
 #include "LateAttr.hpp"
@@ -72,7 +72,7 @@ void Node::add_variable_bypass_name_check(const std::string& name, const std::st
 }
 
 void Node::add_variable_int(const std::string& name, int some_int) {
-    std::string value = boost::lexical_cast<std::string>(some_int);
+    std::string value = ecf::convert_to<std::string>(some_int);
     add_variable(name, value);
 }
 

--- a/ANode/src/NodeChange.cpp
+++ b/ANode/src/NodeChange.cpp
@@ -12,10 +12,10 @@
 //
 // Description :
 //============================================================================
+
 #include <stdexcept>
 
-#include <boost/lexical_cast.hpp>
-
+#include "Converter.hpp"
 #include "Ecf.hpp"
 #include "ExprAst.hpp"
 #include "LateAttr.hpp"
@@ -55,7 +55,7 @@ bool Node::set_event(const std::string& event_name_or_number, bool value) {
     // Test for numeric, and then casting, is ****faster***** than relying on exception alone
     if (event_name_or_number.find_first_of(Str::NUMERIC()) == 0) {
         try {
-            auto eventNumber = boost::lexical_cast<int>(event_name_or_number);
+            auto eventNumber = ecf::convert_to<int>(event_name_or_number);
             for (size_t i = 0; i < theSize; i++) {
                 if (events_[i].number() == eventNumber) {
                     events_[i].set_value(value);
@@ -63,7 +63,7 @@ bool Node::set_event(const std::string& event_name_or_number, bool value) {
                 }
             }
         }
-        catch (boost::bad_lexical_cast&) {
+        catch (const ecf::bad_conversion&) {
         }
     }
     return false;
@@ -86,7 +86,7 @@ bool Node::set_event_used_in_trigger(const std::string& event_name_or_number) {
     // Test for numeric, and then casting, is ****faster***** than relying on exception alone
     if (event_name_or_number.find_first_of(Str::NUMERIC()) == 0) {
         try {
-            auto eventNumber = boost::lexical_cast<int>(event_name_or_number);
+            auto eventNumber = ecf::convert_to<int>(event_name_or_number);
             for (size_t i = 0; i < theSize; i++) {
                 if (events_[i].number() == eventNumber) {
                     events_[i].usedInTrigger(true);
@@ -95,7 +95,7 @@ bool Node::set_event_used_in_trigger(const std::string& event_name_or_number) {
                 }
             }
         }
-        catch (boost::bad_lexical_cast&) {
+        catch (const ecf::bad_conversion&) {
         }
     }
     return false;
@@ -144,9 +144,9 @@ bool Node::set_meter_used_in_trigger(const std::string& meter_name) {
 void Node::changeMeter(const std::string& meter_name, const std::string& value) {
     int theValue = 0;
     try {
-        theValue = boost::lexical_cast<int>(value);
+        theValue = ecf::convert_to<int>(value);
     }
-    catch (boost::bad_lexical_cast&) {
+    catch (const ecf::bad_conversion&) {
         throw std::runtime_error("Node::changeMeter expected integer value but found " + value);
     }
     changeMeter(meter_name, theValue);
@@ -195,9 +195,9 @@ void Node::increment_repeat() {
 void Node::changeLimitMax(const std::string& name, const std::string& maxValue) {
     int theValue = 0;
     try {
-        theValue = boost::lexical_cast<int>(maxValue);
+        theValue = ecf::convert_to<int>(maxValue);
     }
-    catch (boost::bad_lexical_cast&) {
+    catch (const ecf::bad_conversion&) {
         throw std::runtime_error("Node::changeLimitMax expected integer value but found " + maxValue);
     }
     changeLimitMax(name, theValue);
@@ -213,9 +213,9 @@ void Node::changeLimitMax(const std::string& name, int maxValue) {
 void Node::changeLimitValue(const std::string& name, const std::string& value) {
     int theValue = 0;
     try {
-        theValue = boost::lexical_cast<int>(value);
+        theValue = ecf::convert_to<int>(value);
     }
-    catch (boost::bad_lexical_cast&) {
+    catch (const ecf::bad_conversion&) {
         throw std::runtime_error("Node::changeLimitValue expected integer value but found " + value);
     }
     changeLimitValue(name, theValue);

--- a/ANode/src/NodeContainer.cpp
+++ b/ANode/src/NodeContainer.cpp
@@ -22,6 +22,7 @@
 
 #include <boost/filesystem/operations.hpp>
 
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "DefsDelta.hpp"
 #include "Ecf.hpp"
@@ -346,11 +347,11 @@ void NodeContainer::order(Node* immediateChild, NOrder::Order ord) {
         case NOrder::ALPHA: {
             std::sort(nodes_.begin(), nodes_.end(), [](const node_ptr& a, const node_ptr& b) {
                 try {
-                    int a_as_int = boost::lexical_cast<int>(a->name());
-                    int b_as_int = boost::lexical_cast<int>(b->name());
+                    int a_as_int = ecf::convert_to<int>(a->name());
+                    int b_as_int = ecf::convert_to<int>(b->name());
                     return a_as_int < b_as_int;
                 }
-                catch (boost::bad_lexical_cast&) {
+                catch (const ecf::bad_conversion&) {
                 }
 
                 return Str::caseInsLess(a->name(), b->name());

--- a/ANode/src/NodeFind.cpp
+++ b/ANode/src/NodeFind.cpp
@@ -13,6 +13,7 @@
 // Description :
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
 
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "Limit.hpp"
 #include "MiscAttrs.hpp"
@@ -318,10 +319,10 @@ const Event& Node::findEventByNameOrNumber(const std::string& theName) const {
     // Test for numeric, and then casting, is ****faster***** than relying on exception alone
     if (theName.find_first_of(Str::NUMERIC(), 0) == 0) {
         try {
-            auto eventNumber = boost::lexical_cast<int>(theName);
+            auto eventNumber = ecf::convert_to<int>(theName);
             return findEventByNumber(eventNumber);
         }
-        catch (boost::bad_lexical_cast&) {
+        catch (const ecf::bad_conversion&) {
         }
     }
     return Event::EMPTY();

--- a/ANode/src/Submittable.cpp
+++ b/ANode/src/Submittable.cpp
@@ -19,8 +19,8 @@
 #include <stdexcept>
 
 #include <boost/filesystem/operations.hpp>
-#include <boost/lexical_cast.hpp>
 
+#include "Converter.hpp"
 #include "DefsDelta.hpp"
 #include "Ecf.hpp"
 #include "EcfFile.hpp"
@@ -209,7 +209,7 @@ void Submittable::write_state(std::string& ret, bool& added_comment_char) const 
     if (tryNo_ != 0) {
         add_comment_char(ret, added_comment_char);
         ret += " try:";
-        ret += boost::lexical_cast<std::string>(tryNo_);
+        ret += ecf::convert_to<std::string>(tryNo_);
     }
     Node::write_state(ret, added_comment_char);
 }
@@ -305,9 +305,9 @@ bool Submittable::operator==(const Submittable& rhs) const {
 
 string Submittable::tryNo() const {
     try {
-        return boost::lexical_cast<string>(tryNo_);
+        return ecf::convert_to<std::string>(tryNo_);
     }
-    catch (boost::bad_lexical_cast& e) {
+    catch (const ecf::bad_conversion&) {
     }
 
     LOG_ASSERT(false, "Submittable::tryNo() corrupt?");

--- a/ANode/src/Suite.cpp
+++ b/ANode/src/Suite.cpp
@@ -18,8 +18,7 @@
 #include <sstream>
 #include <stdexcept>
 
-#include <boost/lexical_cast.hpp>
-
+#include "Converter.hpp"
 #include "DefsDelta.hpp"
 #include "Ecf.hpp"
 #include "Indentor.hpp"
@@ -493,9 +492,9 @@ void Suite::changeClockGain(const std::string& gain) {
     // See: ISSUES on Suite::changeClockType
     long theGain = 0;
     try {
-        theGain = boost::lexical_cast<long>(gain);
+        theGain = ecf::convert_to<long>(gain);
     }
-    catch (boost::bad_lexical_cast&) {
+    catch (const ecf::bad_conversion&) {
         throw std::runtime_error("Suite::changeClockGain: value '" + gain +
                                  "' is not convertible to an long, for suite " + name());
     }
@@ -851,9 +850,9 @@ void SuiteGenVariables::update_generated_variables() const {
     if (suite_->cal_.dayChanged() || genvar_yyyy_.theValue().empty() || force_update_) {
 
         force_update_ = false;
-        genvar_yyyy_.set_value(boost::lexical_cast<std::string>(suite_->cal_.year()));
-        genvar_dow_.set_value(boost::lexical_cast<std::string>(suite_->cal_.day_of_week()));
-        genvar_doy_.set_value(boost::lexical_cast<std::string>(suite_->cal_.day_of_year()));
+        genvar_yyyy_.set_value(ecf::convert_to<std::string>(suite_->cal_.year()));
+        genvar_dow_.set_value(ecf::convert_to<std::string>(suite_->cal_.day_of_week()));
+        genvar_doy_.set_value(ecf::convert_to<std::string>(suite_->cal_.day_of_year()));
         // cout << "genvar_yyyy_ = " << genvar_yyyy_.theValue() << "\n";
         // cout << "genvar_dow_ = " << genvar_dow_.theValue() << "\n";
         // cout << "genvar_doy_ = " << genvar_doy_.theValue() << "\n";
@@ -917,7 +916,7 @@ void SuiteGenVariables::update_generated_variables() const {
         genvar_ecf_clock_.set_value(buffer);
         // cout << "genvar_ecf_clock_ = " << genvar_ecf_clock_.theValue() << "\n";
 
-        genvar_ecf_julian_.set_value(boost::lexical_cast<std::string>(suite_->cal_.suiteTime().date().julian_day()));
+        genvar_ecf_julian_.set_value(ecf::convert_to<std::string>(suite_->cal_.suiteTime().date().julian_day()));
     }
 }
 

--- a/ANode/src/Task.cpp
+++ b/ANode/src/Task.cpp
@@ -18,9 +18,8 @@
 #include <sstream>
 #include <stdexcept>
 
-#include <boost/lexical_cast.hpp>
-
 #include "Alias.hpp"
+#include "Converter.hpp"
 #include "DefsDelta.hpp"
 #include "Ecf.hpp"
 #include "Extract.hpp"
@@ -139,7 +138,7 @@ void Task::write_state(std::string& ret, bool& added_comment_char) const {
     if (alias_no_ != 0) {
         add_comment_char(ret, added_comment_char);
         ret += " alias_no:";
-        ret += boost::lexical_cast<std::string>(alias_no_);
+        ret += ecf::convert_to<std::string>(alias_no_);
     }
     Submittable::write_state(ret, added_comment_char);
 }
@@ -228,7 +227,7 @@ alias_ptr Task::add_alias(std::vector<std::string>& user_file_contents,
     }
 
     // create alias
-    std::string alias_name = "alias" + boost::lexical_cast<std::string>(alias_no_);
+    std::string alias_name = "alias" + ecf::convert_to<std::string>(alias_no_);
     alias_ptr alias        = Alias::create(alias_name);
     alias->set_parent(this);
 
@@ -528,7 +527,7 @@ bool Task::resolveDependencies(JobsParam& jobsParam) {
         if (findParentUserVariableValue(Str::ECF_TRIES(), varValue)) {
             // std::cout << "tryNo_ = " << tryNo_ << " ECF_TRIES = " <<  varValue << "\n";
             try {
-                auto ecf_tries = boost::lexical_cast<int>(varValue);
+                auto ecf_tries = ecf::convert_to<int>(varValue);
                 if (try_no() >= ecf_tries) {
 #ifdef DEBUG_DEPENDENCIES
                     LOG(Log::DBG,
@@ -539,7 +538,7 @@ bool Task::resolveDependencies(JobsParam& jobsParam) {
                     return false;
                 }
             }
-            catch (boost::bad_lexical_cast&) {
+            catch (const ecf::bad_conversion&) {
                 LOG(Log::ERR,
                     "Variable ECF_TRIES must be convertible to an integer. Cannot resubmit job for task:"
                         << absNodePath());

--- a/ANode/src/TaskScriptGenerator.cpp
+++ b/ANode/src/TaskScriptGenerator.cpp
@@ -18,8 +18,8 @@
 #include <stdexcept>
 
 #include <boost/filesystem.hpp>
-#include <boost/lexical_cast.hpp>
 
+#include "Converter.hpp"
 #include "Ecf.hpp"
 #include "File.hpp"
 #include "QueueAttr.hpp"
@@ -201,7 +201,7 @@ std::string TaskScriptGenerator::getDefaultTemplateEcfFile() const {
         content += "for i in";
         for (int i = m.min(); i <= m.max(); i = i + 1) {
             content += " ";
-            content += boost::lexical_cast<std::string>(i);
+            content += ecf::convert_to<std::string>(i);
         }
         content += "\n";
         content += "do\n";

--- a/ANode/test/MyDefsFixture.hpp
+++ b/ANode/test/MyDefsFixture.hpp
@@ -16,14 +16,14 @@
 //               as each new object is created we add it here, to test
 //               Serialisation read/write and migration of previous fixtures
 //============================================================================
-#include <algorithm> //for for_each()
 
-#include <boost/lexical_cast.hpp>
+#include <algorithm>
 
 #include "Alias.hpp"
 #include "AutoArchiveAttr.hpp"
 #include "AutoCancelAttr.hpp"
 #include "AutoRestoreAttr.hpp"
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "Expression.hpp"
 #include "Family.hpp"
@@ -208,9 +208,9 @@ private:
             std::string labelName = "labelName";
             std::string limitName = "limitName";
             if (i != 0) {
-                fname += boost::lexical_cast<std::string>(i);
-                tname += boost::lexical_cast<std::string>(i);
-                labelName += boost::lexical_cast<std::string>(i);
+                fname += ecf::convert_to<std::string>(i);
+                tname += ecf::convert_to<std::string>(i);
+                labelName += ecf::convert_to<std::string>(i);
             }
 
             family_ptr fam = suite->add_family(fname);
@@ -251,13 +251,13 @@ private:
             nodes_to_restore.emplace_back("/EmptySuite");
             task->add_autorestore(ecf::AutoRestoreAttr(nodes_to_restore));
             if (i == 2) {
-                std::string compExpr = "../familyName" + boost::lexical_cast<std::string>(i - 1);
-                compExpr += "/taskName" + boost::lexical_cast<std::string>(i - 1);
+                std::string compExpr = "../familyName" + ecf::convert_to<std::string>(i - 1);
+                compExpr += "/taskName" + ecf::convert_to<std::string>(i - 1);
                 compExpr += ":myMeter ge 10";
                 task->add_complete(compExpr);
 
-                std::string expression = "../familyName" + boost::lexical_cast<std::string>(i - 1);
-                expression += "/taskName" + boost::lexical_cast<std::string>(i - 1);
+                std::string expression = "../familyName" + ecf::convert_to<std::string>(i - 1);
+                expression += "/taskName" + ecf::convert_to<std::string>(i - 1);
                 expression += " == complete";
                 task->add_trigger(expression);
             }

--- a/ANode/test/TestDefs.cpp
+++ b/ANode/test/TestDefs.cpp
@@ -10,10 +10,12 @@
 // granted to it by virtue of its status as an intergovernmental organisation
 // nor does it submit to any jurisdiction.
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+
 #include <iostream>
 
 #include <boost/test/unit_test.hpp>
 
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "Family.hpp"
 #include "Suite.hpp"
@@ -28,7 +30,7 @@ BOOST_AUTO_TEST_CASE(test_defs_absorb) {
 
     // Create a defs file corresponding to:
     // suite suite1
-    //	family family
+    //  family family
     //   	task t1
     //  endfamily
     // endsuite
@@ -47,7 +49,7 @@ BOOST_AUTO_TEST_CASE(test_defs_absorb) {
     Defs otherDefs;
     {
         for (int i = 0; i < 14; ++i) {
-            suite_ptr suite1 = otherDefs.add_suite("suite" + boost::lexical_cast<std::string>(i));
+            suite_ptr suite1 = otherDefs.add_suite("suite" + ecf::convert_to<std::string>(i));
             family_ptr fam   = suite1->add_family("family");
             fam->add_task("suite1_task1");
         }

--- a/ANode/test/TestExprParser.cpp
+++ b/ANode/test/TestExprParser.cpp
@@ -17,6 +17,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "ExprAst.hpp"
 #include "ExprParser.hpp"
@@ -578,7 +579,7 @@ BOOST_AUTO_TEST_CASE(test_trigger_functions_with_boost_date) {
     boost::gregorian::date endDate(2017, 12, 31);
     while (startDate != endDate) {
         long julian_day                    = startDate.julian_day();
-        std::string str_julian_day         = boost::lexical_cast<std::string>(julian_day);
+        std::string str_julian_day         = ecf::convert_to<std::string>(julian_day);
         std::string eight_digit_iso_string = to_iso_string(startDate);
         string expr                  = str_julian_day + " ==  cal::date_to_julian(" + eight_digit_iso_string + ")";
         exprMap[expr]                = std::make_pair(AstEqual::stype(), true);

--- a/ANode/test/TestFindAbsNodePath.cpp
+++ b/ANode/test/TestFindAbsNodePath.cpp
@@ -10,15 +10,16 @@
 // granted to it by virtue of its status as an intergovernmental organisation
 // nor does it submit to any jurisdiction.
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
-#include "Defs.hpp"
-#include "Family.hpp"
-#include "Suite.hpp"
-#include "Task.hpp"
-// #include "PrintStyle.hpp"
 
 #include <iostream>
 
 #include <boost/test/unit_test.hpp>
+
+#include "Converter.hpp"
+#include "Defs.hpp"
+#include "Family.hpp"
+#include "Suite.hpp"
+#include "Task.hpp"
 
 using namespace std;
 using namespace ecf;
@@ -33,16 +34,16 @@ BOOST_AUTO_TEST_CASE(test_find_abs_node_path) {
     Defs theDefs;
     {
         for (int s = 0; s < 3; s++) {
-            suite_ptr suite = theDefs.add_suite("suite" + boost::lexical_cast<std::string>(s));
+            suite_ptr suite = theDefs.add_suite("suite" + ecf::convert_to<std::string>(s));
             no_of_nodes++;
             for (int f = 0; f < 3; f++) {
-                family_ptr fam = suite->add_family("family" + boost::lexical_cast<std::string>(f));
+                family_ptr fam = suite->add_family("family" + ecf::convert_to<std::string>(f));
                 no_of_nodes++;
                 for (int ff = 0; ff < 3; ff++) {
-                    family_ptr hfam = fam->add_family("family" + boost::lexical_cast<std::string>(ff));
+                    family_ptr hfam = fam->add_family("family" + ecf::convert_to<std::string>(ff));
                     no_of_nodes++;
                     for (int t = 0; t < 3; t++) {
-                        task_ptr task = hfam->add_task("t1" + boost::lexical_cast<std::string>(t));
+                        task_ptr task = hfam->add_task("t1" + ecf::convert_to<std::string>(t));
                         no_of_nodes++;
                         for (int a = 0; a < 3; a++) {
                             task->add_alias_only();

--- a/ANode/test/TestLimit.cpp
+++ b/ANode/test/TestLimit.cpp
@@ -1,4 +1,3 @@
-
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
 // Name        :
 // Author      : Avi
@@ -16,9 +15,9 @@
 
 #include <iostream>
 
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "Converter.hpp"
 #include "Ecf.hpp"
 #include "Limit.hpp"
 #include "SerializationTest.hpp"
@@ -50,14 +49,14 @@ BOOST_AUTO_TEST_CASE(test_limit_basics) {
 
     Limit l1("name", 100);
     for (int i = 1; i < 10; i++) {
-        std::string path = boost::lexical_cast<std::string>(i);
+        std::string path = ecf::convert_to<std::string>(i);
         expected_paths.insert(path);
         l1.increment(1, path);
         BOOST_CHECK_MESSAGE(l1.paths() == expected_paths, "Expected paths not the same at " << i);
     }
 
     for (int i = 9; i >= 1; i--) {
-        std::string path = boost::lexical_cast<std::string>(i);
+        std::string path = ecf::convert_to<std::string>(i);
         l1.decrement(1, path);
         auto iter = expected_paths.find(path);
         expected_paths.erase(iter);
@@ -114,7 +113,7 @@ BOOST_AUTO_TEST_CASE(test_limit_increment_2) {
     Limit limit("name", 10); // Limit of 10
     for (int i = 0; i < 20; i++) {
         // increment should keep increasing limit value, *EVEN* if over the limit. See ECFLOW-324
-        std::string path = boost::lexical_cast<std::string>(i);
+        std::string path = ecf::convert_to<std::string>(i);
         limit.increment(1, path);
         BOOST_CHECK_MESSAGE(limit.value() == i + 1,
                             "Expected limit value of " << i + 1 << " but found " << limit.value());

--- a/ANode/test/TestVariableGeneration.cpp
+++ b/ANode/test/TestVariableGeneration.cpp
@@ -10,12 +10,13 @@
 // granted to it by virtue of its status as an intergovernmental organisation
 // nor does it submit to any jurisdiction.
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+
 #include <iostream>
 
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "Cal.hpp"
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "Family.hpp"
 #include "Str.hpp"
@@ -100,7 +101,7 @@ BOOST_AUTO_TEST_CASE(test_generated_variables) {
     findParentVariableValue(t, "YMD_MM", "1");
     findParentVariableValue(t, "YMD_DD", "1");
     findParentVariableValue(t, "YMD_DOW", "4");
-    findParentVariableValue(t, "YMD_JULIAN", boost::lexical_cast<std::string>(Cal::date_to_julian(20090101)));
+    findParentVariableValue(t, "YMD_JULIAN", ecf::convert_to<std::string>(Cal::date_to_julian(20090101)));
     findParentVariableValue(t, "RepeatInteger", "10");
 }
 

--- a/Base/src/cts/AlterCmd.cpp
+++ b/Base/src/cts/AlterCmd.cpp
@@ -15,11 +15,10 @@
 
 #include <stdexcept>
 
-#include <boost/lexical_cast.hpp>
-
 #include "AbstractClientEnv.hpp"
 #include "AbstractServer.hpp"
 #include "ClientToServerCmd.hpp"
+#include "Converter.hpp"
 #include "CtsApi.hpp"
 #include "Defs.hpp"
 #include "ExprAst.hpp"
@@ -678,9 +677,9 @@ STC_Cmd_ptr AlterCmd::doHandleRequest(AbstractServer* as) const {
                 case AlterCmd::ADD_LIMIT: {
                     int int_value = 0;
                     try {
-                        int_value = boost::lexical_cast<int>(value_);
+                        int_value = ecf::convert_to<int>(value_);
                     }
-                    catch (boost::bad_lexical_cast&) {
+                    catch (const ecf::bad_conversion&) {
                         std::stringstream mss;
                         mss << "AlterCmd: add_limit " << name_ << " " << value_ << " failed. Expected '" << value_
                             << "' to be convertible to an integer";
@@ -698,9 +697,9 @@ STC_Cmd_ptr AlterCmd::doHandleRequest(AbstractServer* as) const {
                     int token_value = 1;
                     if (!value_.empty()) {
                         try {
-                            token_value = boost::lexical_cast<int>(value_);
+                            token_value = ecf::convert_to<int>(value_);
                         }
-                        catch (boost::bad_lexical_cast&) {
+                        catch (const ecf::bad_conversion&) {
                             ss << "AlterCmd: add_inlimit expected '" << value_ << "' to be convertible to an integer";
                             throw std::runtime_error(ss.str());
                         }
@@ -1051,9 +1050,9 @@ void AlterCmd::check_for_add(AlterCmd::Add_attr_type theAttrType,
         case AlterCmd::ADD_LIMIT: {
             int int_value = 0;
             try {
-                int_value = boost::lexical_cast<int>(value);
+                int_value = ecf::convert_to<int>(value);
             }
-            catch (boost::bad_lexical_cast&) {
+            catch (const ecf::bad_conversion&) {
                 ss << "AlterCmd add_limit expected value(" << value << ") to be convertible to an integer\n";
                 throw std::runtime_error(ss.str());
             }
@@ -1073,9 +1072,9 @@ void AlterCmd::check_for_add(AlterCmd::Add_attr_type theAttrType,
             int token_value = 1;
             if (!value.empty()) {
                 try {
-                    token_value = boost::lexical_cast<int>(value);
+                    token_value = ecf::convert_to<int>(value);
                 }
-                catch (boost::bad_lexical_cast&) {
+                catch (const ecf::bad_conversion&) {
                     ss << "AlterCmd add inlimit expected optional limit token '" << value
                        << "' to be convertible to an integer\n";
                     throw std::runtime_error(ss.str());
@@ -1613,9 +1612,9 @@ void AlterCmd::check_for_change(AlterCmd::Change_attr_type theAttrType,
 
         case AlterCmd::CLOCK_GAIN: {
             try {
-                boost::lexical_cast<int>(name);
+                ecf::convert_to<int>(name);
             }
-            catch (boost::bad_lexical_cast&) {
+            catch (const ecf::bad_conversion&) {
                 ss << "AlterCmd:change  clock_gain expected '" << name << "' to be convertible to an integer\n";
                 throw std::runtime_error(ss.str());
             }
@@ -1632,9 +1631,9 @@ void AlterCmd::check_for_change(AlterCmd::Change_attr_type theAttrType,
             }
             // The name could be an integer
             try {
-                boost::lexical_cast<int>(name);
+                ecf::convert_to<int>(name);
             }
-            catch (boost::bad_lexical_cast&) {
+            catch (const ecf::bad_conversion&) {
                 // name is not an integer, check name is valid
                 Event check_name(name); // will throw if name is not valid
             }
@@ -1644,9 +1643,9 @@ void AlterCmd::check_for_change(AlterCmd::Change_attr_type theAttrType,
         case AlterCmd::METER: {
             Meter check(name, 0, 100); // Check meter name , by creating a meter
             try {
-                boost::lexical_cast<int>(value);
+                ecf::convert_to<int>(value);
             }
-            catch (boost::bad_lexical_cast&) {
+            catch (const ecf::bad_conversion&) {
                 ss << "AlterCmd change meter : " << value << " to be convertible to an integer\n";
                 throw std::runtime_error(ss.str());
             }
@@ -1703,9 +1702,9 @@ void AlterCmd::check_for_change(AlterCmd::Change_attr_type theAttrType,
         case AlterCmd::LIMIT_MAX: {
             int limit = 0;
             try {
-                limit = boost::lexical_cast<int>(value);
+                limit = ecf::convert_to<int>(value);
             }
-            catch (boost::bad_lexical_cast&) {
+            catch (const ecf::bad_conversion&) {
                 ss << "AlterCmd: change: limit-max: expected " << value << " to be convertible to an integer\n";
                 throw std::runtime_error(ss.str());
             }
@@ -1715,9 +1714,9 @@ void AlterCmd::check_for_change(AlterCmd::Change_attr_type theAttrType,
 
         case AlterCmd::LIMIT_VAL: {
             try {
-                boost::lexical_cast<int>(value);
+                ecf::convert_to<int>(value);
             }
-            catch (boost::bad_lexical_cast&) {
+            catch (const ecf::bad_conversion&) {
                 ss << "AlterCmd: change: limit_value: expected " << value << " to be convertible to an integer\n";
                 throw std::runtime_error(ss.str());
             }

--- a/Base/src/cts/CFileCmd.cpp
+++ b/Base/src/cts/CFileCmd.cpp
@@ -17,11 +17,11 @@
 #include <stdexcept>
 
 #include <boost/filesystem/operations.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include "AbstractClientEnv.hpp"
 #include "AbstractServer.hpp"
 #include "ClientToServerCmd.hpp"
+#include "Converter.hpp"
 #include "CtsApi.hpp"
 #include "EcfFile.hpp"
 #include "File.hpp"
@@ -61,12 +61,12 @@ CFileCmd::CFileCmd(const std::string& pathToNode, const std::string& file_type, 
     if (!input_max_lines.empty()) {
         try {
             // Note: max_lines_ if type size_t, hence we cast to int to check for negative numbers
-            auto the_max_lines = boost::lexical_cast<int>(input_max_lines);
+            auto the_max_lines = ecf::convert_to<int>(input_max_lines);
             if (the_max_lines <= 0)
                 the_max_lines = File::MAX_LINES();
             max_lines_ = the_max_lines;
         }
-        catch (boost::bad_lexical_cast& e) {
+        catch (const ecf::bad_conversion&) {
             std::stringstream ss;
             ss << "CFileCmd::CFileCmd: The third argument(" << input_max_lines
                << ") must be convertible to an integer\n";
@@ -130,12 +130,11 @@ bool CFileCmd::equals(ClientToServerCmd* rhs) const {
 }
 
 void CFileCmd::print(std::string& os) const {
-    user_cmd(
-        os,
-        CtsApi::to_string(CtsApi::file(pathToNode_, toString(file_), boost::lexical_cast<std::string>(max_lines_))));
+    user_cmd(os,
+             CtsApi::to_string(CtsApi::file(pathToNode_, toString(file_), ecf::convert_to<std::string>(max_lines_))));
 }
 void CFileCmd::print_only(std::string& os) const {
-    os += CtsApi::to_string(CtsApi::file(pathToNode_, toString(file_), boost::lexical_cast<std::string>(max_lines_)));
+    os += CtsApi::to_string(CtsApi::file(pathToNode_, toString(file_), ecf::convert_to<std::string>(max_lines_)));
 }
 
 STC_Cmd_ptr CFileCmd::doHandleRequest(AbstractServer* as) const {

--- a/Base/src/cts/CheckPtCmd.cpp
+++ b/Base/src/cts/CheckPtCmd.cpp
@@ -12,13 +12,13 @@
 //
 // Description :
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
-#include <stdexcept>
 
-#include <boost/lexical_cast.hpp>
+#include <stdexcept>
 
 #include "AbstractClientEnv.hpp"
 #include "AbstractServer.hpp"
 #include "ClientToServerCmd.hpp"
+#include "Converter.hpp"
 #include "CtsApi.hpp"
 
 using namespace ecf;
@@ -125,7 +125,7 @@ void CheckPtCmd::addOption(boost::program_options::options_description& desc) co
 static int parse_check_pt_interval(const std::string& the_arg) {
     int check_pt_interval = 0;
     try {
-        check_pt_interval = boost::lexical_cast<int>(the_arg);
+        check_pt_interval = ecf::convert_to<int>(the_arg);
     }
     catch (...) {
         std::stringstream ss;
@@ -147,7 +147,7 @@ static int parse_check_pt_alarm_time(const std::string& the_arg, int colon_pos) 
 
     int check_pt_alarm_time = 0;
     try {
-        check_pt_alarm_time = boost::lexical_cast<int>(alarm_time);
+        check_pt_alarm_time = ecf::convert_to<int>(alarm_time);
     }
     catch (...) {
         std::stringstream ss;

--- a/Base/src/cts/ClientHandleCmd.cpp
+++ b/Base/src/cts/ClientHandleCmd.cpp
@@ -14,11 +14,10 @@
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
 #include <stdexcept>
 
-#include <boost/lexical_cast.hpp>
-
 #include "AbstractClientEnv.hpp"
 #include "AbstractServer.hpp"
 #include "ClientToServerCmd.hpp"
+#include "Converter.hpp"
 #include "CtsApi.hpp"
 #include "Defs.hpp"
 
@@ -386,7 +385,7 @@ void ClientHandleCmd::create(Cmd_ptr& cmd, boost::program_options::variables_map
             if (!args.empty()) {
                 int suite_names_index = 1;
                 try {
-                    client_handle = boost::lexical_cast<int>(args[0]);
+                    client_handle = ecf::convert_to<int>(args[0]);
                     if (args.size() > 1) {
                         if (args[1] == "true")
                             auto_add_new_suites = true;
@@ -433,7 +432,7 @@ void ClientHandleCmd::create(Cmd_ptr& cmd, boost::program_options::variables_map
                     "To few arguments. First arg should be a integer handle, then a list of suite names. See help");
             int client_handle = 0;
             try {
-                client_handle = boost::lexical_cast<int>(args[0]);
+                client_handle = ecf::convert_to<int>(args[0]);
             }
             catch (std::exception&) {
                 throw std::runtime_error("The first argument must be an integer. See help");
@@ -456,7 +455,7 @@ void ClientHandleCmd::create(Cmd_ptr& cmd, boost::program_options::variables_map
                     "To few arguments. First arg should be a integer handle, then a list of suite names. See help");
             int client_handle = 0;
             try {
-                client_handle = boost::lexical_cast<int>(args[0]);
+                client_handle = ecf::convert_to<int>(args[0]);
             }
             catch (std::exception&) {
                 throw std::runtime_error("ClientHandleCmd::create: The first argument must be an integer. See help");
@@ -479,7 +478,7 @@ void ClientHandleCmd::create(Cmd_ptr& cmd, boost::program_options::variables_map
                                          "be true or false. See help");
             int client_handle = 0;
             try {
-                client_handle = boost::lexical_cast<int>(args[0]);
+                client_handle = ecf::convert_to<int>(args[0]);
             }
             catch (std::exception&) {
                 throw std::runtime_error("ClientHandleCmd::create: The first argument must be an integer. See help");

--- a/Base/src/cts/CtsApi.cpp
+++ b/Base/src/cts/CtsApi.cpp
@@ -17,7 +17,7 @@
 
 #include <sstream>
 
-#include <boost/lexical_cast.hpp>
+#include "Converter.hpp"
 
 std::string CtsApi::to_string(const std::vector<std::string>& vec) {
     std::string ret;
@@ -107,7 +107,7 @@ CtsApi::ch_register(int client_handle, bool auto_add_new_suites, const std::vect
     retVec.reserve(suites.size() + 1);
     std::string ret = "--ch_register=";
     if (client_handle != 0) {
-        ret += boost::lexical_cast<std::string>(client_handle);
+        ret += ecf::convert_to<std::string>(client_handle);
         retVec.push_back(ret);
         if (auto_add_new_suites)
             retVec.emplace_back("true");
@@ -139,7 +139,7 @@ const char* CtsApi::ch_suites_arg() {
 
 std::string CtsApi::ch_drop(int client_handle) {
     std::string ret = "--ch_drop=";
-    ret += boost::lexical_cast<std::string>(client_handle);
+    ret += ecf::convert_to<std::string>(client_handle);
     return ret;
 }
 const char* CtsApi::ch_drop_arg() {
@@ -162,7 +162,7 @@ std::vector<std::string> CtsApi::ch_add(int client_handle, const std::vector<std
     std::vector<std::string> retVec;
     retVec.reserve(suites.size() + 1);
     std::string ret = "--ch_add=";
-    ret += boost::lexical_cast<std::string>(client_handle);
+    ret += ecf::convert_to<std::string>(client_handle);
     retVec.push_back(ret);
     for (const auto& suite : suites) {
         retVec.push_back(suite);
@@ -177,7 +177,7 @@ std::vector<std::string> CtsApi::ch_remove(int client_handle, const std::vector<
     std::vector<std::string> retVec;
     retVec.reserve(suites.size() + 1);
     std::string ret = "--ch_rem=";
-    ret += boost::lexical_cast<std::string>(client_handle);
+    ret += ecf::convert_to<std::string>(client_handle);
     retVec.push_back(ret);
     for (const auto& suite : suites) {
         retVec.push_back(suite);
@@ -192,7 +192,7 @@ std::vector<std::string> CtsApi::ch_auto_add(int client_handle, bool auto_add_ne
     std::vector<std::string> retVec;
     retVec.reserve(2);
     std::string ret = "--ch_auto_add=";
-    ret += boost::lexical_cast<std::string>(client_handle);
+    ret += ecf::convert_to<std::string>(client_handle);
     retVec.push_back(ret);
     if (auto_add_new_suites)
         retVec.emplace_back("true");
@@ -209,10 +209,10 @@ CtsApi::sync(unsigned int client_handle, unsigned int state_change_no, unsigned 
     std::vector<std::string> retVec;
     retVec.reserve(3);
     std::string ret = "--sync=";
-    ret += boost::lexical_cast<std::string>(client_handle);
+    ret += ecf::convert_to<std::string>(client_handle);
     retVec.push_back(ret);
-    retVec.push_back(boost::lexical_cast<std::string>(state_change_no));
-    retVec.push_back(boost::lexical_cast<std::string>(modify_change_no));
+    retVec.push_back(ecf::convert_to<std::string>(state_change_no));
+    retVec.push_back(ecf::convert_to<std::string>(modify_change_no));
     return retVec;
 }
 const char* CtsApi::syncArg() {
@@ -224,10 +224,10 @@ CtsApi::sync_clock(unsigned int client_handle, unsigned int state_change_no, uns
     std::vector<std::string> retVec;
     retVec.reserve(3);
     std::string ret = "--sync_clock=";
-    ret += boost::lexical_cast<std::string>(client_handle);
+    ret += ecf::convert_to<std::string>(client_handle);
     retVec.push_back(ret);
-    retVec.push_back(boost::lexical_cast<std::string>(state_change_no));
-    retVec.push_back(boost::lexical_cast<std::string>(modify_change_no));
+    retVec.push_back(ecf::convert_to<std::string>(state_change_no));
+    retVec.push_back(ecf::convert_to<std::string>(modify_change_no));
     return retVec;
 }
 const char* CtsApi::sync_clock_arg() {
@@ -236,7 +236,7 @@ const char* CtsApi::sync_clock_arg() {
 
 std::string CtsApi::sync_full(unsigned int client_handle) {
     std::string ret = "--sync_full=";
-    ret += boost::lexical_cast<std::string>(client_handle);
+    ret += ecf::convert_to<std::string>(client_handle);
     return ret;
 }
 const char* CtsApi::sync_full_arg() {
@@ -248,10 +248,10 @@ CtsApi::news(unsigned int client_handle, unsigned int state_change_no, unsigned 
     std::vector<std::string> retVec;
     retVec.reserve(3);
     std::string ret = "--news=";
-    ret += boost::lexical_cast<std::string>(client_handle);
+    ret += ecf::convert_to<std::string>(client_handle);
     retVec.push_back(ret);
-    retVec.push_back(boost::lexical_cast<std::string>(state_change_no));
-    retVec.push_back(boost::lexical_cast<std::string>(modify_change_no));
+    retVec.push_back(ecf::convert_to<std::string>(state_change_no));
+    retVec.push_back(ecf::convert_to<std::string>(modify_change_no));
     return retVec;
 }
 const char* CtsApi::newsArg() {
@@ -838,12 +838,12 @@ std::string CtsApi::checkPtDefs(ecf::CheckPt::Mode m, int check_pt_interval, int
     if (check_pt_interval != 0) {
         if (m != ecf::CheckPt::UNDEFINED)
             ret += ":";
-        ret += boost::lexical_cast<std::string>(check_pt_interval);
+        ret += ecf::convert_to<std::string>(check_pt_interval);
     }
     else {
         if (m == ecf::CheckPt::UNDEFINED && check_pt_save_time_alarm != 0) {
             ret += "alarm:";
-            ret += boost::lexical_cast<std::string>(check_pt_save_time_alarm);
+            ret += ecf::convert_to<std::string>(check_pt_save_time_alarm);
         }
     }
     return ret;

--- a/Base/src/cts/ForceCmd.cpp
+++ b/Base/src/cts/ForceCmd.cpp
@@ -14,11 +14,10 @@
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
 #include <stdexcept>
 
-#include <boost/lexical_cast.hpp>
-
 #include "AbstractClientEnv.hpp"
 #include "AbstractServer.hpp"
 #include "ClientToServerCmd.hpp"
+#include "Converter.hpp"
 #include "CtsApi.hpp"
 #include "Defs.hpp"
 #include "Extract.hpp"
@@ -66,7 +65,7 @@ std::string ForceCmd::print_short() const {
 
     if (paths_.size() > 1) {
         os += " : truncated : ";
-        os += boost::lexical_cast<std::string>(paths_.size() - 1);
+        os += ecf::convert_to<std::string>(paths_.size() - 1);
         os += " paths *not* shown";
     }
     return os;

--- a/Base/src/cts/LogCmd.cpp
+++ b/Base/src/cts/LogCmd.cpp
@@ -12,6 +12,7 @@
 //
 // Description :
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+
 #include <stdexcept>
 
 #include <boost/algorithm/string/trim.hpp>
@@ -19,6 +20,7 @@
 #include "AbstractClientEnv.hpp"
 #include "AbstractServer.hpp"
 #include "ClientToServerCmd.hpp"
+#include "Converter.hpp"
 #include "CtsApi.hpp"
 #include "Defs.hpp"
 #include "Log.hpp"
@@ -237,9 +239,9 @@ void LogCmd::create(Cmd_ptr& cmd, boost::program_options::variables_map& vm, Abs
         int value = Log::get_last_n_lines_default();
         if (args.size() == 2) {
             try {
-                value = boost::lexical_cast<int>(args[1]);
+                value = ecf::convert_to<int>(args[1]);
             }
-            catch (boost::bad_lexical_cast& e) {
+            catch (const ecf::bad_conversion&) {
                 throw std::runtime_error("LogCmd: Second argument must be a integer, i.e. --log get 100\n");
             }
         }

--- a/Base/src/cts/PathsCmd.cpp
+++ b/Base/src/cts/PathsCmd.cpp
@@ -18,6 +18,7 @@
 #include "AbstractClientEnv.hpp"
 #include "AbstractServer.hpp"
 #include "ClientToServerCmd.hpp"
+#include "Converter.hpp"
 #include "CtsApi.hpp"
 #include "Defs.hpp"
 #include "Log.hpp"
@@ -47,7 +48,7 @@ std::string PathsCmd::print_short() const {
     my_print_only(os, paths);
     if (paths_.size() > 1) {
         os += " : truncated : ";
-        os += boost::lexical_cast<std::string>(paths_.size() - 1);
+        os += ecf::convert_to<std::string>(paths_.size() - 1);
         os += " paths *not* shown";
     }
     return os;

--- a/Base/src/cts/QueryCmd.cpp
+++ b/Base/src/cts/QueryCmd.cpp
@@ -18,6 +18,7 @@
 #include "AbstractClientEnv.hpp"
 #include "AbstractServer.hpp"
 #include "ClientToServerCmd.hpp"
+#include "Converter.hpp"
 #include "CtsApi.hpp"
 #include "Defs.hpp"
 #include "Expression.hpp"
@@ -247,20 +248,20 @@ STC_Cmd_ptr QueryCmd::doHandleRequest(AbstractServer* as) const {
             ss << "QueryCmd: Cannot find meter " << attribute_ << " on node " << path_to_attribute_;
             throw std::runtime_error(ss.str());
         }
-        return PreAllocatedReply::string_cmd(boost::lexical_cast<std::string>(meter.value()));
+        return PreAllocatedReply::string_cmd(ecf::convert_to<std::string>(meter.value()));
     }
 
     if (query_type_ == "limit") {
         limit_ptr limit = node->find_limit(attribute_);
         if (!limit.get())
             throw std::runtime_error("QueryCmd: Could not find limit " + attribute_);
-        return PreAllocatedReply::string_cmd(boost::lexical_cast<std::string>(limit->value()));
+        return PreAllocatedReply::string_cmd(ecf::convert_to<std::string>(limit->value()));
     }
     if (query_type_ == "limit_max") {
         limit_ptr limit = node->find_limit(attribute_);
         if (!limit.get())
             throw std::runtime_error("QueryCmd: Could not find limit " + attribute_);
-        return PreAllocatedReply::string_cmd(boost::lexical_cast<std::string>(limit->theLimit()));
+        return PreAllocatedReply::string_cmd(ecf::convert_to<std::string>(limit->theLimit()));
     }
 
     if (query_type_ == "label") {

--- a/Base/src/cts/TaskCmds.cpp
+++ b/Base/src/cts/TaskCmds.cpp
@@ -12,11 +12,13 @@
 //
 // Description :
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+
 #include <stdexcept>
 
 #include "AbstractClientEnv.hpp"
 #include "AbstractServer.hpp"
 #include "ClientToServerCmd.hpp"
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "Expression.hpp"
 #include "Log.hpp"
@@ -857,7 +859,7 @@ void MeterCmd::print(std::string& os) const {
     os += "meter ";
     os += name_;
     os += " ";
-    os += boost::lexical_cast<std::string>(value_);
+    os += ecf::convert_to<std::string>(value_);
     os += " ";
     os += path_to_node();
 }
@@ -939,9 +941,9 @@ void MeterCmd::create(Cmd_ptr& cmd, boost::program_options::variables_map& vm, A
     int value = 0;
     try {
         std::string strVal = args[1];
-        value              = boost::lexical_cast<int>(strVal);
+        value              = ecf::convert_to<int>(strVal);
     }
-    catch (boost::bad_lexical_cast& e) {
+    catch (const ecf::bad_conversion&) {
         throw std::runtime_error("MeterCmd: Second argument must be a integer, i.e. --meter=name 100\n");
     }
 

--- a/Base/src/stc/SClientHandleCmd.cpp
+++ b/Base/src/stc/SClientHandleCmd.cpp
@@ -17,7 +17,7 @@
 
 #include <iostream>
 
-#include <boost/lexical_cast.hpp>
+#include "Converter.hpp"
 
 using namespace ecf;
 using namespace std;
@@ -29,7 +29,7 @@ bool SClientHandleCmd::equals(ServerToClientCmd* rhs) const {
 std::string SClientHandleCmd::print() const {
     string os;
     os += "cmd:SClientHandleCmd [ ";
-    os += boost::lexical_cast<string>(handle_);
+    os += ecf::convert_to<std::string>(handle_);
     os += " ]";
     return os;
 }

--- a/Base/src/stc/ZombieGetCmd.cpp
+++ b/Base/src/stc/ZombieGetCmd.cpp
@@ -16,9 +16,8 @@
 
 #include <iostream>
 
-#include <boost/lexical_cast.hpp>
-
 #include "AbstractServer.hpp"
+#include "Converter.hpp"
 
 using namespace std;
 using namespace boost;
@@ -43,7 +42,7 @@ bool ZombieGetCmd::equals(ServerToClientCmd* rhs) const {
 std::string ZombieGetCmd::print() const {
     string os;
     os += "cmd:ZombieGetCmd [ ";
-    os += boost::lexical_cast<std::string>(zombies_.size());
+    os += ecf::convert_to<std::string>(zombies_.size());
     os += " ]";
     return os;
 }

--- a/Base/test/TestClientHandleCmd.cpp
+++ b/Base/test/TestClientHandleCmd.cpp
@@ -17,6 +17,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "ClientToServerCmd.hpp"
+#include "Converter.hpp"
 #include "Suite.hpp"
 #include "TestHelper.hpp"
 
@@ -41,7 +42,7 @@ BOOST_AUTO_TEST_CASE(test_client_handle_cmd_empty_server) {
     std::vector<std::string> suite_names;
     suite_names.reserve(5);
     for (int i = 0; i < 5; i++)
-        suite_names.push_back("s" + boost::lexical_cast<std::string>(i));
+        suite_names.push_back("s" + ecf::convert_to<std::string>(i));
 
     defs_ptr new_defs = Defs::create();
 
@@ -95,7 +96,7 @@ BOOST_AUTO_TEST_CASE(test_client_handle_cmd_register_and_drop) {
     std::vector<std::string> suite_names;
     suite_names.reserve(6);
     for (int i = 0; i < 5; i++)
-        suite_names.push_back("s" + boost::lexical_cast<std::string>(i));
+        suite_names.push_back("s" + ecf::convert_to<std::string>(i));
 
     Defs defs;
     for (const auto& suite_name : suite_names)
@@ -128,7 +129,7 @@ BOOST_AUTO_TEST_CASE(test_client_handle_cmd_register__with_drop) {
     std::vector<std::string> suite_names;
     suite_names.reserve(6);
     for (int i = 0; i < 5; i++)
-        suite_names.push_back("s" + boost::lexical_cast<std::string>(i));
+        suite_names.push_back("s" + ecf::convert_to<std::string>(i));
 
     Defs defs;
     for (const auto& suite_name : suite_names)
@@ -172,7 +173,7 @@ BOOST_AUTO_TEST_CASE(test_client_handle_cmd_auto_add) {
     std::vector<std::string> suite_names;
     suite_names.reserve(6);
     for (int i = 0; i < 5; i++)
-        suite_names.push_back("s" + boost::lexical_cast<std::string>(i));
+        suite_names.push_back("s" + std::to_string(i));
 
     Defs defs;
     for (const auto& suite_name : suite_names)
@@ -198,7 +199,7 @@ BOOST_AUTO_TEST_CASE(test_client_handle_cmd_auto_add) {
     // now add new suite, they should get added to the new client handles
     names.clear();
     for (int i = 5; i < 10; i++)
-        names.push_back("s" + boost::lexical_cast<std::string>(i));
+        names.push_back("s" + std::to_string(i));
     for (const auto& name : names)
         defs.addSuite(Suite::create(name));
 
@@ -209,7 +210,7 @@ BOOST_AUTO_TEST_CASE(test_client_handle_cmd_auto_add) {
 
     // Delete the suite s5,s6,s7,s8,s9
     for (int i = 5; i < 10; i++) {
-        suite_ptr suite = defs.findSuite("s" + boost::lexical_cast<std::string>(i));
+        suite_ptr suite = defs.findSuite("s" + std::to_string(i));
         BOOST_CHECK_MESSAGE(suite.get(), "Failed to find suite s" << i);
         suite->remove();
     }
@@ -230,7 +231,7 @@ BOOST_AUTO_TEST_CASE(test_client_handle_cmd_add_remove) {
     std::vector<std::string> suite_names;
     suite_names.reserve(6);
     for (int i = 0; i < 5; i++)
-        suite_names.push_back("s" + boost::lexical_cast<std::string>(i));
+        suite_names.push_back("s" + std::to_string(i));
 
     defs_ptr defs = Defs::create();
     for (const auto& suite_name : suite_names)
@@ -321,7 +322,7 @@ BOOST_AUTO_TEST_CASE(test_client_handle_suite_ordering) {
     std::vector<std::string> suite_names;
     suite_names.reserve(6);
     for (int i = 0; i < 5; i++)
-        suite_names.push_back("s" + boost::lexical_cast<std::string>(i));
+        suite_names.push_back("s" + ecf::convert_to<std::string>(i));
 
     Defs defs;
     for (const auto& suite_name : suite_names)

--- a/Base/test/TestCmd.cpp
+++ b/Base/test/TestCmd.cpp
@@ -12,11 +12,13 @@
 //
 // Description :
 //============================================================================
+
 #include <iostream>
 #include <string>
 
 #include <boost/test/unit_test.hpp>
 
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "Family.hpp"
 #include "Str.hpp"
@@ -79,7 +81,7 @@ BOOST_AUTO_TEST_CASE(test_simple_cmd) {
     {
         std::string varValue;
         if (t1->findParentUserVariableValue(Str::ECF_TRIES(), varValue)) {
-            auto ecf_tries = boost::lexical_cast<int>(varValue);
+            auto ecf_tries = ecf::convert_to<int>(varValue);
             while (true) {
                 TestHelper::invokeRequest(
                     &defs,

--- a/Base/test/TestSSyncCmd_CH1.cpp
+++ b/Base/test/TestSSyncCmd_CH1.cpp
@@ -15,6 +15,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "ClientToServerCmd.hpp"
+#include "Converter.hpp"
 #include "Ecf.hpp"
 #include "Family.hpp"
 #include "Limit.hpp"
@@ -49,7 +50,7 @@ BOOST_AUTO_TEST_SUITE(BaseTestSuite)
 
 static defs_ptr create_client_defs(defs_ptr defs) {
     for (size_t j = 0; j < 5; j++) {
-        suite_ptr suite = defs->add_suite("s" + boost::lexical_cast<std::string>(j));
+        suite_ptr suite = defs->add_suite("s" + ecf::convert_to<std::string>(j));
         family_ptr f    = suite->add_family("f");
         f->add_task("t");
         if (j == 0) {

--- a/Base/test/TestStatsCmd.cpp
+++ b/Base/test/TestStatsCmd.cpp
@@ -42,7 +42,7 @@ std::string extract_report_value(const std::string& report, const std::string& l
 
 int extract_number_of_suites(const std::string& report) {
     auto entry = extract_report_value(report, "Number of Suites");
-    return boost::lexical_cast<int>(entry);
+    return ecf::convert_to<int>(entry);
 }
 
 std::string extract_request_per_second(const std::string& report) {

--- a/CSim/test/TestRepeat.cpp
+++ b/CSim/test/TestRepeat.cpp
@@ -19,6 +19,7 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "Family.hpp"
 #include "Simulator.hpp"
@@ -26,8 +27,6 @@
 #include "Task.hpp"
 #include "TestUtil.hpp"
 #include "VerifyAttr.hpp"
-
-// #include "PrintStyle.hpp"
 
 using namespace std;
 using namespace ecf;
@@ -67,7 +66,7 @@ BOOST_AUTO_TEST_CASE(test_repeat_integer) {
         fam->addVerify(VerifyAttr(NState::COMPLETE, 4)); // verify family repeats 2 times
         int taskSize = 2;
         for (int i = 0; i < taskSize; i++) {
-            task_ptr t = fam->add_task("t" + boost::lexical_cast<std::string>(i));
+            task_ptr t = fam->add_task("t" + ecf::convert_to<std::string>(i));
             t->addVerify(VerifyAttr(NState::COMPLETE, 4)); // Each task should run 4 times
         }
         //		cout << theDefs << "\n";

--- a/Client/src/ClientEnvironment.cpp
+++ b/Client/src/ClientEnvironment.cpp
@@ -22,8 +22,8 @@
 #include <stdexcept>
 
 #include <boost/filesystem/operations.hpp>
-#include <boost/lexical_cast.hpp>
 
+#include "Converter.hpp"
 #include "Ecf.hpp"
 #include "File.hpp"
 #include "Host.hpp"
@@ -162,9 +162,9 @@ void ClientEnvironment::set_host_port(const std::string& the_host, const std::st
     if (the_port.empty())
         throw std::runtime_error("ClientEnvironment::set_host_port: Empty port specified ?");
     try {
-        boost::lexical_cast<int>(the_port);
+        ecf::convert_to<int>(the_port);
     }
-    catch (boost::bad_lexical_cast& e) {
+    catch (const ecf::bad_conversion&) {
         throw std::runtime_error("ClientEnvironment::set_host_port: Invalid port number " + the_port);
     }
 
@@ -291,7 +291,7 @@ void ClientEnvironment::read_environment_variables() {
     char* debug_level = getenv("ECF_DEBUG_LEVEL");
     if (debug_level) {
         try {
-            Ecf::set_debug_level(boost::lexical_cast<unsigned int>(debug_level));
+            Ecf::set_debug_level(ecf::convert_to<unsigned int>(debug_level));
         }
         catch (...) {
             throw std::runtime_error("The environment variable ECF_DEBUG_LEVEL must be an unsigned integer.");

--- a/Client/src/ClientInvoker.cpp
+++ b/Client/src/ClientInvoker.cpp
@@ -12,6 +12,7 @@
 //
 // Description :
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+
 #include "ClientInvoker.hpp"
 
 #include <iostream>
@@ -21,6 +22,7 @@
 #include <boost/date_time/posix_time/time_formatters.hpp> // requires boost date and time lib
 
 #include "Client.hpp"
+#include "Converter.hpp"
 #ifdef ECF_OPENSSL
     #include "SslClient.hpp"
 #endif
@@ -87,7 +89,7 @@ ClientInvoker::ClientInvoker(const std::string& host, const std::string& port)
 }
 
 ClientInvoker::ClientInvoker(const std::string& host, int port)
-    : clientEnv_(false, host, boost::lexical_cast<std::string>(port)),
+    : clientEnv_(false, host, ecf::convert_to<std::string>(port)),
       retry_connection_period_(RETRY_CONNECTION_PERIOD) {
     if (clientEnv_.debug())
         cout << TimeStamp::now() << "ClientInvoker::ClientInvoker(): 4=================start=================\n";
@@ -1460,7 +1462,7 @@ std::string ClientInvoker::find_free_port(int seed_port_number, bool debug) {
     client.set_retry_connection_period(1); // avoid long wait
     client.set_connection_attempts(1);     // avoid long wait
     while (true) {
-        free_port = boost::lexical_cast<std::string>(the_port);
+        free_port = ecf::convert_to<std::string>(the_port);
         try {
             if (debug)
                 cout << "   Trying to connect to server on '" << Str::LOCALHOST() << ":" << free_port << "'\n";

--- a/Client/src/ClientOptions.cpp
+++ b/Client/src/ClientOptions.cpp
@@ -12,17 +12,18 @@
 //
 // Description : Delegates argument parsing to the registered commands
 //============================================================================
+
 #include "ClientOptions.hpp"
 
 #include <iostream>
 #include <stdexcept>
 
-#include <boost/lexical_cast.hpp>
 #include <boost/program_options.hpp>
 
 #include "ClientEnvironment.hpp"
 #include "ClientOptionsParser.hpp"
 #include "CommandLine.hpp"
+#include "Converter.hpp"
 #include "Help.hpp"
 #include "PasswordEncryption.hpp"
 #include "Str.hpp"
@@ -134,9 +135,9 @@ Cmd_ptr ClientOptions::parse(const CommandLine& cl, ClientEnvironment* env) cons
         if (env->debug())
             std::cout << "  port " << port << " overridden at the command line\n";
         try {
-            boost::lexical_cast<int>(port);
+            ecf::convert_to<int>(port);
         }
-        catch (boost::bad_lexical_cast& e) {
+        catch (ecf::bad_conversion& e) {
             std::stringstream ss;
             ss << "ClientOptions::parse: The specified port(" << port << ") must be convertible to an integer";
             throw std::runtime_error(ss.str());

--- a/Client/test/SCPort.cpp
+++ b/Client/test/SCPort.cpp
@@ -50,7 +50,7 @@ std::string SCPort::next() {
             std::cout << " seed_port=ECF_FREE_PORT=(" << ECF_FREE_PORT << ")";
         std::string port = ECF_FREE_PORT;
         try {
-            thePort_ = boost::lexical_cast<int>(port);
+            thePort_ = ecf::convert_to<int>(port);
         }
         catch (...) {
             std::cout << "SCPort::next()  ECF_FREE_PORT(" << ECF_FREE_PORT << ") not convertible to an integer\n";

--- a/Client/test/TestCheckPtDefsCmd.cpp
+++ b/Client/test/TestCheckPtDefsCmd.cpp
@@ -226,7 +226,7 @@ BOOST_AUTO_TEST_CASE(test_restore_from_check_pt) {
                               "Expected " << expected_no_of_suites << " suites, after restoreDefsFromCheckPt but found "
                                           << theClient.defs()->suiteVec().size() << "\n");
 
-        std::string suite = "/s" + boost::lexical_cast<std::string>(i);
+        std::string suite = "/s" + ecf::convert_to<std::string>(i);
         BOOST_REQUIRE_MESSAGE(theClient.delete_node(suite) == 0,
                               "Expected delete single suite to succeed\n"
                                   << theClient.errorMsg());

--- a/Http/src/ApiV1Impl.cpp
+++ b/Http/src/ApiV1Impl.cpp
@@ -24,7 +24,7 @@
 
 #include "BasicAuth.hpp"
 #include "Child.hpp"
-#include "ClientInvoker.hpp"
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "DefsStructureParser.hpp"
 #include "Family.hpp"
@@ -104,11 +104,11 @@ std::string json_type_to_string(const ecf::ojson& j) {
         case ecf::ojson::value_t::discarded:
             return "discarded";
         case ecf::ojson::value_t::number_integer:
-            return std::to_string(j.get<int>());
+            return ecf::convert_to<std::string>(j.get<int>());
         case ecf::ojson::value_t::number_unsigned:
-            return std::to_string(j.get<unsigned int>());
+            return ecf::convert_to<std::string>(j.get<unsigned int>());
         case ecf::ojson::value_t::number_float:
-            return std::to_string(j.get<double>());
+            return ecf::convert_to<std::string>(j.get<double>());
         default:
             return std::string();
     }

--- a/Http/src/HttpServer.cpp
+++ b/Http/src/HttpServer.cpp
@@ -17,6 +17,7 @@
 #include <boost/program_options.hpp>
 
 #include "ApiV1.hpp"
+#include "Converter.hpp"
 #include "JSON.hpp"
 #include "Options.hpp"
 
@@ -96,7 +97,7 @@ void HttpServer::parse_args(int argc, char** argv) {
         opts.no_ssl = true;
 
     setenv("ECF_HOST", opts.ecflow_host.c_str(), 1);
-    setenv("ECF_PORT", std::to_string(opts.ecflow_port).c_str(), 1);
+    setenv("ECF_PORT", ecf::convert_to<std::string>(opts.ecflow_port).c_str(), 1);
     // Unset these, otherwise ClientInvoker will automatically
     // try to use them
     unsetenv("ECF_PASSWD");
@@ -197,7 +198,7 @@ void start_server(httplib::Server& http_server) {
     try {
         bool ret = http_server.listen("0.0.0.0", opts.port);
         if (ret == false) {
-            throw std::runtime_error("Failed to bind to port " + std::to_string(opts.port));
+            throw std::runtime_error("Failed to bind to port " + ecf::convert_to<std::string>(opts.port));
         }
     }
     catch (const std::exception& e) {

--- a/Http/test/TestApiV1.cpp
+++ b/Http/test/TestApiV1.cpp
@@ -139,13 +139,16 @@ httplib::Response handle_response(const httplib::Result& r,
             throw std::runtime_error("NULL reply from server");
         }
         else if (r->status != expected_code) {
-            throw std::runtime_error("Expected status code: " + std::to_string(expected_code) +
-                                     " got: " + std::to_string(r->status));
+            throw std::runtime_error(
+                "Expected status code: " + ecf::convert_to<std::string>(static_cast<int>(expected_code)) +
+                " got: " + ecf::convert_to<std::string>(r->status));
         }
     }
     else {
         BOOST_REQUIRE_MESSAGE(r, "ERROR: no response");
-        BOOST_REQUIRE_MESSAGE(r->status == expected_code, "ERROR: status code is not " + std::to_string(expected_code));
+        BOOST_REQUIRE_MESSAGE(r->status == expected_code,
+                              "ERROR: status code is not " +
+                                  ecf::convert_to<std::string>(static_cast<int>(expected_code)));
     }
 
     return httplib::Response(*r);
@@ -230,9 +233,9 @@ std::string json_type_to_string(const json& j) {
         case json::value_t::discarded:
             return "discarded";
         case json::value_t::number_integer:
-            return std::to_string(j.get<int>());
+            return ecf::convert_to<std::string>(j.get<int>());
         case json::value_t::number_unsigned:
-            return std::to_string(j.get<unsigned int>());
+            return ecf::convert_to<std::string>(j.get<unsigned int>());
         case json::value_t::number_float:
             return std::to_string(j.get<double>());
         default:

--- a/Pyext/src/BoostPythonUtil.cpp
+++ b/Pyext/src/BoostPythonUtil.cpp
@@ -19,6 +19,7 @@
 
 #include <stdexcept>
 
+#include "Converter.hpp"
 #include "Variable.hpp"
 
 void BoostPythonUtil::list_to_int_vec(const boost::python::list& list, std::vector<int>& int_vec) {
@@ -60,7 +61,7 @@ void BoostPythonUtil::dict_to_str_vec(const boost::python::dict& dict,
         }
         else if (boost::python::extract<int>(dict[keys[i]]).check()) {
             int the_int = boost::python::extract<int>(dict[keys[i]]);
-            second      = boost::lexical_cast<std::string>(the_int);
+            second      = ecf::convert_to<std::string>(the_int);
         }
         else
             throw std::runtime_error("BoostPythonUtil::dict_to_str_vec: type not convertible to string or integer");
@@ -83,7 +84,7 @@ void BoostPythonUtil::dict_to_str_vec(const boost::python::dict& dict, std::vect
         }
         else if (boost::python::extract<int>(dict[keys[i]]).check()) {
             int the_int = boost::python::extract<int>(dict[keys[i]]);
-            second      = boost::lexical_cast<std::string>(the_int);
+            second      = ecf::convert_to<std::string>(the_int);
         }
         else
             throw std::runtime_error("BoostPythonUtil::dict_to_str_vec: type not convertible to string or integer");

--- a/Pyext/src/ExportClient.cpp
+++ b/Pyext/src/ExportClient.cpp
@@ -12,6 +12,7 @@
 //
 // Description :
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+
 #include <algorithm> // for std::transform
 
 #include <boost/algorithm/string.hpp>
@@ -21,6 +22,7 @@
 #include "BoostPythonUtil.hpp"
 #include "ClientDoc.hpp"
 #include "ClientInvoker.hpp"
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "Log.hpp"
 #include "NState.hpp"
@@ -38,7 +40,7 @@ namespace bp = boost::python;
 // See: http://wiki.python.org/moin/boost.python/HowTo#boost.function_objects
 
 void set_host_port(ClientInvoker* self, const std::string& host, int port) {
-    self->set_host_port(host, boost::lexical_cast<std::string>(port));
+    self->set_host_port(host, ecf::convert_to<std::string>(port));
 }
 
 std::string version(ClientInvoker* self) {
@@ -375,7 +377,7 @@ void alter_sort(ClientInvoker* self,
 }
 
 void set_child_pid(ClientInvoker* self, int pid) {
-    self->set_child_pid(boost::lexical_cast<std::string>(pid));
+    self->set_child_pid(ecf::convert_to<std::string>(pid));
 }
 
 void set_child_init_add_vars(ClientInvoker* self, const bp::dict& dict) {

--- a/Pyext/src/ExportDefs.cpp
+++ b/Pyext/src/ExportDefs.cpp
@@ -13,12 +13,14 @@
 // Description :
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
 // file deepcode ignore CppConstantBinaryExpression: <comment the reason here>
+
 #include <stdexcept>
 
 #include <boost/python.hpp>
 #include <boost/python/raw_function.hpp>
 
 #include "BoostPythonUtil.hpp"
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "DefsDoc.hpp"
 #include "Edit.hpp"
@@ -143,7 +145,7 @@ defs_ptr add_variable(defs_ptr self, const std::string& name, const std::string&
     return self;
 }
 defs_ptr add_variable_int(defs_ptr self, const std::string& name, int value) {
-    self->set_server().add_or_update_user_variables(name, boost::lexical_cast<std::string>(value));
+    self->set_server().add_or_update_user_variables(name, ecf::convert_to<std::string>(value));
     return self;
 }
 defs_ptr add_variable_var(defs_ptr self, const Variable& var) {

--- a/Server/src/ServerEnvironment.cpp
+++ b/Server/src/ServerEnvironment.cpp
@@ -21,10 +21,10 @@
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/program_options.hpp>
 
 #include "Calendar.hpp"
+#include "Converter.hpp"
 #include "Ecf.hpp"
 #include "JobProfiler.hpp"
 #include "Log.hpp"
@@ -152,7 +152,7 @@ void ServerEnvironment::init(int argc, char* argv[], const std::string& path_to_
     assert(!ecf_passwd_file_.empty());         // expect name of form "ecf.passwd"
     assert(!ecf_passwd_custom_file_.empty());  // expect name of form "ecf.custom_passwd"
 
-    std::string port = boost::lexical_cast<std::string>(serverPort_);
+    std::string port = ecf::convert_to<std::string>(serverPort_);
 
     // If path is absolute leave as is
     if (ecf_checkpt_file_ == Ecf::CHECKPT())
@@ -367,7 +367,7 @@ std::pair<std::string, std::string> ServerEnvironment::hostPort() const {
 }
 
 std::string ServerEnvironment::the_port() const {
-    return boost::lexical_cast<std::string>(serverPort_);
+    return ecf::convert_to<std::string>(serverPort_);
 }
 
 void ServerEnvironment::variables(std::vector<std::pair<std::string, std::string>>& theRetVec) const {
@@ -382,7 +382,7 @@ void ServerEnvironment::variables(std::vector<std::pair<std::string, std::string
     theRetVec.emplace_back(std::string("ECF_LOG"), Log::instance()->path());
     theRetVec.emplace_back(std::string("ECF_CHECK"), ecf_checkpt_file_);
     theRetVec.emplace_back(std::string("ECF_CHECKOLD"), ecf_backup_checkpt_file_);
-    theRetVec.emplace_back(std::string("ECF_INTERVAL"), boost::lexical_cast<std::string>(submitJobsInterval_));
+    theRetVec.emplace_back(std::string("ECF_INTERVAL"), ecf::convert_to<std::string>(submitJobsInterval_));
 
     // These variable are read in from the environment, but are not exposed
     // since they only affect the server
@@ -660,9 +660,9 @@ void ServerEnvironment::read_environment_variables(std::string& log_file_name) {
     if (serverPort) {
         std::string port = serverPort;
         try {
-            serverPort_ = boost::lexical_cast<int>(port);
+            serverPort_ = ecf::convert_to<int>(port);
         }
-        catch (boost::bad_lexical_cast& e) {
+        catch (const ecf::bad_conversion&) {
             std::stringstream ss;
             ss << "ServerEnvironment::read_environment_variables(): ECF_PORT is defined(" << port
                << ") but value is *not* convertible to an integer\n";
@@ -673,9 +673,9 @@ void ServerEnvironment::read_environment_variables(std::string& log_file_name) {
     if (checkPtInterval) {
         std::string interval = checkPtInterval;
         try {
-            checkPtInterval_ = boost::lexical_cast<int>(interval);
+            checkPtInterval_ = ecf::convert_to<int>(interval);
         }
-        catch (boost::bad_lexical_cast& e) {
+        catch (const ecf::bad_conversion&) {
             std::stringstream ss;
             ss << "ServerEnvironment::read_environment_variables(): ECF_CHECKINTERVAL is defined(" << interval
                << ") but value is *not* convertible to an integer\n";
@@ -717,9 +717,9 @@ void ServerEnvironment::read_environment_variables(std::string& log_file_name) {
     char* ecf_prune_node_log = getenv("ECF_PRUNE_NODE_LOG");
     if (ecf_prune_node_log) {
         try {
-            ecf_prune_node_log_ = boost::lexical_cast<int>(ecf_prune_node_log);
+            ecf_prune_node_log_ = ecf::convert_to<int>(ecf_prune_node_log);
         }
-        catch (boost::bad_lexical_cast& e) {
+        catch (const ecf::bad_conversion&) {
             std::stringstream ss;
             ss << "ServerEnviroment::read_environment_variables: ECF_PRUNE_NODE_LOG must be convertible to an integer, "
                   "But found: "
@@ -742,7 +742,7 @@ void ServerEnvironment::read_environment_variables(std::string& log_file_name) {
     if (threshold) {
         std::string task_threshold = threshold;
         try {
-            JobProfiler::set_task_threshold(boost::lexical_cast<int>(task_threshold));
+            JobProfiler::set_task_threshold(ecf::convert_to<int>(task_threshold));
         }
         catch (...) {
             std::stringstream ss;

--- a/Server/test/TestServer1.cpp
+++ b/Server/test/TestServer1.cpp
@@ -17,7 +17,6 @@
 #include <iostream>
 
 #include <boost/filesystem/operations.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "Defs.hpp"
@@ -166,10 +165,10 @@ BOOST_AUTO_TEST_CASE(test_server) {
         the_port1 = test_ecf_port;
     cout << "  Find free port to start server, starting with port " << the_port1 << "\n";
 
-    auto the_port = boost::lexical_cast<int>(the_port1);
+    auto the_port = ecf::convert_to<int>(the_port1);
     while (!EcfPortLock::is_free(the_port))
         the_port++;
-    std::string port = boost::lexical_cast<std::string>(the_port);
+    std::string port = ecf::convert_to<std::string>(the_port);
     EcfPortLock::create(port);
     cout << "  Found free port: " << port << " ";
 
@@ -190,12 +189,12 @@ BOOST_AUTO_TEST_CASE(test_server) {
 
             cout << " : port " << port << " is used, trying next port\n";
 
-            the_port = boost::lexical_cast<int>(port);
+            the_port = ecf::convert_to<int>(port);
             the_port++;
 
             while (!EcfPortLock::is_free(the_port))
                 the_port++;
-            port = boost::lexical_cast<std::string>(the_port);
+            port = ecf::convert_to<std::string>(the_port);
             EcfPortLock::create(port);
             cout << "  Found free port: " << port << "\n";
 

--- a/Server/test/TestServerEnvironment.cpp
+++ b/Server/test/TestServerEnvironment.cpp
@@ -18,10 +18,10 @@
 #include <stdexcept>
 
 #include <boost/filesystem/operations.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "CheckPt.hpp"
+#include "Converter.hpp"
 #include "Ecf.hpp"
 #include "File.hpp"
 #include "Host.hpp"
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(test_server_environment_ecfinterval) {
     std::string port = Str::DEFAULT_PORT_NUMBER();
     for (int i = -10; i < 70; ++i) {
         string errorMsg;
-        string argument = "--ecfinterval=" + boost::lexical_cast<std::string>(i);
+        string argument = "--ecfinterval=" + ecf::convert_to<std::string>(i);
 
         int argc        = 2;
         char* argv[]    = {const_cast<char*>("ServerEnvironment"), const_cast<char*>(argument.c_str())};
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(test_server_config_file) {
             continue;
         }
         if (string("ECF_CHECKINTERVAL") == p.first) {
-            std::string expected = boost::lexical_cast<std::string>(CheckPt::default_interval());
+            std::string expected = ecf::convert_to<std::string>(CheckPt::default_interval());
             BOOST_CHECK_MESSAGE(p.second == expected,
                                 "for ECF_CHECKINTERVAL expected " << CheckPt::default_interval() << " but found "
                                                                   << p.second);

--- a/Test/TestAbortCmd.cpp
+++ b/Test/TestAbortCmd.cpp
@@ -19,7 +19,6 @@
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "Defs.hpp"

--- a/Test/TestAlias.cpp
+++ b/Test/TestAlias.cpp
@@ -24,7 +24,6 @@
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "Alias.hpp"

--- a/Test/TestClkSync.cpp
+++ b/Test/TestClkSync.cpp
@@ -20,7 +20,6 @@
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "Defs.hpp"

--- a/Test/TestComplete.cpp
+++ b/Test/TestComplete.cpp
@@ -19,7 +19,6 @@
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "Defs.hpp"

--- a/Test/TestCtsWaitCmd.cpp
+++ b/Test/TestCtsWaitCmd.cpp
@@ -19,7 +19,6 @@
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "AssertTimer.hpp"

--- a/Test/TestDayDate.cpp
+++ b/Test/TestDayDate.cpp
@@ -20,7 +20,6 @@
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "Defs.hpp"

--- a/Test/TestEcfNoScriptCmd.cpp
+++ b/Test/TestEcfNoScriptCmd.cpp
@@ -24,7 +24,6 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/test/unit_test.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <iostream>
 #include <fstream>

--- a/Test/TestFileCmd.cpp
+++ b/Test/TestFileCmd.cpp
@@ -12,15 +12,16 @@
 //
 // Description : This is used to INVOKE a SINGLE test. Easier for debugging
 //============================================================================
+
 #include <iostream>
 
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "ClientToServerCmd.hpp"
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "DurationTimer.hpp"
 #include "Family.hpp"
@@ -69,7 +70,7 @@ BOOST_AUTO_TEST_CASE(test_file_cmd) {
         family_ptr fam = suite->add_family("family");
         int taskSize   = 2; // on linux 1024 tasks take ~4 seconds for job submission
         for (int i = 0; i < taskSize; i++) {
-            task_ptr task = fam->add_task("t" + boost::lexical_cast<std::string>(i));
+            task_ptr task = fam->add_task("t" + ecf::convert_to<std::string>(i));
             task->addVerify(VerifyAttr(NState::COMPLETE, 1));
         }
     }

--- a/Test/TestHandle.cpp
+++ b/Test/TestHandle.cpp
@@ -19,11 +19,11 @@
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "AssertTimer.hpp"
 #include "ClientToServerCmd.hpp"
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "DurationTimer.hpp"
 #include "Family.hpp"
@@ -72,10 +72,10 @@ BOOST_AUTO_TEST_CASE(test_handle) {
     Defs theDefs;
     {
         for (int s = 0; s < 7; s++) {
-            suite_ptr suite = theDefs.add_suite("s" + boost::lexical_cast<std::string>(s));
+            suite_ptr suite = theDefs.add_suite("s" + ecf::convert_to<std::string>(s));
             suite->addDefStatus(DState::SUSPENDED); // NO NEED to run jobs for this test:
             for (int t = 0; t < 2; t++) {
-                suite->add_task("t" + boost::lexical_cast<std::string>(t));
+                suite->add_task("t" + ecf::convert_to<std::string>(t));
             }
         }
     }
@@ -225,10 +225,10 @@ BOOST_AUTO_TEST_CASE(test_handle_sync) {
     Defs theDefs;
     {
         for (int s = 0; s < 7; s++) {
-            suite_ptr suite = theDefs.add_suite("s" + boost::lexical_cast<std::string>(s));
+            suite_ptr suite = theDefs.add_suite("s" + ecf::convert_to<std::string>(s));
             suite->addDefStatus(DState::SUSPENDED);
             for (int t = 0; t < 2; t++) {
-                suite->add_task("t" + boost::lexical_cast<std::string>(t));
+                suite->add_task("t" + ecf::convert_to<std::string>(t));
             }
         }
     }
@@ -363,10 +363,10 @@ BOOST_AUTO_TEST_CASE(test_handle_add_remove_add) {
     defs_ptr theDefs = Defs::create();
     {
         for (int s = 0; s < 3; s++) {
-            suite_ptr suite = theDefs->add_suite("s" + boost::lexical_cast<std::string>(s));
+            suite_ptr suite = theDefs->add_suite("s" + ecf::convert_to<std::string>(s));
             suite->addDefStatus(DState::SUSPENDED); // NO NEED to run jobs for this test:
             for (int t = 0; t < 2; t++) {
-                suite->add_task("t" + boost::lexical_cast<std::string>(t));
+                suite->add_task("t" + ecf::convert_to<std::string>(t));
             }
         }
     }

--- a/Test/TestInitAddVariable.cpp
+++ b/Test/TestInitAddVariable.cpp
@@ -19,6 +19,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "DurationTimer.hpp"
 #include "Family.hpp"
@@ -68,7 +69,7 @@ BOOST_AUTO_TEST_CASE(test_init_add_variable) {
         fam->addVerify(VerifyAttr(NState::COMPLETE, 1));
         task_ptr t1 = fam->add_task("t1");
         t1->addVerify(VerifyAttr(NState::COMPLETE, 1));
-        t1->add_variable("SLEEPTIME", boost::lexical_cast<std::string>(TestFixture::job_submission_interval()));
+        t1->add_variable("SLEEPTIME", ecf::convert_to<std::string>(TestFixture::job_submission_interval()));
 
         task_ptr t2 = fam->add_task("t2");
         t2->add_trigger("t1 == active and ./t1:NAME1 == 1 and ./t1:NAME2 == 2");

--- a/Test/TestKillCmd.cpp
+++ b/Test/TestKillCmd.cpp
@@ -17,7 +17,6 @@
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "AssertTimer.hpp"

--- a/Test/TestLate.cpp
+++ b/Test/TestLate.cpp
@@ -12,17 +12,18 @@
 //
 // Description :
 //============================================================================
+
 #include <iostream>
 #include <limits> // for std::numeric_limits<int>::max()
 
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "AssertTimer.hpp"
 #include "ClientToServerCmd.hpp"
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "DurationTimer.hpp"
 #include "Family.hpp"
@@ -56,7 +57,7 @@ BOOST_AUTO_TEST_CASE(test_late) {
         suite_ptr suite = theDefs.add_suite("test_late");
         suite->add_variable(
             "SLEEPTIME",
-            boost::lexical_cast<std::string>(TestFixture::job_submission_interval() * 2)); // this will cause the late
+            ecf::convert_to<std::string>(TestFixture::job_submission_interval() * 2)); // this will cause the late
 
         task_ptr task = suite->add_task("t1");
         ecf::LateAttr lateAttr;
@@ -104,7 +105,7 @@ BOOST_AUTO_TEST_CASE(test_late_hierarchically) {
         suite_ptr suite = theDefs.add_suite("test_late_hierarchically");
         suite->add_variable(
             "SLEEPTIME",
-            boost::lexical_cast<std::string>(TestFixture::job_submission_interval() * 2)); // this will cause the late
+            ecf::convert_to<std::string>(TestFixture::job_submission_interval() * 2)); // this will cause the late
         ecf::LateAttr lateAttr;
         lateAttr.addComplete(ecf::TimeSlot(0, 1), true);
         suite->addLate(lateAttr);

--- a/Test/TestLimit.cpp
+++ b/Test/TestLimit.cpp
@@ -19,9 +19,9 @@
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "DurationTimer.hpp"
 #include "Family.hpp"
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(test_limit) {
         fam->addVerify(VerifyAttr(NState::COMPLETE, 1));
         int taskSize = 3;
         for (int i = 0; i < taskSize; i++) {
-            task_ptr task = fam->add_task("t" + boost::lexical_cast<std::string>(i));
+            task_ptr task = fam->add_task("t" + ecf::convert_to<std::string>(i));
             task->addVerify(VerifyAttr(NState::COMPLETE, 1));
         }
 
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(test_limit) {
         fam2->addInLimit(InLimit("disk", pathToLimit, 20));
         fam2->addVerify(VerifyAttr(NState::COMPLETE, 1));
         for (int i = 0; i < taskSize; i++) {
-            task_ptr task = fam2->add_task("t" + boost::lexical_cast<std::string>(i));
+            task_ptr task = fam2->add_task("t" + ecf::convert_to<std::string>(i));
             task->addVerify(VerifyAttr(NState::COMPLETE, 1));
         }
     }

--- a/Test/TestOrderCmd.cpp
+++ b/Test/TestOrderCmd.cpp
@@ -19,7 +19,6 @@
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "AssertTimer.hpp"

--- a/Test/TestQueueCmd.cpp
+++ b/Test/TestQueueCmd.cpp
@@ -19,7 +19,6 @@
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "Defs.hpp"

--- a/Test/TestRepeat.cpp
+++ b/Test/TestRepeat.cpp
@@ -21,9 +21,9 @@
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "DurationTimer.hpp"
 #include "Family.hpp"
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(test_repeat_integer) {
         fam->addVerify(VerifyAttr(NState::COMPLETE, 4));
         int taskSize = 2; // on linux 1024 tasks take ~4 seconds for job submission
         for (int i = 0; i < taskSize; i++) {
-            task_ptr task = fam->add_task("t" + boost::lexical_cast<std::string>(i));
+            task_ptr task = fam->add_task("t" + ecf::convert_to<std::string>(i));
             task->addVerify(VerifyAttr(NState::COMPLETE, 4)); // task should complete 4 times
         }
     }
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(test_repeat_date) {
         fam->addVerify(VerifyAttr(NState::COMPLETE, 5));
         int taskSize = 2;
         for (int i = 0; i < taskSize; i++) {
-            task_ptr task = fam->add_task("t" + boost::lexical_cast<std::string>(i));
+            task_ptr task = fam->add_task("t" + ecf::convert_to<std::string>(i));
             task->addVerify(VerifyAttr(NState::COMPLETE, 5));
         }
     }
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE(test_repeat_date_list) {
         fam->addVerify(VerifyAttr(NState::COMPLETE, 2));
         int taskSize = 2;
         for (int i = 0; i < taskSize; i++) {
-            task_ptr task = fam->add_task("t" + boost::lexical_cast<std::string>(i));
+            task_ptr task = fam->add_task("t" + ecf::convert_to<std::string>(i));
             task->addVerify(VerifyAttr(NState::COMPLETE, 2));
         }
     }
@@ -251,7 +251,7 @@ BOOST_AUTO_TEST_CASE(test_repeat_defstatus) {
         int taskSize = 2; // on linux 1024 tasks take ~4 seconds for job submission
         for (int i = 0; i < taskSize; i++) {
 
-            task_ptr task = fam->add_task("t" + boost::lexical_cast<std::string>(i));
+            task_ptr task = fam->add_task("t" + ecf::convert_to<std::string>(i));
             task->addVerify(VerifyAttr(NState::COMPLETE, 1));
         }
     }

--- a/Test/TestRequeueNode.cpp
+++ b/Test/TestRequeueNode.cpp
@@ -18,9 +18,9 @@
 #include <fstream>
 #include <iostream>
 
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "DurationTimer.hpp"
 #include "Family.hpp"
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(test_requeue_node) {
         fam->addVerify(VerifyAttr(NState::COMPLETE, 4));
         int taskSize = 2; // on linux 1024 tasks take ~4 seconds for job submission
         for (int i = 0; i < taskSize; i++) {
-            task_ptr task = fam->add_task("t" + boost::lexical_cast<std::string>(i));
+            task_ptr task = fam->add_task("t" + ecf::convert_to<std::string>(i));
             task->addVerify(VerifyAttr(NState::COMPLETE, 4)); // task should complete 4 times
         }
     }

--- a/Test/TestServer.cpp
+++ b/Test/TestServer.cpp
@@ -19,9 +19,9 @@
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "DurationTimer.hpp"
 #include "Family.hpp"
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE(test_server_job_submission) {
         fam->addVerify(VerifyAttr(NState::COMPLETE, 1));
         int taskSize = 3; // on linux 1024 tasks take ~4 seconds for job submission
         for (int i = 0; i < taskSize; i++) {
-            task_ptr task = fam->add_task("t" + boost::lexical_cast<std::string>(i));
+            task_ptr task = fam->add_task("t" + ecf::convert_to<std::string>(i));
             task->addVerify(VerifyAttr(NState::COMPLETE, 1));
         }
     }

--- a/Test/TestSingle.cpp
+++ b/Test/TestSingle.cpp
@@ -1,14 +1,14 @@
 //============================================================================
 // Name        :
 // Author      : Avi
-// Revision    : $Revision: #80 $ 
+// Revision    : $Revision: #80 $
 //
 // Copyright 2009- ECMWF.
-// This software is licensed under the terms of the Apache Licence version 2.0 
-// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0. 
-// In applying this licence, ECMWF does not waive the privileges and immunities 
-// granted to it by virtue of its status as an intergovernmental organisation 
-// nor does it submit to any jurisdiction. 
+// This software is licensed under the terms of the Apache Licence version 2.0
+// which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+// In applying this licence, ECMWF does not waive the privileges and immunities
+// granted to it by virtue of its status as an intergovernmental organisation
+// nor does it submit to any jurisdiction.
 //
 // Description : This is used to INVOKE a SINGLE test.
 //               Making it easier for Easier for debugging and development
@@ -18,7 +18,6 @@
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #define BOOST_TEST_MODULE TEST_SINGLE
 #include <boost/test/included/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
@@ -26,6 +25,7 @@
 #include "TestFixture.hpp"
 #include "ServerTestHarness.hpp"
 
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "Suite.hpp"
 #include "Family.hpp"
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE( test_stress )
       suite_ptr suite = theDefs.add_suite( test_name );
       family_ptr fam = suite->add_family("family");
       for(int i=0; i < no_of_tasks_to_run ; i++) {
-         task_ptr t = fam->add_task ( "t" + boost::lexical_cast<std::string>(i) );
+         task_ptr t = fam->add_task ( "t" + ecf::convert_to<std::string>(i) );
          t->addRepeat(RepeatDay(1));
          t->addEvent(Event("event"));
          t->addLabel(Label("name","value"));
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE( test_stress )
 ///   6000               37                     900
 //void time_for_tasks(int tasks) {
 //
-//   std::string test_name = "test_stress_" + boost::lexical_cast<std::string>(tasks);
+//   std::string test_name = "test_stress_" + ecf::convert_to<std::string>(tasks);
 //   cout << "Test:: ..." << test_name  << flush;
 //
 //   Defs theDefs;
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE( test_stress )
 //      suite_ptr suite = theDefs.add_suite( test_name );
 //      family_ptr fam = suite->add_family("fam" );
 //      for(int i = 0; i < tasks; i++) {
-//         fam->add_task( "t" +   boost::lexical_cast<std::string>(i));
+//         fam->add_task( "t" + ecf::convert_to<std::string>(i));
 //      }
 //      //      suite->addRepeat( RepeatDate("YMD",19000101,99991201,1) );
 //   }

--- a/Test/TestSuspend.cpp
+++ b/Test/TestSuspend.cpp
@@ -18,10 +18,10 @@
 #include <iostream>
 
 #include <boost/date_time/posix_time/posix_time_types.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "AssertTimer.hpp"
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "DurationTimer.hpp"
 #include "Family.hpp"
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(test_shutdown) {
         family_ptr fam = suite->add_family("family");
         int taskSize   = 2; // on linux 1024 tasks take ~4 seconds for job submission
         for (int i = 0; i < taskSize; i++) {
-            task_ptr task                  = fam->add_task("t" + boost::lexical_cast<std::string>(i));
+            task_ptr task                  = fam->add_task("t" + ecf::convert_to<std::string>(i));
 
             boost::posix_time::ptime time1 = theLocalTime + minutes(1 + i);
             task->addTime(ecf::TimeAttr(ecf::TimeSlot(time1.time_of_day())));
@@ -195,7 +195,7 @@ BOOST_AUTO_TEST_CASE(test_suspend_node) {
 
         family_ptr fam = suite->add_family("family");
         for (int i = 0; i < 2; i++) {
-            task_ptr task = fam->add_task("t" + boost::lexical_cast<std::string>(i));
+            task_ptr task = fam->add_task("t" + ecf::convert_to<std::string>(i));
             task->addVerify(VerifyAttr(NState::COMPLETE, 1)); // task should complete 1 times
 
             boost::posix_time::ptime time3 = theLocalTime + minutes(1 + i);

--- a/Test/TestToday.cpp
+++ b/Test/TestToday.cpp
@@ -22,6 +22,7 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "DurationTimer.hpp"
 #include "Family.hpp"
@@ -119,7 +120,7 @@ BOOST_AUTO_TEST_CASE(test_today_relative_time_series) {
         // Initialise clock with todays date and time, then create a today attribute
         // with a time series, so that task runs 3 times
         suite_ptr suite = theDefs.add_suite("test_today_relative_time_series");
-        suite->add_variable("SLEEPTIME", boost::lexical_cast<std::string>(TestFixture::job_submission_interval() - 1));
+        suite->add_variable("SLEEPTIME", ecf::convert_to<std::string>(TestFixture::job_submission_interval() - 1));
         ClockAttr clockAttr(Calendar::second_clock_time(), false);
         suite->addClock(clockAttr);
 
@@ -170,7 +171,7 @@ BOOST_AUTO_TEST_CASE(test_today_real_time_series) {
         suite_ptr suite                       = theDefs.add_suite("test_today_real_time_series");
         ClockAttr clockAttr(theLocalTime, false);
         suite->addClock(clockAttr);
-        suite->add_variable("SLEEPTIME", boost::lexical_cast<std::string>(TestFixture::job_submission_interval() - 1));
+        suite->add_variable("SLEEPTIME", ecf::convert_to<std::string>(TestFixture::job_submission_interval() - 1));
         suite->addVerify(VerifyAttr(NState::COMPLETE, 1));
 
         family_ptr fam = suite->add_family("family");

--- a/Test/TestTrigger.cpp
+++ b/Test/TestTrigger.cpp
@@ -19,9 +19,9 @@
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "DurationTimer.hpp"
 #include "Family.hpp"
@@ -76,10 +76,9 @@ BOOST_AUTO_TEST_CASE(test_triggers_and_meters) {
 
         int taskSize = 9; // on linux 1024 tasks take ~4 seconds for job submission
         for (int i = 0; i < taskSize; i++) {
-            task_ptr task = fam->add_task("t" + boost::lexical_cast<std::string>(i * 10 + 10));
+            task_ptr task = fam->add_task("t" + ecf::convert_to<std::string>(i * 10 + 10));
             task->addVerify(VerifyAttr(NState::COMPLETE, 1));
-            task->add_trigger(taskName + Str::COLON() + meterName + " ge " +
-                              boost::lexical_cast<std::string>(i * 10 + 10));
+            task->add_trigger(taskName + Str::COLON() + meterName + " ge " + ecf::convert_to<std::string>(i * 10 + 10));
         }
     }
 
@@ -125,7 +124,7 @@ BOOST_AUTO_TEST_CASE(test_triggers_with_limits) {
         fam->addVerify(VerifyAttr(NState::COMPLETE, 1));
         int taskSize = 10;
         for (int i = 0; i < taskSize; i++) {
-            task_ptr task = fam->add_task("t" + boost::lexical_cast<std::string>(i));
+            task_ptr task = fam->add_task("t" + ecf::convert_to<std::string>(i));
             task->addVerify(VerifyAttr(NState::COMPLETE, 1));
         }
 
@@ -133,7 +132,7 @@ BOOST_AUTO_TEST_CASE(test_triggers_with_limits) {
         fam2->addVerify(VerifyAttr(NState::COMPLETE, 1));
         fam2->add_trigger("/test_triggers_with_limits:limit > 1");
         for (int i = 0; i < 3; i++) {
-            task_ptr task = fam2->add_task("t" + boost::lexical_cast<std::string>(i));
+            task_ptr task = fam2->add_task("t" + ecf::convert_to<std::string>(i));
             task->addVerify(VerifyAttr(NState::COMPLETE, 1));
         }
     }

--- a/Test/TestWhyCmd.cpp
+++ b/Test/TestWhyCmd.cpp
@@ -12,16 +12,17 @@
 //
 // Description :
 //============================================================================
+
 #include <iostream>
 
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "AssertTimer.hpp"
 #include "ClientToServerCmd.hpp"
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "DurationTimer.hpp"
 #include "Family.hpp"
@@ -321,7 +322,7 @@ BOOST_AUTO_TEST_CASE(test_why_limit) {
         fam->addInLimit(InLimit("disk", pathToLimit, 50));
         int taskSize = 6;
         for (int i = 0; i < taskSize; i++) {
-            fam->addTask(Task::create("t" + boost::lexical_cast<std::string>(i)));
+            fam->addTask(Task::create("t" + ecf::convert_to<std::string>(i)));
         }
     }
 

--- a/Test/TestZombies.cpp
+++ b/Test/TestZombies.cpp
@@ -13,18 +13,19 @@
 // Description : This is used to INVOKE a SINGLE test.
 //               Making it easier for Easier for debugging and development
 //============================================================================
+
 #include <iostream>
 #include <limits> // for std::numeric_limits<int>::max()
 
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 #define BOOST_TEST_MODULE TEST_ZOMBIES
 #include <boost/test/included/unit_test.hpp>
 
 #include "AssertTimer.hpp"
 #include "Child.hpp"
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "DurationTimer.hpp"
 #include "Family.hpp"
@@ -470,7 +471,7 @@ static void populate_defs(Defs& theDefs, const std::string& suite_name) {
     suite->addVariable(Variable("SLEEPTIME", "5")); // sleep for longer than normal to allow for creation of zombies
     family_ptr family = suite->add_family("f");
     for (int i = 0; i < NUM_OF_TASKS; i++) {
-        family->add_task("t" + boost::lexical_cast<std::string>(i));
+        family->add_task("t" + ecf::convert_to<std::string>(i));
     }
     suite->add_variable("CHECK_TASK_DURATION_LESS_THAN_SERVER_POLL", "_any_");
 }

--- a/Test/Test_Time.cpp
+++ b/Test/Test_Time.cpp
@@ -22,6 +22,7 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "DurationTimer.hpp"
 #include "Family.hpp"
@@ -237,7 +238,7 @@ BOOST_AUTO_TEST_CASE(test_time_relative_time_series) {
         suite_ptr suite = theDefs.add_suite("test_time_relative_time_series");
         ClockAttr clockAttr(Calendar::second_clock_time(), false);
         suite->addClock(clockAttr);
-        suite->add_variable("SLEEPTIME", boost::lexical_cast<std::string>(TestFixture::job_submission_interval() - 2));
+        suite->add_variable("SLEEPTIME", ecf::convert_to<std::string>(TestFixture::job_submission_interval() - 2));
 
         family_ptr fam = suite->add_family("family");
         task_ptr task  = fam->add_task("t");
@@ -339,7 +340,7 @@ BOOST_AUTO_TEST_CASE(test_single_real_time_near_midnight) {
         suite_ptr suite                      = theDefs.add_suite("test_single_real_time_near_midnight");
         ClockAttr clockAttr(clock_start, false);
         suite->addClock(clockAttr);
-        suite->add_variable("SLEEPTIME", boost::lexical_cast<string>(TestFixture::job_submission_interval() * 2));
+        suite->add_variable("SLEEPTIME", ecf::convert_to<std::string>(TestFixture::job_submission_interval() * 2));
 
         family_ptr fam = suite->add_family("family");
         task_ptr task  = fam->add_task("t");
@@ -401,7 +402,7 @@ BOOST_AUTO_TEST_CASE(test_time_real_series_near_midnight) {
         boost::posix_time::ptime clock_start = first_time - minutes(1);
 
         suite_ptr suite                      = theDefs.add_suite("test_time_real_series_near_midnight");
-        suite->add_variable("SLEEPTIME", boost::lexical_cast<string>(TestFixture::job_submission_interval() * 2));
+        suite->add_variable("SLEEPTIME", ecf::convert_to<std::string>(TestFixture::job_submission_interval() * 2));
 
         ClockAttr clockAttr(clock_start, false);
         suite->addClock(clockAttr);

--- a/Test/src/ServerTestHarness.cpp
+++ b/Test/src/ServerTestHarness.cpp
@@ -21,6 +21,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "AssertTimer.hpp"
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "DurationTimer.hpp"
 #include "Ecf.hpp"
@@ -326,7 +327,7 @@ defs_ptr ServerTestHarness::testWaiter(const Defs& theClientDefs, int timeout, b
 #ifdef DEBUG_DIFF
             {
                 counter++;
-                std::string filename = dump_defs_filename + boost::lexical_cast<std::string>(counter);
+                std::string filename = dump_defs_filename + ecf::convert_to<std::string>(counter);
                 std::ofstream theFile(filename.c_str());
 
                 std::vector<Task*> tasks;
@@ -524,7 +525,7 @@ std::string ServerTestHarness::getDefaultTemplateEcfFile(Task* t) const {
         int delta = abs(max - min) / 10;
         for (int i = min + delta; i <= max; i = i + delta) {
             templateEcfFile += " ";
-            templateEcfFile += boost::lexical_cast<std::string>(i);
+            templateEcfFile += ecf::convert_to<std::string>(i);
         }
         templateEcfFile += "\n";
         templateEcfFile += "do\n";

--- a/Test/src/TestFixture.cpp
+++ b/Test/src/TestFixture.cpp
@@ -21,7 +21,6 @@
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include "ClientEnvironment.hpp" // needed for static ClientEnvironment::hostSpecified(); ONLY
 #include "CtsApi.hpp"
@@ -185,7 +184,7 @@ void TestFixture::init(const std::string& project_test_dir) {
         // Note: linux64 and linux64intel, can run on same machine, on different workspace
         // Hence the lock file is not sufficient. Hence we will make a client server call.
         cout << "Find free port to start server, starting with port " << port_ << "\n";
-        auto the_port = boost::lexical_cast<int>(port_);
+        auto the_port = ecf::convert_to<int>(port_);
         while (!EcfPortLock::is_free(the_port))
             the_port++;
         port_ = ClientInvoker::find_free_port(the_port, true /*show debug output */);
@@ -202,7 +201,7 @@ void TestFixture::init(const std::string& project_test_dir) {
         std::string theServerInvokePath = File::find_ecf_server_path();
         assert(!theServerInvokePath.empty());
         theServerInvokePath += " --port=" + port_;
-        theServerInvokePath += " --ecfinterval=" + boost::lexical_cast<std::string>(job_submission_interval());
+        theServerInvokePath += " --ecfinterval=" + ecf::convert_to<std::string>(job_submission_interval());
         theServerInvokePath += "&";
         if (system(theServerInvokePath.c_str()) != 0)
             assert(false); // " Server invoke failed "
@@ -442,6 +441,6 @@ int TestFixture::server_version() {
     // Could 4.0.8rc1
     Str::replace_all(the_server_version_str, "rc1", "");
     Str::replace_all(the_server_version_str, "rc2", "");
-    auto the_server_version = boost::lexical_cast<int>(the_server_version_str);
+    auto the_server_version = ecf::convert_to<int>(the_server_version_str);
     return the_server_version;
 }

--- a/Udp/src/RequestHandler.cpp
+++ b/Udp/src/RequestHandler.cpp
@@ -13,10 +13,10 @@
 #include <string>
 #include <vector>
 
-#include <boost/lexical_cast.hpp>
 #include <nlohmann/json.hpp>
 
 #include "ClientAPI.hpp"
+#include "Converter.hpp"
 #include "Trace.hpp"
 
 namespace ecf {
@@ -205,7 +205,7 @@ public:
         std::string path  = obj.at("path");
         std::string value = obj.at("value");
 
-        auto meter_value  = boost::lexical_cast<int>(value);
+        auto meter_value  = ecf::convert_to<int>(value);
 
         return Command::make_command<CommandUserAlterMeter>(path, name, meter_value);
     }
@@ -265,7 +265,7 @@ public:
         std::string path  = obj.at("path");
         std::string value = obj.at("value");
 
-        auto meter_value  = boost::lexical_cast<int>(value);
+        auto meter_value  = ecf::convert_to<int>(value);
 
         TRACE_NFO("CommandChildUpdateLabelBuilder", "update to meter ", path, ":", name, " to value: ", meter_value);
 

--- a/Udp/src/UDPServerEnvironment.hpp
+++ b/Udp/src/UDPServerEnvironment.hpp
@@ -15,8 +15,9 @@
 #include <string>
 #include <vector>
 
-#include <boost/lexical_cast.hpp>
 #include <unordered_map>
+
+#include "Converter.hpp"
 
 namespace ecf {
 
@@ -40,7 +41,7 @@ public:
     std::optional<U> get_variable(const std::string& key) const {
         auto found = environment_.find(key);
         if (found != std::end(environment_)) {
-            return boost::lexical_cast<U>(found->second);
+            return ecf::convert_to<U>(found->second);
         }
         return {};
     }

--- a/Viewer/ecflowUI/src/Dashboard.cpp
+++ b/Viewer/ecflowUI/src/Dashboard.cpp
@@ -17,6 +17,7 @@
 #include <QToolButton>
 #include <QVBoxLayout>
 
+#include "Converter.hpp"
 #include "DashboardDialog.hpp"
 #include "DashboardDock.hpp"
 #include "DashboardTitle.hpp"
@@ -558,7 +559,7 @@ QString Dashboard::uniqueDockId() {
 }
 
 std::string Dashboard::widgetSettingsId(int i) {
-    return "widget_" + boost::lexical_cast<std::string>(i);
+    return "widget_" + ecf::convert_to<std::string>(i);
 }
 
 void Dashboard::notifyServerFilterAdded(ServerItem* /*item*/) {

--- a/Viewer/ecflowUI/src/MainWindow.cpp
+++ b/Viewer/ecflowUI/src/MainWindow.cpp
@@ -22,7 +22,6 @@
 #include <QSplitter>
 #include <QToolBar>
 #include <QVBoxLayout>
-#include <boost/lexical_cast.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 #include "AboutDialog.hpp"
@@ -31,6 +30,7 @@
 #include "ClockWidget.hpp"
 #include "CommandOutputDialog.hpp"
 #include "ConnectState.hpp"
+#include "Converter.hpp"
 #include "FilterWidget.hpp"
 #include "InfoPanel.hpp"
 #include "InfoPanelHandler.hpp"
@@ -666,7 +666,7 @@ void MainWindow::init() {
     std::string winPattern("window_");
     for (int i = 0; i < cnt; i++) {
         if (i != topWinId) {
-            std::string id = winPattern + boost::lexical_cast<std::string>(i);
+            std::string id = winPattern + ecf::convert_to<std::string>(i);
             if (vs.contains(id)) {
                 vs.beginGroup(id);
                 MainWindow::makeWindow(&vs);
@@ -677,7 +677,7 @@ void MainWindow::init() {
 
     // Create the topwindow
     if (topWinId != -1) {
-        std::string id = winPattern + boost::lexical_cast<std::string>(topWinId);
+        std::string id = winPattern + ecf::convert_to<std::string>(topWinId);
         if (vs.contains(id)) {
             vs.beginGroup(id);
             MainWindow::makeWindow(&vs);
@@ -722,7 +722,7 @@ void MainWindow::saveContents(MainWindow* topWin) {
 
     // Save info for all the windows
     for (int i = 0; i < windows_.count(); i++) {
-        std::string id = "window_" + boost::lexical_cast<std::string>(i);
+        std::string id = "window_" + ecf::convert_to<std::string>(i);
         vs.beginGroup(id);
         windows_.at(i)->writeSettings(&vs);
         vs.endGroup();

--- a/Viewer/ecflowUI/src/NodePanel.cpp
+++ b/Viewer/ecflowUI/src/NodePanel.cpp
@@ -12,6 +12,7 @@
 #include <QDebug>
 #include <QResizeEvent>
 
+#include "Converter.hpp"
 #include "Dashboard.hpp"
 #include "DashboardTitle.hpp"
 #include "InfoPanel.hpp"
@@ -317,7 +318,7 @@ void NodePanel::writeSettings(VComboSettings* vs) {
             vs->beginGroup(id);
             nw->writeSettings(vs);
             vs->endGroup();
-            // pt.add_child("tab_"+ boost::lexical_cast<std::string>(i),ptTab);
+            // pt.add_child("tab_"+   ecf::convert_to<std::string>(i),ptTab);
         }
     }
 }
@@ -362,5 +363,5 @@ void NodePanel::readSettings(VComboSettings* vs) {
 }
 
 std::string NodePanel::tabSettingsId(int i) {
-    return "tab_" + boost::lexical_cast<std::string>(i);
+    return "tab_" + ecf::convert_to<std::string>(i);
 }

--- a/Viewer/ecflowUI/src/ServerComThread.cpp
+++ b/Viewer/ecflowUI/src/ServerComThread.cpp
@@ -13,6 +13,7 @@
 
 #include "ClientInvoker.hpp"
 #include "CommandLine.hpp"
+#include "Converter.hpp"
 #include "Defs.hpp"
 #include "ServerComQueue.hpp"
 #include "ServerDefsAccess.hpp"
@@ -235,7 +236,7 @@ void ServerComThread::run() {
                     if (maxLineNum_ < 0)
                         ci_->file(nodePath_, params_["clientPar"]);
                     else
-                        ci_->file(nodePath_, params_["clientPar"], boost::lexical_cast<std::string>(maxLineNum_));
+                        ci_->file(nodePath_, params_["clientPar"], ecf::convert_to<std::string>(maxLineNum_));
 
                     break;
                 }

--- a/Viewer/ecflowUI/src/ServerHandler.cpp
+++ b/Viewer/ecflowUI/src/ServerHandler.cpp
@@ -18,7 +18,6 @@
 #include <QMetaType>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/asio/ip/host_name.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include "ChangeNotify.hpp"
 #include "ClientInvoker.hpp"
@@ -817,7 +816,7 @@ void ServerHandler::slotNodeChanged(const Node* nc, std::vector<ecf::Aspect::Typ
     UiLogS(this).dbg() << "ServerHandler::slotNodeChanged - node: " + nc->name();
 
     // for(std::vector<ecf::Aspect::Type>::const_iterator it=aspect.begin(); it != aspect.end(); ++it)
-    // UserMessage::message(UserMessage::DBG, false, std::string(" aspect: ") + boost::lexical_cast<std::string>(*it));
+    //     UserMessage::message(UserMessage::DBG, false, std::string(" aspect: ") + ecf::convert_to<std::string>(*it));
 
     // This can happen if we initiated a reset while we sync in the thread
     if (vRoot_->isEmpty()) {
@@ -900,7 +899,7 @@ void ServerHandler::broadcast(NoMethodV1 proc,
 void ServerHandler::slotDefsChanged(std::vector<ecf::Aspect::Type> aspect) {
     UiLog().dbg() << "ServerHandler::slotDefsChanged -->";
     // for(std::vector<ecf::Aspect::Type>::const_iterator it=aspect.begin(); it != aspect.end(); ++it)
-    //	UserMessage::message(UserMessage::DBG, false, std::string(" aspect: ") + boost::lexical_cast<std::string>(*it));
+    //     UserMessage::message(UserMessage::DBG, false, std::string(" aspect: ") + ecf::convert_to<std::string>(*it));
 
     // Begin update for the VNode
     // VNodeChange change;

--- a/Viewer/ecflowUI/src/ServerList.cpp
+++ b/Viewer/ecflowUI/src/ServerList.cpp
@@ -20,8 +20,8 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/lexical_cast.hpp>
 
+#include "Converter.hpp"
 #include "DirectoryHandler.hpp"
 #include "MainWindow.hpp"
 #include "ServerItem.hpp"
@@ -494,9 +494,9 @@ bool ServerList::checkItemToAdd(const std::string& name,
     }
 
     try {
-        boost::lexical_cast<int>(port);
+        ecf::convert_to<int>(port);
     }
-    catch (boost::bad_lexical_cast& e) {
+    catch (const ecf::bad_conversion&) {
         errStr = "Invalid port number: " + port;
         return false;
     }

--- a/Viewer/ecflowUI/src/Sound.cpp
+++ b/Viewer/ecflowUI/src/Sound.cpp
@@ -13,6 +13,7 @@
 #include <cassert>
 #include <cstdlib>
 
+#include "Converter.hpp"
 #include "DirectoryHandler.hpp"
 #include "UiLog.hpp"
 #include "VConfig.hpp"
@@ -26,7 +27,6 @@
 #include <regex>
 
 #include <boost/algorithm/string/replace.hpp>
-#include <boost/lexical_cast.hpp>
 
 Sound* Sound::instance_ = nullptr;
 
@@ -80,7 +80,7 @@ void Sound::play(const std::string& fName, int loopCount) {
     else {
         std::string cmd = currentCmd_;
         boost::replace_first(cmd, "%FILE%", fName);
-        boost::replace_first(cmd, "%REPEAT%", boost::lexical_cast<std::string>(loopCount - 1));
+        boost::replace_first(cmd, "%REPEAT%", ecf::convert_to<std::string>(loopCount - 1));
         if (system(cmd.c_str())) {
             UiLog().dbg() << "Sound::play() could not play sound alert. Command: " << cmd;
         }

--- a/Viewer/ecflowUI/src/VFile.cpp
+++ b/Viewer/ecflowUI/src/VFile.cpp
@@ -16,10 +16,10 @@
 #include <iostream>
 #include <unistd.h>
 
-#include <boost/lexical_cast.hpp>
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include "Converter.hpp"
 #include "DirectoryHandler.hpp"
 #include "UiLog.hpp"
 
@@ -329,7 +329,7 @@ int VFile::numberOfLines() const {
 void VFile::print() {
     std::string str = " VFile storage=" + std::to_string(storageMode_) + " ";
     if (storageMode_ == MemoryStorage) {
-        str += "memory size:" + boost::lexical_cast<std::string>(dataSize_);
+        str += "memory size:" + ecf::convert_to<std::string>(dataSize_);
     }
     else {
         str += "disk path: " + path_;

--- a/Viewer/ecflowUI/src/VInfo.cpp
+++ b/Viewer/ecflowUI/src/VInfo.cpp
@@ -10,8 +10,6 @@
 
 #include "VInfo.hpp"
 
-#include <boost/lexical_cast.hpp>
-
 #include "ServerHandler.hpp"
 #include "UiLog.hpp"
 #include "VAttribute.hpp"

--- a/Viewer/ecflowUI/src/VNode.cpp
+++ b/Viewer/ecflowUI/src/VNode.cpp
@@ -14,6 +14,7 @@
 
 #include "AstCollateVNodesVisitor.hpp"
 #include "ConnectState.hpp"
+#include "Converter.hpp"
 #include "Expression.hpp"
 #include "Limit.hpp"
 #include "ServerDefsAccess.hpp"
@@ -450,7 +451,7 @@ int VNode::tryNo() const {
     if (v.empty())
         return 0;
 
-    return boost::lexical_cast<int>(v);
+    return ecf::convert_to<int>(v);
 }
 
 VNode* VNode::find(const std::vector<std::string>& pathVec) {


### PR DESCRIPTION
These changes create a thin layer wrapper for conversions between basic types (e.g. std::string, int), allowing to encapsulate all uses of boost::lexical_cast.