### PR TITLE
allow empty logfile

### DIFF
--- a/tools/ecflow_logsvr.pl
+++ b/tools/ecflow_logsvr.pl
@@ -147,7 +147,7 @@ sub do_get {
 	{
 		syswrite($client,$buf,$size);
 	}
-
+        syswrite($client,"end of output");
 	close(IN);
 }
 

--- a/tools/ecflow_logsvr.pl
+++ b/tools/ecflow_logsvr.pl
@@ -147,7 +147,7 @@ sub do_get {
 	{
 		syswrite($client,$buf,$size);
 	}
-        syswrite($client,"end of output");
+        syswrite($client,"/n");
 	close(IN);
 }
 


### PR DESCRIPTION
with the previous code, if a logfile is empty the clients complains with     
`Failed to fetch file from logserver [server name]@[port] Error: The remote host closed the connection`  
the added syswrite makes the client happy