### PR TITLE
Correct default status log optimization ECFLOW-1914

### DIFF
--- a/ANode/src/Node.hpp
+++ b/ANode/src/Node.hpp
@@ -187,12 +187,12 @@ public:
               reset_next_time_slot_(reset_next_time_slot),
               reset_relative_duration_(reset_relative_duration),
               log_state_changes_(log_state_changes) {}
-        Requeue_t requeue_t{FULL};
+        const Requeue_t requeue_t{FULL};
         int clear_suspended_in_child_nodes_{0};
-        bool resetRepeats_{true};
-        bool reset_next_time_slot_{true};
-        bool reset_relative_duration_{true};
-        bool log_state_changes_{true};
+        const bool resetRepeats_{true};
+        const bool reset_next_time_slot_{true};
+        const bool reset_relative_duration_{true};
+        const bool log_state_changes_{true};
     };
     virtual void requeue(Requeue_args&);
 

--- a/Base/src/AbstractServer.hpp
+++ b/Base/src/AbstractServer.hpp
@@ -178,7 +178,7 @@ public:
 
     // Instead of immediate node tree traversal at the end of child command
     // we use 'increment_job_generation_count' to defer job generation to server
-    // The server will will check job generation count at poll time.
+    // The server will check job generation count at poll time.
     // This approach radically reduces the number of times we traverse the node tree
     // and hence improves server throughput.
     void increment_job_generation_count() { job_gen_count_++; }


### PR DESCRIPTION
These changes correct the optimisation/inhibition of unnecessarily logging the node state change, applicable to the descendants of a node with default status COMPLETE.

Without these changes, the controlling flag was update+used and, because it was passed as reference, later incorrectly applied to siblings nodes.

To avoid similar issues in the future, all Requeue_args data members not currently updated in the scope of handling requeue are made constant.