### PR TITLE
General improvement of tests

### DIFF
--- a/libs/attribute/test/TestAttrSerialization.cpp
+++ b/libs/attribute/test/TestAttrSerialization.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "TestSerialisation.hpp"
 #include "ecflow/attribute/AutoArchiveAttr.hpp"
 #include "ecflow/attribute/AutoCancelAttr.hpp"
@@ -42,7 +43,7 @@ BOOST_AUTO_TEST_SUITE(U_Attributes)
 BOOST_AUTO_TEST_SUITE(T_AttrSerialization)
 
 BOOST_AUTO_TEST_CASE(test_AttrDefaultConstructor_serialisation) {
-    cout << "ANattr:: ...test_AttrDefaultConstructor_serialisation \n";
+    ECF_NAME_THIS_TEST();
 
     doSaveAndRestore<VerifyAttr>(fileName);
     doSaveAndRestore<TodayAttr>(fileName);
@@ -69,13 +70,15 @@ BOOST_AUTO_TEST_CASE(test_AttrDefaultConstructor_serialisation) {
 }
 
 BOOST_AUTO_TEST_CASE(test_VerifyAttr_serialisation) {
-    cout << "ANattr:: ...test_VerifyAttr_serialisation \n";
+    ECF_NAME_THIS_TEST();
+
     VerifyAttr saved(NState::COMPLETE, 10);
     doSaveAndRestore(fileName, saved);
 }
 
 BOOST_AUTO_TEST_CASE(test_TodayAttr_serialisation) {
-    cout << "ANattr:: ...test_TodayAttr_serialisation \n";
+    ECF_NAME_THIS_TEST();
+
     {
         TodayAttr saved(TimeSlot(10, 12));
         doSaveAndRestore(fileName, saved);
@@ -95,7 +98,8 @@ BOOST_AUTO_TEST_CASE(test_TodayAttr_serialisation) {
 }
 
 BOOST_AUTO_TEST_CASE(test_TimeAttr_serialisation) {
-    cout << "ANattr:: ...test_TimeAttr_serialisation \n";
+    ECF_NAME_THIS_TEST();
+
     {
         TimeAttr saved(TimeSlot(10, 12));
         doSaveAndRestore(fileName, saved);
@@ -111,7 +115,8 @@ BOOST_AUTO_TEST_CASE(test_TimeAttr_serialisation) {
 }
 
 BOOST_AUTO_TEST_CASE(test_RepeatAttr_serialisation) {
-    cout << "ANattr:: ...test_RepeatAttr_serialisation \n";
+    ECF_NAME_THIS_TEST();
+
     {
         RepeatDate saved("varname", 20101210, 20101230, 3);
         doSaveAndRestore(fileName, saved);
@@ -166,7 +171,8 @@ BOOST_AUTO_TEST_CASE(test_RepeatAttr_serialisation) {
 }
 
 BOOST_AUTO_TEST_CASE(test_LateAttr_serialisation) {
-    cout << "ANattr:: ...test_LateAttr_serialisation \n";
+    ECF_NAME_THIS_TEST();
+
     LateAttr saved;
     saved.addSubmitted(TimeSlot(10, 12));
     saved.addActive(TimeSlot(10, 12));
@@ -175,7 +181,8 @@ BOOST_AUTO_TEST_CASE(test_LateAttr_serialisation) {
 }
 
 BOOST_AUTO_TEST_CASE(test_DayAttr_serialisation) {
-    cout << "ANattr:: ...test_DayAttr_serialisation\n";
+    ECF_NAME_THIS_TEST();
+
     std::vector<DayAttr::Day_t> dvec;
     dvec.push_back(DayAttr::SUNDAY);
     dvec.push_back(DayAttr::MONDAY);
@@ -191,13 +198,15 @@ BOOST_AUTO_TEST_CASE(test_DayAttr_serialisation) {
 }
 
 BOOST_AUTO_TEST_CASE(test_DateAttr_serialisation) {
-    cout << "ANattr:: ...test_DateAttr_serialisation\n";
+    ECF_NAME_THIS_TEST();
+
     DateAttr saved(1, 1, 2010);
     doSaveAndRestore(fileName, saved);
 }
 
 BOOST_AUTO_TEST_CASE(test_CronAttr_serialisation) {
-    cout << "ANattr:: ...test_CronAttr_serialisation\n";
+    ECF_NAME_THIS_TEST();
+
     CronAttr saved;
     std::vector<int> weekDays;
     weekDays.push_back(1);
@@ -217,7 +226,8 @@ BOOST_AUTO_TEST_CASE(test_CronAttr_serialisation) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ClockAttr_serialisation) {
-    cout << "ANattr:: ...test_ClockAttr_serialisation\n";
+    ECF_NAME_THIS_TEST();
+
     {
         ClockAttr saved(false);
         saved.date(1, 1, 2009);
@@ -232,7 +242,8 @@ BOOST_AUTO_TEST_CASE(test_ClockAttr_serialisation) {
 }
 
 BOOST_AUTO_TEST_CASE(test_AutoCancelAttr_serialisation) {
-    cout << "ANattr:: ...test_AutoCancelAttr_serialisation\n";
+    ECF_NAME_THIS_TEST();
+
     {
         AutoCancelAttr saved(100);
         doSaveAndRestore(fileName, saved);
@@ -244,7 +255,8 @@ BOOST_AUTO_TEST_CASE(test_AutoCancelAttr_serialisation) {
 }
 
 BOOST_AUTO_TEST_CASE(test_AutoArchiveAttr_serialisation) {
-    cout << "ANattr:: ...test_AutoArchiveAttr_serialisation\n";
+    ECF_NAME_THIS_TEST();
+
     {
         AutoArchiveAttr saved(100);
         doSaveAndRestore(fileName, saved);
@@ -264,7 +276,8 @@ BOOST_AUTO_TEST_CASE(test_AutoArchiveAttr_serialisation) {
 }
 
 BOOST_AUTO_TEST_CASE(test_Label_serialisation) {
-    cout << "ANattr:: ...test_Label_serialisation\n";
+    ECF_NAME_THIS_TEST();
+
     {
         Label saved("labelName", "some text");
         doSaveAndRestore(fileName, saved);
@@ -272,13 +285,15 @@ BOOST_AUTO_TEST_CASE(test_Label_serialisation) {
 }
 
 BOOST_AUTO_TEST_CASE(test_Variable_serialisation) {
-    cout << "ANattr:: ...test_Variable_serialisation\n";
+    ECF_NAME_THIS_TEST();
+
     Variable saved("varname", "var value 123 12 =");
     doSaveAndRestore(fileName, saved);
 }
 
 BOOST_AUTO_TEST_CASE(test_Event_serialisation) {
-    cout << "ANattr:: ...test_Event_serialisation\n";
+    ECF_NAME_THIS_TEST();
+
     {
         Event saved(3);
         doSaveAndRestore(fileName, saved);
@@ -298,13 +313,15 @@ BOOST_AUTO_TEST_CASE(test_Event_serialisation) {
 }
 
 BOOST_AUTO_TEST_CASE(test_Meter_serialisation) {
-    cout << "ANattr:: ...test_Meter_serialisation\n";
+    ECF_NAME_THIS_TEST();
+
     Meter saved("meter", 0, 20, 20);
     doSaveAndRestore(fileName, saved);
 }
 
 BOOST_AUTO_TEST_CASE(test_queue_serialisation) {
-    cout << "ANattr:: ...test_queue_serialisation\n";
+    ECF_NAME_THIS_TEST();
+
     std::vector<std::string> queue_items;
     queue_items.emplace_back("a");
     queue_items.emplace_back("b");
@@ -313,7 +330,8 @@ BOOST_AUTO_TEST_CASE(test_queue_serialisation) {
 }
 
 BOOST_AUTO_TEST_CASE(test_generic_serialisation) {
-    cout << "ANattr:: ...test_generic_serialisation\n";
+    ECF_NAME_THIS_TEST();
+
     std::vector<std::string> queue_items;
     queue_items.emplace_back("a");
     queue_items.emplace_back("b");
@@ -322,7 +340,7 @@ BOOST_AUTO_TEST_CASE(test_generic_serialisation) {
 }
 
 BOOST_AUTO_TEST_CASE(test_zombie_attr_serialisation) {
-    cout << "ANattr:: ...test_zombie_attr_serialisation\n";
+    ECF_NAME_THIS_TEST();
 
     std::vector<ecf::Child::CmdType> child_cmds = ecf::Child::list();
 

--- a/libs/attribute/test/TestCron.cpp
+++ b/libs/attribute/test/TestCron.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/attribute/CronAttr.hpp"
 #include "ecflow/core/Calendar.hpp"
 #include "ecflow/core/Str.hpp"
@@ -28,7 +29,8 @@ BOOST_AUTO_TEST_SUITE(U_Attributes)
 BOOST_AUTO_TEST_SUITE(T_Cron)
 
 BOOST_AUTO_TEST_CASE(test_cron_parsing) {
-    cout << "ANattr:: ...test_cron_parsing\n";
+    ECF_NAME_THIS_TEST();
+
     TimeSlot start(10, 10);
     TimeSlot finish(23, 10);
     TimeSlot incr(0, 1);
@@ -214,7 +216,7 @@ BOOST_AUTO_TEST_CASE(test_cron_parsing) {
 }
 
 BOOST_AUTO_TEST_CASE(test_cron_state_parsing) {
-    cout << "ANattr:: ...test_cron_state_parsing\n";
+    ECF_NAME_THIS_TEST();
 
     size_t index = 1; // to get over the cron
     {
@@ -338,7 +340,7 @@ BOOST_AUTO_TEST_CASE(test_cron_state_parsing) {
 }
 
 BOOST_AUTO_TEST_CASE(test_cron_once_free_stays_free) {
-    cout << "ANattr:: ...test_cron_once_free_stays_free\n";
+    ECF_NAME_THIS_TEST();
 
     Calendar calendar;
     calendar.init(ptime(date(2010, 2, 10), minutes(0)), Calendar::REAL);
@@ -460,7 +462,7 @@ BOOST_AUTO_TEST_CASE(test_cron_once_free_stays_free) {
 }
 
 BOOST_AUTO_TEST_CASE(test_cron_time_series) {
-    cout << "ANattr:: ...test_cron_time_series\n";
+    ECF_NAME_THIS_TEST();
 
     // See TimeAttr.hpp for rules concerning isFree() and checkForReque()
     // test time attr isFree(), and checkForRequeue

--- a/libs/attribute/test/TestCron.cpp
+++ b/libs/attribute/test/TestCron.cpp
@@ -377,7 +377,6 @@ BOOST_AUTO_TEST_CASE(test_cron_once_free_stays_free) {
             day_changed = calendar.dayChanged();
         }
         boost::posix_time::time_duration time = calendar.suiteTime().time_of_day();
-        // cout << time << " day_changed(" << day_changed << ")\n";
 
         timeSeries.calendarChanged(calendar);
         timeSeries2.calendarChanged(calendar);
@@ -501,7 +500,6 @@ BOOST_AUTO_TEST_CASE(test_cron_time_series) {
             day_changed = calendar.dayChanged();
         }
         boost::posix_time::time_duration time = calendar.suiteTime().time_of_day();
-        //      cout << time << " day_changed(" << day_changed << ")\n";
 
         timeSeries.calendarChanged(calendar);
         timeSeries2.calendarChanged(calendar);

--- a/libs/attribute/test/TestDateAttr.cpp
+++ b/libs/attribute/test/TestDateAttr.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/attribute/DateAttr.hpp"
 #include "ecflow/core/PrintStyle.hpp"
 #include "ecflow/core/Str.hpp"
@@ -27,7 +28,8 @@ BOOST_AUTO_TEST_SUITE(U_Attributes)
 BOOST_AUTO_TEST_SUITE(T_DateAttr)
 
 BOOST_AUTO_TEST_CASE(test_date) {
-    cout << "ANattr:: ...test_date\n";
+    ECF_NAME_THIS_TEST();
+
     {
         DateAttr empty;
         DateAttr empty2;
@@ -79,8 +81,8 @@ static DateAttr print_and_parse_attr(DateAttr& date) {
 }
 
 BOOST_AUTO_TEST_CASE(test_date_parsing) {
+    ECF_NAME_THIS_TEST();
 
-    cout << "ANattr:: ...test_date_parsing\n";
     {
         DateAttr date("12.12.2019");
         date.setFree();
@@ -107,7 +109,8 @@ BOOST_AUTO_TEST_CASE(test_date_parsing) {
 }
 
 BOOST_AUTO_TEST_CASE(test_date_errors) {
-    cout << "ANattr:: ...test_date_errors\n";
+    ECF_NAME_THIS_TEST();
+
     {
         BOOST_REQUIRE_THROW(DateAttr("-1.2.*"), std::runtime_error);
         BOOST_REQUIRE_THROW(DateAttr("32.2.*"), std::runtime_error);

--- a/libs/attribute/test/TestDayAttr.cpp
+++ b/libs/attribute/test/TestDayAttr.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/attribute/DayAttr.hpp"
 #include "ecflow/core/Calendar.hpp"
 #include "ecflow/core/PrintStyle.hpp"
@@ -28,7 +29,7 @@ BOOST_AUTO_TEST_SUITE(U_Attributes)
 BOOST_AUTO_TEST_SUITE(T_DayAttr)
 
 BOOST_AUTO_TEST_CASE(test_day_attr) {
-    cout << "ANattr:: ...test_day_attr\n";
+    ECF_NAME_THIS_TEST();
 
     // See TimeAttr.hpp for rules concerning isFree() and checkForReque()
     // test time attr isFree(), and checkForRequeue
@@ -78,7 +79,8 @@ BOOST_AUTO_TEST_CASE(test_day_attr) {
 }
 
 BOOST_AUTO_TEST_CASE(test_day_attr_constructor) {
-    cout << "ANattr:: ...test_day_attr_constructor \n";
+    ECF_NAME_THIS_TEST();
+
     {
         DayAttr day;
         BOOST_CHECK_MESSAGE(day.day() == DayAttr::SUNDAY, "");
@@ -113,8 +115,8 @@ static DayAttr print_and_parse_attr(DayAttr& day) {
 }
 
 BOOST_AUTO_TEST_CASE(test_day_parsing) {
+    ECF_NAME_THIS_TEST();
 
-    cout << "ANattr:: ...test_day_parsing\n";
     {
         DayAttr day(DayAttr::WEDNESDAY);
         day.setFree();

--- a/libs/attribute/test/TestDayAttr.cpp
+++ b/libs/attribute/test/TestDayAttr.cpp
@@ -51,8 +51,6 @@ BOOST_AUTO_TEST_CASE(test_day_attr) {
         // if (calendar.dayChanged())
         //     day_changed++;
 
-        // cout << " day_changed(" << day_changed << ") calendar.day_of_week() = " <<  calendar.day_of_week() << "\n";
-
         day.calendarChanged(calendar);
 
         if (day.date() < calendar.date()) {

--- a/libs/attribute/test/TestLabel.cpp
+++ b/libs/attribute/test/TestLabel.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/attribute/NodeAttr.hpp"
 #include "ecflow/core/Str.hpp"
 
@@ -24,7 +25,8 @@ BOOST_AUTO_TEST_SUITE(U_Attributes)
 BOOST_AUTO_TEST_SUITE(T_Label)
 
 BOOST_AUTO_TEST_CASE(test_label_parsing) {
-    cout << "ANattr:: ...test_label_parsing\n";
+    ECF_NAME_THIS_TEST();
+
     {
         std::string line = "label name \"value\"";
         std::vector<string> linetokens;

--- a/libs/attribute/test/TestLateAttr.cpp
+++ b/libs/attribute/test/TestLateAttr.cpp
@@ -15,6 +15,7 @@
 #include <boost/date_time/posix_time/time_formatters.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/attribute/LateAttr.hpp"
 #include "ecflow/core/Calendar.hpp"
 #include "ecflow/core/NState.hpp"
@@ -29,7 +30,7 @@ BOOST_AUTO_TEST_SUITE(U_Attributes)
 BOOST_AUTO_TEST_SUITE(T_LateAttr)
 
 BOOST_AUTO_TEST_CASE(test_late_attr_submitted) {
-    cout << "ANattr:: ...test_late_attr_submitted\n";
+    ECF_NAME_THIS_TEST();
 
     // REF: ECFLOW-322
     Calendar calendar;
@@ -75,7 +76,7 @@ BOOST_AUTO_TEST_CASE(test_late_attr_submitted) {
 }
 
 BOOST_AUTO_TEST_CASE(test_late_attr_active) {
-    cout << "ANattr:: ...test_late_attr_active\n";
+    ECF_NAME_THIS_TEST();
 
     Calendar calendar;
     calendar.init(ptime(date(2013, 7, 9), minutes(0)), Calendar::REAL); // tuesday
@@ -115,7 +116,7 @@ BOOST_AUTO_TEST_CASE(test_late_attr_active) {
 }
 
 BOOST_AUTO_TEST_CASE(test_late_attr_complete_relative) {
-    cout << "ANattr:: ...test_late_attr_complete_relative\n";
+    ECF_NAME_THIS_TEST();
 
     Calendar calendar;
     calendar.init(ptime(date(2013, 7, 9), minutes(0)), Calendar::REAL); // tuesday
@@ -155,7 +156,7 @@ BOOST_AUTO_TEST_CASE(test_late_attr_complete_relative) {
 }
 
 BOOST_AUTO_TEST_CASE(test_late_attr_complete_real) {
-    cout << "ANattr:: ...test_late_attr_complete_real\n";
+    ECF_NAME_THIS_TEST();
 
     Calendar calendar;
     calendar.init(ptime(date(2013, 7, 9), minutes(0)), Calendar::REAL); // tuesday
@@ -196,7 +197,8 @@ BOOST_AUTO_TEST_CASE(test_late_attr_complete_real) {
 }
 
 BOOST_AUTO_TEST_CASE(test_late_parsing) {
-    cout << "ANattr:: ...test_late_parsing\n";
+    ECF_NAME_THIS_TEST();
+
     TimeSlot start(10, 10);
     TimeSlot finish(23, 10);
     {
@@ -282,7 +284,8 @@ BOOST_AUTO_TEST_CASE(test_late_parsing) {
 }
 
 BOOST_AUTO_TEST_CASE(test_late_parsing_errors) {
-    cout << "ANattr:: ...test_late_parsing_errors\n";
+    ECF_NAME_THIS_TEST();
+
     BOOST_REQUIRE_THROW((void)LateAttr::create(""), std::runtime_error);
     BOOST_REQUIRE_THROW((void)LateAttr::create("late"), std::runtime_error);
     BOOST_REQUIRE_THROW((void)LateAttr::create("late 10:10"), std::runtime_error);

--- a/libs/attribute/test/TestLateAttr.cpp
+++ b/libs/attribute/test/TestLateAttr.cpp
@@ -54,19 +54,14 @@ BOOST_AUTO_TEST_CASE(test_late_attr_submitted) {
     calendar.update(time_duration(minutes(1)));
 
     // set submitted state at 00:05:00
-    // cout << "start:" << to_simple_string(calendar.suiteTime()) << "\n";
     std::pair<NState, boost::posix_time::time_duration> state =
         std::make_pair(NState(NState::SUBMITTED), calendar.duration());
 
     // after four minutes in submitted state, we should be late
     for (int m = 1; m < 10; m++) {
         calendar.update(time_duration(minutes(1)));
-        // cout << "m=" << m << " " << to_simple_string(calendar.suiteTime()) << "\n";
 
         lateAttr.checkForLateness(state, calendar);
-        // if (lateAttr.isLate()) {
-        //    cout << "late at m=" << m << " " << to_simple_string(calendar.suiteTime()) << "\n";
-        // }
 
         if (m >= 4) {
             BOOST_CHECK_MESSAGE(lateAttr.isLate(),
@@ -94,19 +89,14 @@ BOOST_AUTO_TEST_CASE(test_late_attr_active) {
     lateAttr.addActive(ecf::TimeSlot(10, 0));
 
     // set submitted state at 00:00:00
-    // cout << "start:" << to_simple_string(calendar.suiteTime()) << "\n";
     std::pair<NState, boost::posix_time::time_duration> state =
         std::make_pair(NState(NState::SUBMITTED), calendar.duration());
 
     // after 10 hours we, if we are not active, we should be late
     for (int m = 1; m < 23; m++) {
         calendar.update(time_duration(hours(1)));
-        // cout << "m=" << m << " " << to_simple_string(calendar.suiteTime()) << "\n";
 
         lateAttr.checkForLateness(state, calendar);
-        //      if (lateAttr.isLate()) {
-        //         cout << "late at m=" << m << " " << to_simple_string(calendar.suiteTime()) << "\n";
-        //      }
 
         if (m >= 10) {
             BOOST_CHECK_MESSAGE(lateAttr.isLate(),
@@ -134,19 +124,14 @@ BOOST_AUTO_TEST_CASE(test_late_attr_complete_relative) {
     lateAttr.addComplete(ecf::TimeSlot(0, 15), true);
 
     // set active state at 00:00:00
-    //   cout << "start:" << to_simple_string(calendar.suiteTime()) << "\n";
     std::pair<NState, boost::posix_time::time_duration> state =
         std::make_pair(NState(NState::ACTIVE), calendar.duration());
 
     // after 15 minutes relative, if we are not complete, we should be late
     for (int m = 1; m < 23; m++) {
         calendar.update(time_duration(minutes(1)));
-        //      cout << "m=" << m << " " << to_simple_string(calendar.suiteTime()) << "\n";
 
         lateAttr.checkForLateness(state, calendar);
-        //      if (lateAttr.isLate()) {
-        //         cout << "late at m=" << m << " " << to_simple_string(calendar.suiteTime()) << "\n";
-        //      }
 
         if (m >= 15) {
             BOOST_CHECK_MESSAGE(lateAttr.isLate(),
@@ -174,7 +159,6 @@ BOOST_AUTO_TEST_CASE(test_late_attr_complete_real) {
     lateAttr.addComplete(ecf::TimeSlot(3, 0), false);
 
     // set active state at 00:00:00
-    //   cout << "start:" << to_simple_string(calendar.suiteTime()) << "\n";
     std::pair<NState, boost::posix_time::time_duration> state =
         std::make_pair(NState(NState::ACTIVE), calendar.duration());
 
@@ -182,12 +166,8 @@ BOOST_AUTO_TEST_CASE(test_late_attr_complete_real) {
     for (int m = 1; m < 7; m++) {
 
         calendar.update(time_duration(hours(1)));
-        //      cout << "m=" << m << " " << to_simple_string(calendar.suiteTime()) << "\n";
 
         lateAttr.checkForLateness(state, calendar);
-        //      if (lateAttr.isLate()) {
-        //         cout << "late at m=" << m << " " << to_simple_string(calendar.suiteTime()) << "\n";
-        //      }
 
         if (m >= 3) {
             BOOST_CHECK_MESSAGE(lateAttr.isLate(),

--- a/libs/attribute/test/TestMigration.cpp
+++ b/libs/attribute/test/TestMigration.cpp
@@ -11,6 +11,7 @@
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "TestSerialisation.hpp"
 #include "ecflow/attribute/AutoArchiveAttr.hpp"
 #include "ecflow/attribute/AutoCancelAttr.hpp"
@@ -47,7 +48,7 @@ BOOST_AUTO_TEST_SUITE(T_Migration)
 // backward compatibility.i.e future release can open file, created by an earlier release
 //
 BOOST_AUTO_TEST_CASE(test_migration_restore_def_con) {
-    cout << "ANattr:: ...test_migration_restore_def_con\n";
+    ECF_NAME_THIS_TEST();
 
     std::string file_name =
         File::test_data("libs/attribute/test/data/migration/default_constructor_1_2_2/", "libs/attribute");
@@ -103,7 +104,7 @@ BOOST_AUTO_TEST_CASE(test_migration_restore_def_con) {
 }
 
 BOOST_AUTO_TEST_CASE(test_migration_restore) {
-    cout << "ANattr:: ...test_migration_restore\n";
+    ECF_NAME_THIS_TEST();
 
     std::string file_name = File::test_data("libs/attribute/test/data/migration/1_2_2/", "libs/attribute");
     // BOOST_CHECK_MESSAGE(File::createDirectories(file_name ),"Could not create directory " << file_name);
@@ -269,7 +270,8 @@ private:
 } // namespace version_new_data_member
 
 BOOST_AUTO_TEST_CASE(test_day_migration) {
-    cout << "ANattr:: ...test_day_migration\n";
+    ECF_NAME_THIS_TEST();
+
     // OLD -> NEW  i.e OLD SERVER --> NEW CLIENT
     {
         const version_old::DayAttr t = version_old::DayAttr();

--- a/libs/attribute/test/TestRepeat.cpp
+++ b/libs/attribute/test/TestRepeat.cpp
@@ -13,6 +13,7 @@
 #include <boost/date_time/posix_time/time_formatters.hpp> // requires boost date and time lib
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/attribute/RepeatAttr.hpp"
 #include "ecflow/core/Cal.hpp"
 #include "ecflow/core/Converter.hpp"
@@ -34,7 +35,7 @@ BOOST_AUTO_TEST_SUITE(T_Repeat)
 BOOST_AUTO_TEST_SUITE(test_repeat)
 
 BOOST_AUTO_TEST_CASE(invariants) {
-    cout << "ANattr:: ...TestRepeat::invariants\n";
+    ECF_NAME_THIS_TEST();
 
     // Test the invariant that non-empty repeat must have a name
     Repeat empty;
@@ -45,7 +46,7 @@ BOOST_AUTO_TEST_CASE(invariants) {
 }
 
 BOOST_AUTO_TEST_CASE(construction) {
-    cout << "ANattr:: ...TestRepeat::construction\n";
+    ECF_NAME_THIS_TEST();
 
     Repeat empty;
 
@@ -77,7 +78,7 @@ BOOST_AUTO_TEST_SUITE_END() // test_repeat
 BOOST_AUTO_TEST_SUITE(test_repeat_datelist)
 
 BOOST_AUTO_TEST_CASE(invariants) {
-    cout << "ANattr:: ...test_repeat_datelist::invariants\n";
+    ECF_NAME_THIS_TEST();
 
     {
         Repeat rep(RepeatDateList("YMD", {20190929, 20190131}));
@@ -152,7 +153,7 @@ BOOST_AUTO_TEST_SUITE_END() // test_repeat_datelist
 BOOST_AUTO_TEST_SUITE(test_repeat_date)
 
 BOOST_AUTO_TEST_CASE(invariants) {
-    cout << "ANattr:: ...test_repeat_date::invariants\n";
+    ECF_NAME_THIS_TEST();
 
     {
         Repeat rep(RepeatDate("YMD", 20090916, 20090930, 1));
@@ -246,7 +247,7 @@ BOOST_AUTO_TEST_CASE(invariants) {
 }
 
 BOOST_AUTO_TEST_CASE(construction) {
-    cout << "ANattr:: ...test_repeat_date::construction\n";
+    ECF_NAME_THIS_TEST();
 
     Repeat empty;
     {
@@ -289,7 +290,7 @@ BOOST_AUTO_TEST_CASE(construction) {
 }
 
 BOOST_AUTO_TEST_CASE(move_semantics) {
-    cout << "ANattr:: ...test_repeat_date::move_semantics\n";
+    ECF_NAME_THIS_TEST();
 
     {
         Repeat x;
@@ -317,7 +318,7 @@ BOOST_AUTO_TEST_CASE(move_semantics) {
 }
 
 BOOST_AUTO_TEST_CASE(last_value) {
-    cout << "ANattr:: ...test_repeat_date::last_value \n";
+    ECF_NAME_THIS_TEST();
 
     {
         Repeat rep(RepeatDate("YMD", 20090916, 20090930, 1));
@@ -356,7 +357,7 @@ BOOST_AUTO_TEST_CASE(last_value) {
 }
 
 BOOST_AUTO_TEST_CASE(increment) {
-    cout << "ANattr:: ...test_repeat_date::increment \n";
+    ECF_NAME_THIS_TEST();
 
     {
         Repeat rep(RepeatDate("YMD", 20090916, 20090920, 1));
@@ -412,7 +413,7 @@ BOOST_AUTO_TEST_CASE(increment) {
 }
 
 BOOST_AUTO_TEST_CASE(handling_errors) {
-    cout << "ANattr:: ...test_repeat_date:handling_errors \n";
+    ECF_NAME_THIS_TEST();
 
     BOOST_REQUIRE_THROW(RepeatDate("", 20090916, 20090920, 1), std::runtime_error);
     BOOST_REQUIRE_THROW(RepeatDate("YMD", 200909161, 20090920, 1), std::runtime_error); // start > 8
@@ -453,7 +454,8 @@ BOOST_AUTO_TEST_CASE(handling_errors) {
 }
 
 BOOST_AUTO_TEST_CASE(change_value) {
-    cout << "ANattr:: ...test_repeat_date::change_value \n";
+    ECF_NAME_THIS_TEST();
+
     {
         Repeat rep2(RepeatDate("YMD", 20150514, 20150730, 7));
         Repeat rep(RepeatDate("YMD", 20150514, 20150730, 7));
@@ -481,7 +483,7 @@ BOOST_AUTO_TEST_CASE(change_value) {
 }
 
 BOOST_AUTO_TEST_CASE(generated_variables) {
-    cout << "ANattr:: ...test_repeat_date::generated_variables\n";
+    ECF_NAME_THIS_TEST();
 
     Repeat rep(RepeatDate("YMD", 20090916, 20090930, 1));
     BOOST_CHECK_MESSAGE(!rep.empty(), " Repeat should not be empty");
@@ -536,7 +538,7 @@ BOOST_AUTO_TEST_CASE(generated_variables) {
 }
 
 BOOST_AUTO_TEST_CASE(more_generated_variables) {
-    cout << "ANattr:: ...test_repeat_date::more_generated_variables\n";
+    ECF_NAME_THIS_TEST();
 
     int start = 20161231;
     int end   = 20170106;
@@ -661,7 +663,7 @@ BOOST_AUTO_TEST_CASE(more_generated_variables) {
 }
 
 BOOST_AUTO_TEST_CASE(convert_xref_to_boost_date) {
-    cout << "ANattr:: ...test_repeat_date::convert_xref_to_boost_date \n";
+    ECF_NAME_THIS_TEST();
 
     auto check_date = [](int start, int end, int delta) {
         boost::gregorian::date bdate(from_undelimited_string(boost::lexical_cast<std::string>(start)));
@@ -701,7 +703,7 @@ BOOST_AUTO_TEST_SUITE_END() // test_repeat_date
 BOOST_AUTO_TEST_SUITE(test_repeat_datetime)
 
 BOOST_AUTO_TEST_CASE(invariants) {
-    cout << "ANattr:: ...test_repeat_datetime::invariants\n";
+    ECF_NAME_THIS_TEST();
 
     {
         Repeat rep(RepeatDateTime("DT", "19700101T000001", "19700102T000001", "24:00:00"));
@@ -802,7 +804,7 @@ BOOST_AUTO_TEST_SUITE_END() // test_repeat_datetime
 BOOST_AUTO_TEST_SUITE(test_repeat_enumerated)
 
 BOOST_AUTO_TEST_CASE(invariants) {
-    cout << "ANattr:: ...test_repeat_enumerated::invariants\n";
+    ECF_NAME_THIS_TEST();
 
     const std::vector<std::string> stringList = {std::string("a"), std::string("b"), std::string("c")};
 
@@ -839,7 +841,7 @@ BOOST_AUTO_TEST_CASE(invariants) {
 }
 
 BOOST_AUTO_TEST_CASE(construction) {
-    cout << "ANattr:: ...TestRepeatEnumerated::construction\n";
+    ECF_NAME_THIS_TEST();
 
     Repeat empty;
     {
@@ -870,7 +872,7 @@ BOOST_AUTO_TEST_CASE(construction) {
 }
 
 BOOST_AUTO_TEST_CASE(last_value) {
-    cout << "ANattr:: ...test_repeat_enumerated::last_value \n";
+    ECF_NAME_THIS_TEST();
 
     Repeat rep(RepeatEnumerated("AEnum", stringList));
     rep.setToLastValue();
@@ -887,7 +889,7 @@ BOOST_AUTO_TEST_CASE(last_value) {
 }
 
 BOOST_AUTO_TEST_CASE(increment) {
-    cout << "ANattr:: ...test_repeat_enumerated::increment \n";
+    ECF_NAME_THIS_TEST();
 
     Repeat rep(RepeatEnumerated("AEnum", stringList));
     while (rep.valid()) {
@@ -898,7 +900,7 @@ BOOST_AUTO_TEST_CASE(increment) {
 }
 
 BOOST_AUTO_TEST_CASE(more_increment) {
-    cout << "ANattr:: ...test_repeat_enumerated::more_increment\n";
+    ECF_NAME_THIS_TEST();
 
     using namespace std::string_literals;
 
@@ -965,7 +967,7 @@ BOOST_AUTO_TEST_CASE(more_increment) {
 }
 
 BOOST_AUTO_TEST_CASE(handling_errors) {
-    cout << "ANattr:: ...test_repeat_enumerated::handling_errors \n";
+    ECF_NAME_THIS_TEST();
 
     const std::vector<std::string> empty;
     const std::vector<std::string> stringList = {"a", "b"};
@@ -985,7 +987,7 @@ BOOST_AUTO_TEST_SUITE_END() // test_repeat_enumerated
 BOOST_AUTO_TEST_SUITE(test_repeat_integer)
 
 BOOST_AUTO_TEST_CASE(invariants) {
-    cout << "ANattr:: ...test_repeat_integer::invariants\n";
+    ECF_NAME_THIS_TEST();
 
     {
         Repeat rep(RepeatInteger("rep", 0, 100, 1));
@@ -1021,7 +1023,7 @@ BOOST_AUTO_TEST_CASE(invariants) {
 }
 
 BOOST_AUTO_TEST_CASE(construction) {
-    cout << "ANattr:: ...test_repeat_integer::construction\n";
+    ECF_NAME_THIS_TEST();
 
     Repeat empty;
 
@@ -1055,7 +1057,7 @@ BOOST_AUTO_TEST_CASE(construction) {
 }
 
 BOOST_AUTO_TEST_CASE(last_value) {
-    cout << "ANattr:: ...test_repeat_integer::last_value \n";
+    ECF_NAME_THIS_TEST();
 
     {
         Repeat rep(RepeatInteger("integer", 0, 10, 1));
@@ -1085,7 +1087,7 @@ BOOST_AUTO_TEST_CASE(last_value) {
 }
 
 BOOST_AUTO_TEST_CASE(increment) {
-    cout << "ANattr:: ...test_repeat_integer::increment \n";
+    ECF_NAME_THIS_TEST();
 
     Repeat rep(RepeatInteger("integer", 0, 10, 1));
     while (rep.valid()) {
@@ -1104,7 +1106,7 @@ BOOST_AUTO_TEST_SUITE_END() // test_repeat_integer
 BOOST_AUTO_TEST_SUITE(test_repeat_day)
 
 BOOST_AUTO_TEST_CASE(invariants) {
-    cout << "ANattr:: ...test_repeat_day::invariants\n";
+    ECF_NAME_THIS_TEST();
 
     {
         Repeat rep(RepeatDay(2));
@@ -1138,7 +1140,7 @@ BOOST_AUTO_TEST_SUITE_END() // test_repeat_day
 BOOST_AUTO_TEST_SUITE(test_repeat_string)
 
 BOOST_AUTO_TEST_CASE(construction) {
-    cout << "ANattr:: ...test_repeat_string::construction\n";
+    ECF_NAME_THIS_TEST();
 
     Repeat empty;
 
@@ -1172,7 +1174,7 @@ BOOST_AUTO_TEST_CASE(construction) {
 }
 
 BOOST_AUTO_TEST_CASE(last_value) {
-    cout << "ANattr:: ...test_repeat_string::last_value \n";
+    ECF_NAME_THIS_TEST();
 
     {
         Repeat rep(RepeatString("Str", stringList));
@@ -1191,7 +1193,7 @@ BOOST_AUTO_TEST_CASE(last_value) {
 }
 
 BOOST_AUTO_TEST_CASE(increment) {
-    cout << "ANattr:: ...test_repeat_string::increment \n";
+    ECF_NAME_THIS_TEST();
 
     Repeat rep(RepeatString("Str", stringList));
     while (rep.valid()) {
@@ -1202,7 +1204,7 @@ BOOST_AUTO_TEST_CASE(increment) {
 }
 
 BOOST_AUTO_TEST_CASE(handling_errors) {
-    cout << "ANattr:: ...test_repeat_string::handling_errors \n";
+    ECF_NAME_THIS_TEST();
 
     const std::vector<std::string> empty;
     const std::vector<std::string> stringList = {"a", "b"};

--- a/libs/attribute/test/TestRepeat.cpp
+++ b/libs/attribute/test/TestRepeat.cpp
@@ -394,7 +394,6 @@ BOOST_AUTO_TEST_CASE(increment) {
         Repeat rep(RepeatDate("YMD", 20150514, 20150730, 7));
         while (rep.valid()) {
             rep.increment();
-            // cout << "YMD: " << rep.value() << "\n";
         }
         BOOST_CHECK_MESSAGE(rep.value() == 20150806, "expected 20150806 but found " << rep.value());
         BOOST_CHECK_MESSAGE(rep.last_valid_value() == 20150730,
@@ -404,7 +403,6 @@ BOOST_AUTO_TEST_CASE(increment) {
         Repeat rep(RepeatDate("YMD", 20150730, 20150514, -7));
         while (rep.valid()) {
             rep.increment();
-            // cout << "YMD: " << rep.value() << "\n";
         }
         BOOST_CHECK_MESSAGE(rep.value() == 20150507, "expected 20150507 but found " << rep.value());
         BOOST_CHECK_MESSAGE(rep.last_valid_value() == 20150514,

--- a/libs/attribute/test/TestSizeOf.cpp
+++ b/libs/attribute/test/TestSizeOf.cpp
@@ -30,25 +30,25 @@ inline const char* typeName(void) {
         return STRINGIFY(T);           \
     }
 
-TYPE_STRING(std::ofstream);
-TYPE_STRING(std::string);
-TYPE_STRING(std::vector<int>);
-TYPE_STRING(std::vector<std::string>);
-TYPE_STRING(std::weak_ptr<int>);
-TYPE_STRING(std::nullptr_t);
-TYPE_STRING(std::unique_ptr<int>);
-TYPE_STRING(double);
-TYPE_STRING(long);
-TYPE_STRING(int);
-TYPE_STRING(unsigned int);
-TYPE_STRING(bool);
-TYPE_STRING(ecf::TimeSeries);
-TYPE_STRING(DayAttr);
+TYPE_STRING(std::ofstream)
+TYPE_STRING(std::string)
+TYPE_STRING(std::vector<int>)
+TYPE_STRING(std::vector<std::string>)
+TYPE_STRING(std::weak_ptr<int>)
+TYPE_STRING(std::nullptr_t)
+TYPE_STRING(std::unique_ptr<int>)
+TYPE_STRING(double)
+TYPE_STRING(long)
+TYPE_STRING(int)
+TYPE_STRING(unsigned int)
+TYPE_STRING(bool)
+TYPE_STRING(ecf::TimeSeries)
+TYPE_STRING(DayAttr)
 
 template <typename T>
 void inspect_size_of(T t = T{}) {
 #if PRINT_SIZEOF_RESULTS
-    std::cout << "   * sizeof(" << typeName<T>() << ") = " << sizeof(T) << "\n";
+    ECF_TEST_DBG(<< "   * sizeof(" << typeName<T>() << ") = " << sizeof(T));
 #endif
     BOOST_REQUIRE_EQUAL(sizeof(T), sizeof(T));
 }

--- a/libs/attribute/test/TestSizeOf.cpp
+++ b/libs/attribute/test/TestSizeOf.cpp
@@ -13,34 +13,68 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/attribute/DayAttr.hpp"
 #include "ecflow/core/TimeSeries.hpp"
 
-using namespace boost;
-using namespace std;
+#define STRINGIFY(x) #x
+
+template <typename T>
+inline const char* typeName(void) {
+    return "unknown";
+}
+
+#define TYPE_STRING(T)                 \
+    template <>                        \
+    inline const char* typeName<T>() { \
+        return STRINGIFY(T);           \
+    }
+
+TYPE_STRING(std::ofstream);
+TYPE_STRING(std::string);
+TYPE_STRING(std::vector<int>);
+TYPE_STRING(std::vector<std::string>);
+TYPE_STRING(std::weak_ptr<int>);
+TYPE_STRING(std::nullptr_t);
+TYPE_STRING(std::unique_ptr<int>);
+TYPE_STRING(double);
+TYPE_STRING(long);
+TYPE_STRING(int);
+TYPE_STRING(unsigned int);
+TYPE_STRING(bool);
+TYPE_STRING(ecf::TimeSeries);
+TYPE_STRING(DayAttr);
+
+template <typename T>
+void inspect_size_of(T t = T{}) {
+#if PRINT_SIZEOF_RESULTS
+    std::cout << "   * sizeof(" << typeName<T>() << ") = " << sizeof(T) << "\n";
+#endif
+    BOOST_REQUIRE_EQUAL(sizeof(T), sizeof(T));
+}
 
 BOOST_AUTO_TEST_SUITE(U_Attributes)
 
 BOOST_AUTO_TEST_SUITE(T_SizeOf)
 
 BOOST_AUTO_TEST_CASE(test_size_of) {
-    cout << "ACore:: ...test_size_of\n";
-    cout << "   sizeof(std::ofstream)      " << sizeof(std::ofstream) << "\n";
-    cout << "   sizeof(std::string)        " << sizeof(std::string) << "\n";
-    cout << "   sizeof(vector<int>)        " << sizeof(std::vector<int>) << "\n";
-    cout << "   sizeof(vector<string>)     " << sizeof(vector<string>) << "\n";
-    cout << "   sizeof(std::weak_ptr<int>) " << sizeof(std::weak_ptr<int>) << "\n";
-    cout << "   sizeof(nullptr)            " << sizeof(nullptr) << "\n";
-    cout << "   sizeof(unique_ptr)         " << sizeof(unique_ptr<int>) << "\n";
-    cout << "   sizeof(double)             " << sizeof(double) << "\n";
-    cout << "   sizeof(long)               " << sizeof(long) << "\n";
-    cout << "   sizeof(int)                " << sizeof(int) << "\n";
-    cout << "   sizeof(unsigned int)       " << sizeof(unsigned int) << "\n";
-    cout << "   sizeof(bool)               " << sizeof(bool) << "\n";
-    cout << "   sizeof(TimeSeries)         " << sizeof(ecf::TimeSeries) << "\n";
-    cout << "   sizeof(DayAttr)            " << sizeof(DayAttr) << "\n";
+    ECF_NAME_THIS_TEST();
 
-    BOOST_CHECK_MESSAGE(true, "Dummy");
+    inspect_size_of<std::ofstream>();
+    inspect_size_of<std::string>();
+    inspect_size_of<std::vector<int>>();
+    inspect_size_of<std::vector<std::string>>();
+    inspect_size_of<std::weak_ptr<int>>();
+    inspect_size_of<std::nullptr_t>();
+    inspect_size_of(nullptr);
+    inspect_size_of<std::unique_ptr<int>>();
+    inspect_size_of<double>();
+    inspect_size_of<long>();
+    inspect_size_of<int>();
+    inspect_size_of<unsigned int>();
+    inspect_size_of<bool>();
+    inspect_size_of<ecf::TimeSeries>();
+    inspect_size_of<DayAttr>();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/attribute/test/TestTimeAttr.cpp
+++ b/libs/attribute/test/TestTimeAttr.cpp
@@ -105,9 +105,6 @@ BOOST_AUTO_TEST_CASE(test_time_attr) {
     BOOST_CHECK_MESSAGE(timeSeries2_free_slots.size() == 5,
                         "Expected 5 free slots for " << timeSeries2.toString() << " but found "
                                                      << timeSeries_free_slots.size());
-    //   cout << "time " << timeSeries.toString() << " free slots:";
-    //   for(size_t i = 0; i < timeSeries_free_slots.size(); i++)  cout << timeSeries_free_slots[i] << " ";
-    //   cout << "\n";
 
     // follow normal process
     timeSeries.reset(calendar);
@@ -123,14 +120,11 @@ BOOST_AUTO_TEST_CASE(test_time_attr) {
             day_changed = calendar.dayChanged();
 
         boost::posix_time::time_duration time = calendar.suiteTime().time_of_day();
-        // cout << time << " day_changed(" << day_changed << ")\n";
 
         timeSeries.calendarChanged(calendar);
         timeSeries2.calendarChanged(calendar);
         timeSeries3.calendarChanged(calendar);
         timeSeries4.calendarChanged(calendar);
-
-        // cout << to_simple_string(calendar.suiteTime()) << "\n";
 
         if (calendar.dayChanged()) {
             BOOST_CHECK_MESSAGE(!timeSeries.checkForRequeue(calendar, t1_min, t1_max),
@@ -305,7 +299,6 @@ BOOST_AUTO_TEST_CASE(test_time_once_free_stays_free) {
             day_changed = calendar.dayChanged();
         }
         boost::posix_time::time_duration time = calendar.suiteTime().time_of_day();
-        // cout << time << " day_changed(" << day_changed << ")\n";
 
         timeSeries.calendarChanged(calendar);
         timeSeries2.calendarChanged(calendar);
@@ -408,7 +401,6 @@ BOOST_AUTO_TEST_CASE(test_time_attr_multiples) {
             day_changed = calendar.dayChanged();
         }
         boost::posix_time::time_duration time = calendar.suiteTime().time_of_day();
-        //      cout << time << " day_changed(" << day_changed << ")\n";
 
         timeSeries.calendarChanged(calendar);
         timeSeries2.calendarChanged(calendar);

--- a/libs/attribute/test/TestTimeAttr.cpp
+++ b/libs/attribute/test/TestTimeAttr.cpp
@@ -15,6 +15,7 @@
 #include <boost/date_time/posix_time/time_formatters.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/attribute/TimeAttr.hpp"
 #include "ecflow/core/Calendar.hpp"
 #include "ecflow/core/TimeSeries.hpp"
@@ -29,7 +30,8 @@ BOOST_AUTO_TEST_SUITE(U_Attributes)
 BOOST_AUTO_TEST_SUITE(T_TimeAttr)
 
 BOOST_AUTO_TEST_CASE(test_time_string_constrcutor) {
-    cout << "ANattr:: ...test_time_string_constrcutor\n";
+    ECF_NAME_THIS_TEST();
+
     {
         TimeAttr time("+00:30");
         BOOST_CHECK_MESSAGE(time.time_series().start().hour() == 0 && time.time_series().start().minute() == 30 &&
@@ -60,7 +62,7 @@ BOOST_AUTO_TEST_CASE(test_time_string_constrcutor) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_attr) {
-    cout << "ANattr:: ...test_time_attr\n";
+    ECF_NAME_THIS_TEST();
 
     // See TimeAttr.hpp for rules concerning isFree() and checkForReque()
     // test time attr isFree(), and checkForRequeue
@@ -281,7 +283,7 @@ BOOST_AUTO_TEST_CASE(test_time_attr) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_once_free_stays_free) {
-    cout << "ANattr:: ...test_time_once_free_stays_free\n";
+    ECF_NAME_THIS_TEST();
 
     Calendar calendar;
     calendar.init(ptime(date(2010, 2, 10), minutes(0)), Calendar::REAL);
@@ -378,7 +380,7 @@ BOOST_AUTO_TEST_CASE(test_time_once_free_stays_free) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_attr_multiples) {
-    cout << "ANattr:: ...test_time_attr_multiples\n";
+    ECF_NAME_THIS_TEST();
 
     // See TimeAttr.hpp for rules concerning isFree() and checkForReque()
     // test time attr isFree(), and checkForRequeue

--- a/libs/attribute/test/TestTodayAttr.cpp
+++ b/libs/attribute/test/TestTodayAttr.cpp
@@ -14,6 +14,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/attribute/TodayAttr.hpp"
 #include "ecflow/core/Calendar.hpp"
 #include "ecflow/core/TimeSeries.hpp"
@@ -28,7 +29,8 @@ BOOST_AUTO_TEST_SUITE(U_Attributes)
 BOOST_AUTO_TEST_SUITE(T_TodayAttr)
 
 BOOST_AUTO_TEST_CASE(test_today_string_constrcutor) {
-    cout << "ANattr:: ...test_today_string_constrcutor\n";
+    ECF_NAME_THIS_TEST();
+
     {
         TodayAttr time("+00:30");
         BOOST_CHECK_MESSAGE(time.time_series().start().hour() == 0 && time.time_series().start().minute() == 30 &&
@@ -59,7 +61,7 @@ BOOST_AUTO_TEST_CASE(test_today_string_constrcutor) {
 }
 
 BOOST_AUTO_TEST_CASE(test_today_attr) {
-    cout << "ANattr:: ...test_today_attr\n";
+    ECF_NAME_THIS_TEST();
 
     // See TodayAttr.hpp for rules concerning isFree() and checkForReque()
     // test today attr isFree(), and checkForRequeue

--- a/libs/attribute/test/TestTodayAttr.cpp
+++ b/libs/attribute/test/TestTodayAttr.cpp
@@ -114,7 +114,6 @@ BOOST_AUTO_TEST_CASE(test_today_attr) {
             day_changed = calendar.dayChanged();
         }
         boost::posix_time::time_duration time = calendar.suiteTime().time_of_day();
-        //      cout << time << " day_changed(" << day_changed << ")\n";
 
         timeSeries.calendarChanged(calendar);
         timeSeries2.calendarChanged(calendar);

--- a/libs/attribute/test/TestVariable.cpp
+++ b/libs/attribute/test/TestVariable.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/attribute/Variable.hpp"
 
 using namespace std;
@@ -22,7 +23,7 @@ BOOST_AUTO_TEST_SUITE(U_Attributes)
 BOOST_AUTO_TEST_SUITE(T_Variable)
 
 BOOST_AUTO_TEST_CASE(test_multi_line_variable_values) {
-    cout << "ANattr:: ...test_multi_line_variable_values\n";
+    ECF_NAME_THIS_TEST();
 
     {
         Variable var("name", "value");
@@ -50,7 +51,7 @@ BOOST_AUTO_TEST_CASE(test_multi_line_variable_values) {
 }
 
 BOOST_AUTO_TEST_CASE(test_variable_value) {
-    cout << "ANattr:: ...test_variable_value\n";
+    ECF_NAME_THIS_TEST();
 
     std::vector<std::string> values;
     values.emplace_back("sdsd");

--- a/libs/attribute/test/TestVariableMap.cpp
+++ b/libs/attribute/test/TestVariableMap.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/attribute/Variable.hpp"
 
 BOOST_AUTO_TEST_SUITE(U_Attributes)
@@ -17,6 +18,8 @@ BOOST_AUTO_TEST_SUITE(U_Attributes)
 BOOST_AUTO_TEST_SUITE(T_VariableMap)
 
 BOOST_AUTO_TEST_CASE(test_variablemap_is_able_to_create_empty_variable_map) {
+    ECF_NAME_THIS_TEST();
+
     VariableMap empty;
 
     BOOST_CHECK(empty.empty());
@@ -24,6 +27,8 @@ BOOST_AUTO_TEST_CASE(test_variablemap_is_able_to_create_empty_variable_map) {
 }
 
 BOOST_AUTO_TEST_CASE(test_variablemap_is_able_to_create_variable_map) {
+    ECF_NAME_THIS_TEST();
+
     VariableMap variables{Variable("n1", "v1"), Variable("n2", "v2"), Variable("n3", "v3")};
 
     BOOST_CHECK(!variables.empty());
@@ -31,6 +36,8 @@ BOOST_AUTO_TEST_CASE(test_variablemap_is_able_to_create_variable_map) {
 }
 
 BOOST_AUTO_TEST_CASE(test_variablemap_is_able_set_value_to_all_variables_in_variable_map) {
+    ECF_NAME_THIS_TEST();
+
     VariableMap variables{Variable("n1", "v1"), Variable("n2", "v2"), Variable("n3", "v3")};
 
     std::string value = "some large value just for precaution!";
@@ -43,6 +50,8 @@ BOOST_AUTO_TEST_CASE(test_variablemap_is_able_set_value_to_all_variables_in_vari
 }
 
 BOOST_AUTO_TEST_CASE(test_variablemap_is_able_to_access_variable_in_variable_map) {
+    ECF_NAME_THIS_TEST();
+
     VariableMap variables{Variable("n1", "v1"), Variable("n2", "v2"), Variable("n3", "v3")};
 
     const Variable& variable = variables["n1"];
@@ -52,6 +61,8 @@ BOOST_AUTO_TEST_CASE(test_variablemap_is_able_to_access_variable_in_variable_map
 }
 
 BOOST_AUTO_TEST_CASE(test_variablemap_throws_when_accessing_inexistent_variable_in_variable_map) {
+    ECF_NAME_THIS_TEST();
+
     VariableMap variables{Variable("n1", "v1"), Variable("n2", "v2"), Variable("n3", "v3")};
 
     Variable found;

--- a/libs/attribute/test/TestZombieAttr.cpp
+++ b/libs/attribute/test/TestZombieAttr.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/attribute/ZombieAttr.hpp"
 
 using namespace std;
@@ -22,7 +23,8 @@ BOOST_AUTO_TEST_SUITE(U_Attributes)
 BOOST_AUTO_TEST_SUITE(T_ZombieAttr)
 
 BOOST_AUTO_TEST_CASE(test_zombie_attr) {
-    cout << "ANattr:: ...test_zombie_attr\n";
+    ECF_NAME_THIS_TEST();
+
     {
         ZombieAttr ecf(ecf::Child::ECF, std::vector<ecf::Child::CmdType>(), ecf::User::FAIL);
         BOOST_CHECK_MESSAGE(ecf.zombie_lifetime() == ZombieAttr::default_ecf_zombie_life_time(),
@@ -82,7 +84,8 @@ BOOST_AUTO_TEST_CASE(test_zombie_attr) {
 }
 
 BOOST_AUTO_TEST_CASE(test_zombie_attr_parsing) {
-    cout << "ANattr:: ...test_zombie_attr_parsing\n";
+    ECF_NAME_THIS_TEST();
+
     {
         ZombieAttr zombie = ZombieAttr::create("user:fob::");
         BOOST_CHECK_MESSAGE(zombie.zombie_type() == ecf::Child::USER, "Type not as expected");

--- a/libs/base/CMakeLists.txt
+++ b/libs/base/CMakeLists.txt
@@ -50,6 +50,7 @@ ecbuild_add_test(
     ecflow_all
     Threads::Threads
     $<$<BOOL:${OPENSSL_FOUND}>:OpenSSL::SSL>
+    test_support
   TEST_DEPENDS
     u_parser
 )

--- a/libs/base/src/ecflow/base/Gnuplot.cpp
+++ b/libs/base/src/ecflow/base/Gnuplot.cpp
@@ -339,7 +339,7 @@ bool Gnuplot::extract_suite_path(const std::string& line,
         if (child_cmd) {
 
             // For labels ignore paths in the label part
-            // MSG:[14:55:04 17.10.2013] chd:label progress 'core/nodeattr/nodeAParser'
+            // MSG:[14:55:04 17.10.2013] chd:label progress 'core/nodeattr/node/parser'
             // /suite/build/cray/cray_gnu/build_release/test
             if (line.find("chd:label") != std::string::npos) {
                 size_t last_tick = line.rfind("'");

--- a/libs/base/test/TestAlterCmd.cpp
+++ b/libs/base/test/TestAlterCmd.cpp
@@ -11,6 +11,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/GenericAttr.hpp"
 #include "ecflow/attribute/LateAttr.hpp"
 #include "ecflow/base/cts/user/AlterCmd.hpp"
@@ -74,13 +75,15 @@ private:
 };
 
 BOOST_AUTO_TEST_CASE(test_add_log5) {
+    ECF_NAME_THIS_TEST();
+
     // create once for all test below, then remove at the end
     Log::create("test_add_log5.log");
     BOOST_CHECK_MESSAGE(true, "stop boost test form complaining");
 }
 
 BOOST_AUTO_TEST_CASE(test_alter_cmd_for_clock_type_hybrid) {
-    cout << "Base:: ...test_alter_cmd_for_clock_type_hybrid\n";
+    ECF_NAME_THIS_TEST();
 
     // In this test the suite has NO Clock attribute. It should get added automatically
     // when a new clock is added, we should sync with the computer clock
@@ -117,7 +120,7 @@ BOOST_AUTO_TEST_CASE(test_alter_cmd_for_clock_type_hybrid) {
 }
 
 BOOST_AUTO_TEST_CASE(test_alter_cmd_for_clock_type_real) {
-    cout << "Base:: ...test_alter_cmd_for_clock_type_real\n";
+    ECF_NAME_THIS_TEST();
 
     // In this test the suite has NO Clock attribute. It should get added automatically
     // when a new clock is added, we should sync with the computer clock
@@ -153,7 +156,7 @@ BOOST_AUTO_TEST_CASE(test_alter_cmd_for_clock_type_real) {
 }
 
 BOOST_AUTO_TEST_CASE(test_alter_cmd_for_clock_sync) {
-    cout << "Base:: ...test_alter_cmd_for_clock_sync\n";
+    ECF_NAME_THIS_TEST();
 
     // Add a suite with a hybrid clock set to the past, on switch to real time, should have todays date
     // Since the clock exists on the suite, with another date, we must explicitly sync with computer
@@ -209,7 +212,7 @@ BOOST_AUTO_TEST_CASE(test_alter_cmd_for_clock_sync) {
 }
 
 BOOST_AUTO_TEST_CASE(test_alter_cmd_for_clock_date) {
-    cout << "Base:: ...test_alter_cmd_for_clock_date\n";
+    ECF_NAME_THIS_TEST();
 
     // In this test the suite has NO Clock attribute. It should get added automatically
     Defs defs;
@@ -256,7 +259,7 @@ BOOST_AUTO_TEST_CASE(test_alter_cmd_for_clock_date) {
 }
 
 BOOST_AUTO_TEST_CASE(test_alter_cmd_for_clock_gain) {
-    cout << "Base:: ...test_alter_cmd_for_clock_gain\n";
+    ECF_NAME_THIS_TEST();
 
     // In this test the suite has NO Clock attribute. It should get added automatically
     Defs defs;
@@ -323,7 +326,7 @@ BOOST_AUTO_TEST_CASE(test_alter_cmd_for_clock_gain) {
 }
 
 BOOST_AUTO_TEST_CASE(test_alter_cmd) {
-    cout << "Base:: ...test_alter_cmd\n";
+    ECF_NAME_THIS_TEST();
 
     Defs defs;
     suite_ptr s   = defs.add_suite("suite");
@@ -1131,7 +1134,7 @@ void add_sorted_attributes(Node* node) {
 }
 
 BOOST_AUTO_TEST_CASE(test_alter_sort_attributes) {
-    cout << "Base:: ...test_alter_sort_attributes\n";
+    ECF_NAME_THIS_TEST();
 
     Defs defs;
     defs.set_server().add_or_update_user_variables("z", "z");
@@ -1171,7 +1174,7 @@ BOOST_AUTO_TEST_CASE(test_alter_sort_attributes) {
 }
 
 BOOST_AUTO_TEST_CASE(test_alter_sort_attributes_for_task) {
-    cout << "Base:: ...test_alter_sort_attributes_for_task\n";
+    ECF_NAME_THIS_TEST();
 
     Defs defs;
     suite_ptr s = defs.add_suite("suite");
@@ -1202,7 +1205,7 @@ BOOST_AUTO_TEST_CASE(test_alter_sort_attributes_for_task) {
 }
 
 BOOST_AUTO_TEST_CASE(test_alter_cmd_errors) {
-    cout << "Base:: ...test_alter_cmd_errors\n";
+    ECF_NAME_THIS_TEST();
 
     Defs defs;
     suite_ptr s = defs.add_suite("suite");

--- a/libs/base/test/TestArchiveAndRestoreCmd.cpp
+++ b/libs/base/test/TestArchiveAndRestoreCmd.cpp
@@ -11,6 +11,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/user/BeginCmd.hpp"
 #include "ecflow/base/cts/user/DeleteCmd.hpp"
 #include "ecflow/base/cts/user/PathsCmd.hpp"
@@ -37,7 +38,7 @@ BOOST_AUTO_TEST_CASE(test_add_log4) {
 }
 
 BOOST_AUTO_TEST_CASE(test_archive_and_restore_suite) {
-    cout << "Base:: ...test_archive_and_restore_suite\n";
+    ECF_NAME_THIS_TEST();
 
     // Please note: after archive we delete the children, hence any references to child refer to a different object
 
@@ -84,7 +85,7 @@ BOOST_AUTO_TEST_CASE(test_archive_and_restore_suite) {
 }
 
 BOOST_AUTO_TEST_CASE(test_archive_and_restore_family) {
-    cout << "Base:: ...test_archive_and_restore_family\n";
+    ECF_NAME_THIS_TEST();
 
     // Create the defs file corresponding to the text below
     // suite suite
@@ -130,7 +131,7 @@ BOOST_AUTO_TEST_CASE(test_archive_and_restore_family) {
 }
 
 BOOST_AUTO_TEST_CASE(test_archive_and_restore_all) {
-    cout << "Base:: ...test_archive_and_restore_all\n";
+    ECF_NAME_THIS_TEST();
 
     // Create the defs file corresponding to the text below
     // suite suite
@@ -233,7 +234,7 @@ BOOST_AUTO_TEST_CASE(test_archive_and_restore_all) {
 }
 
 BOOST_AUTO_TEST_CASE(test_archive_and_restore_overlap) {
-    cout << "Base:: ...test_archive_and_restore_overlap\n";
+    ECF_NAME_THIS_TEST();
 
     // Create the defs file corresponding to the text below
     // suite suite
@@ -276,7 +277,7 @@ BOOST_AUTO_TEST_CASE(test_archive_and_restore_overlap) {
 }
 
 BOOST_AUTO_TEST_CASE(test_archive_and_delete_suite) {
-    cout << "Base:: ...test_archive_and_delete_suite\n";
+    ECF_NAME_THIS_TEST();
 
     // Create the defs file corresponding to the text below
     // suite suite
@@ -315,7 +316,7 @@ BOOST_AUTO_TEST_CASE(test_archive_and_delete_suite) {
 }
 
 BOOST_AUTO_TEST_CASE(test_archive_and_restore_errors) {
-    cout << "Base:: ...test_archive_and_restore_errors\n";
+    ECF_NAME_THIS_TEST();
 
     // Create the defs file corresponding to the text below
     // suite suite

--- a/libs/base/test/TestClientHandleCmd.cpp
+++ b/libs/base/test/TestClientHandleCmd.cpp
@@ -11,6 +11,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/user/ClientHandleCmd.hpp"
 #include "ecflow/base/cts/user/OrderNodeCmd.hpp"
 #include "ecflow/core/Converter.hpp"
@@ -33,7 +34,7 @@ BOOST_AUTO_TEST_CASE(test_add_log3) {
 }
 
 BOOST_AUTO_TEST_CASE(test_client_handle_cmd_empty_server) {
-    cout << "Base:: ...test_client_handle_cmd_empty_server\n";
+    ECF_NAME_THIS_TEST();
 
     std::vector<std::string> suite_names;
     suite_names.reserve(5);
@@ -87,7 +88,7 @@ BOOST_AUTO_TEST_CASE(test_client_handle_cmd_empty_server) {
 }
 
 BOOST_AUTO_TEST_CASE(test_client_handle_cmd_register_and_drop) {
-    cout << "Base:: ...test_client_handle_cmd_register_and_drop\n";
+    ECF_NAME_THIS_TEST();
 
     std::vector<std::string> suite_names;
     suite_names.reserve(6);
@@ -120,7 +121,7 @@ BOOST_AUTO_TEST_CASE(test_client_handle_cmd_register_and_drop) {
 }
 
 BOOST_AUTO_TEST_CASE(test_client_handle_cmd_register__with_drop) {
-    cout << "Base:: ...test_client_handle_cmd_register_with_drop\n";
+    ECF_NAME_THIS_TEST();
 
     std::vector<std::string> suite_names;
     suite_names.reserve(6);
@@ -164,7 +165,7 @@ BOOST_AUTO_TEST_CASE(test_client_handle_cmd_register__with_drop) {
 }
 
 BOOST_AUTO_TEST_CASE(test_client_handle_cmd_auto_add) {
-    cout << "Base:: ...test_client_handle_cmd_auto_add\n";
+    ECF_NAME_THIS_TEST();
 
     std::vector<std::string> suite_names;
     suite_names.reserve(6);
@@ -222,7 +223,7 @@ BOOST_AUTO_TEST_CASE(test_client_handle_cmd_auto_add) {
 }
 
 BOOST_AUTO_TEST_CASE(test_client_handle_cmd_add_remove) {
-    cout << "Base:: ...test_client_handle_cmd_add_remove\n";
+    ECF_NAME_THIS_TEST();
 
     std::vector<std::string> suite_names;
     suite_names.reserve(6);
@@ -312,7 +313,7 @@ static bool check_ordering(Defs& defs) {
 }
 
 BOOST_AUTO_TEST_CASE(test_client_handle_suite_ordering) {
-    cout << "Base:: ...test_client_handle_suite_ordering\n";
+    ECF_NAME_THIS_TEST();
     // ensure order of suites in a handle is the same as server suites
 
     std::vector<std::string> suite_names;

--- a/libs/base/test/TestCmd.cpp
+++ b/libs/base/test/TestCmd.cpp
@@ -14,6 +14,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/task/AbortCmd.hpp"
 #include "ecflow/base/cts/user/BeginCmd.hpp"
 #include "ecflow/base/cts/user/CtsCmd.hpp"
@@ -33,7 +34,8 @@ BOOST_AUTO_TEST_SUITE(U_Base)
 BOOST_AUTO_TEST_SUITE(T_Cmd)
 
 BOOST_AUTO_TEST_CASE(test_simple_cmd) {
-    cout << "Base:: ...test_simple_cmd\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_simple_cmd.log"); // will create log file, and destroy log and remove file at end of scope
 
     // Create the defs file. Note that the default ECF_TRIES = 3

--- a/libs/base/test/TestDeleteNodeCmd.cpp
+++ b/libs/base/test/TestDeleteNodeCmd.cpp
@@ -12,6 +12,7 @@
 
 #include "MockServer.hpp"
 #include "MyDefsFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/user/DeleteCmd.hpp"
 #include "ecflow/base/cts/user/PathsCmd.hpp"
 #include "ecflow/base/stc/ServerToClientCmd.hpp"
@@ -25,7 +26,8 @@ BOOST_AUTO_TEST_SUITE(U_Base)
 BOOST_AUTO_TEST_SUITE(T_DeleteNodeCmd)
 
 BOOST_AUTO_TEST_CASE(test_delete_node_cmd) {
-    cout << "Base:: ...test_delete_node_cmd\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log(
         "test_delete_node_cmd.log"); // will create log file, and destroy log and remove file at end of scope
 
@@ -185,7 +187,7 @@ BOOST_AUTO_TEST_CASE(test_delete_node_cmd) {
 }
 
 BOOST_AUTO_TEST_CASE(test_delete_node_edit_history_ECFLOW_1684) {
-    cout << "Base:: ...test_delete_node_edit_history_ECFLOW_1684\n";
+    ECF_NAME_THIS_TEST();
 
     // This test will ensure that if a suite/family node is deleted, we *remove* any *OLD* edit history associated
     // with the node, AND and of its children

--- a/libs/base/test/TestForceCmd.cpp
+++ b/libs/base/test/TestForceCmd.cpp
@@ -15,6 +15,7 @@
 #include "MockServer.hpp"
 #include "MyDefsFixture.hpp"
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/user/BeginCmd.hpp"
 #include "ecflow/base/cts/user/ForceCmd.hpp"
 #include "ecflow/base/cts/user/RequeueNodeCmd.hpp"
@@ -48,7 +49,7 @@ BOOST_AUTO_TEST_CASE(test_add_log2) {
 }
 
 BOOST_AUTO_TEST_CASE(test_force_cmd) {
-    cout << "Base:: ...test_force_cmd\n";
+    ECF_NAME_THIS_TEST();
 
     defs_ptr the_defs = create_defs();
     the_defs->beginAll();
@@ -149,7 +150,7 @@ doForce(MockServer& mockServer, Node* fnode, const std::string& stateOrEvent, co
 }
 
 BOOST_AUTO_TEST_CASE(test_force_cmd_recursive) {
-    cout << "Base:: ...test_force_cmd_recursive\n";
+    ECF_NAME_THIS_TEST();
 
     defs_ptr the_defs = create_defs();
     node_ptr suite    = the_defs->findAbsNode("/s1");
@@ -164,7 +165,7 @@ BOOST_AUTO_TEST_CASE(test_force_cmd_recursive) {
 }
 
 BOOST_AUTO_TEST_CASE(test_force_cmd_bubbles_up_state_changes) {
-    cout << "Base:: ...test_force_cmd_bubbles_up_state_changes\n";
+    ECF_NAME_THIS_TEST();
 
     defs_ptr the_defs = create_defs();
     std::vector<Node*> nodes;
@@ -198,7 +199,7 @@ BOOST_AUTO_TEST_CASE(test_force_cmd_bubbles_up_state_changes) {
 }
 
 BOOST_AUTO_TEST_CASE(test_force_cmd_alias_does_not_bubble_up_state_changes) {
-    cout << "Base:: ...test_force_cmd_alias_does_not_bubble_up_state_changes\n";
+    ECF_NAME_THIS_TEST();
 
     defs_ptr the_defs = create_defs();
     std::vector<Node*> nodes;
@@ -230,7 +231,7 @@ BOOST_AUTO_TEST_CASE(test_force_cmd_alias_does_not_bubble_up_state_changes) {
 }
 
 BOOST_AUTO_TEST_CASE(test_force_events) {
-    cout << "Base:: ...test_force_events\n";
+    ECF_NAME_THIS_TEST();
 
     MyDefsFixture fixtureDef;
     MockServer mockServer(&fixtureDef.defsfile_);
@@ -268,7 +269,7 @@ BOOST_AUTO_TEST_CASE(test_force_events) {
 }
 
 BOOST_AUTO_TEST_CASE(test_force_events_errors) {
-    cout << "Base:: ...test_force_events_errors\n";
+    ECF_NAME_THIS_TEST();
 
     MyDefsFixture fixtureDef;
     MockServer mockServer(&fixtureDef.defsfile_);
@@ -341,7 +342,7 @@ BOOST_AUTO_TEST_CASE(test_force_interactive) {
     // this functionality. What we want is that task is set to complete, without
     // forcing a re-queue, this is then propagated up the node tree. Which forces the
     // family to complete, and hence update the repeat variable.
-    cout << "Base:: ...test_force_interactive\n";
+    ECF_NAME_THIS_TEST();
 
     //   suite s1
     //     family daily
@@ -429,7 +430,7 @@ BOOST_AUTO_TEST_CASE(test_force_interactive_next_time_slot) {
     // This test is custom. When the user interactively forces a node to the complete state,
     // But where the user has a single time slot. We should stay complete and NOT requee
     //
-    cout << "Base:: ...test_force_interactive_next_time_slot\n";
+    ECF_NAME_THIS_TEST();
 
     //   suite s1
     //       task t1
@@ -498,7 +499,7 @@ BOOST_AUTO_TEST_CASE(test_force_interactive_next_time_slot_1) {
     // end of the time slot. In which case the node should *not* re-queue and stay complete
     //
     // When the node is then re-queued check that the time has been correctly reset.
-    cout << "Base:: ...test_force_interactive_next_time_slot_1\n";
+    ECF_NAME_THIS_TEST();
 
     //   suite s1
     //       task t1
@@ -622,7 +623,7 @@ BOOST_AUTO_TEST_CASE(test_force_interactive_next_time_slot_2) {
     // end of the time slot. In which case the node should *not* reque and stay complete
     //
     // When the node is then requeed check that the next time slot has been correctly reset.
-    cout << "Base:: ...test_force_interactive_next_time_slot_2\n";
+    ECF_NAME_THIS_TEST();
 
     //   suite s1
     //       task t1
@@ -722,7 +723,7 @@ BOOST_AUTO_TEST_CASE(test_force_interactive_next_time_slot_3) {
     // end of the time slot. In which case the node should *not* re-queue and stay complete
     //
     // When the node is then re-queued check that the time has been correctly reset.
-    cout << "Base:: ...test_force_interactive_next_time_slot_3\n";
+    ECF_NAME_THIS_TEST();
 
     //   suite s1
     //       task t1
@@ -833,7 +834,7 @@ BOOST_AUTO_TEST_CASE(test_force_interactive_next_time_slot_4) {
     // end of the time slot. In which case the node should *not* reque and stay complete
     //
     // When the node is then requeed check that the next time slot has been correctly reset.
-    cout << "Base:: ...test_force_interactive_next_time_slot_4\n";
+    ECF_NAME_THIS_TEST();
 
     //   suite s1
     //       task t1
@@ -923,7 +924,7 @@ BOOST_AUTO_TEST_CASE(test_force_interactive_next_time_slot_for_cron) {
     // end of the time slot.
     //
     // When the node is then requeed check that the next time slot has been correctly reset.
-    cout << "Base:: ...test_force_interactive_next_time_slot_for_cron\n";
+    ECF_NAME_THIS_TEST();
 
     //   suite s1
     //       task t1
@@ -1016,7 +1017,7 @@ BOOST_AUTO_TEST_CASE(test_force_interactive_next_time_slot_for_cron_on_family) {
     // end of the time slot.
     //
     // When the node is then requeed check that the next time slot has been correctly reset.
-    cout << "Base:: ...test_force_interactive_next_time_slot_for_cron_on_family\n";
+    ECF_NAME_THIS_TEST();
 
     //   suite s1
     //     family

--- a/libs/base/test/TestFreeDepCmd.cpp
+++ b/libs/base/test/TestFreeDepCmd.cpp
@@ -13,6 +13,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "MockServer.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/user/FreeDepCmd.hpp"
 #include "ecflow/base/stc/ServerToClientCmd.hpp"
 #include "ecflow/node/Defs.hpp"
@@ -31,7 +32,8 @@ BOOST_AUTO_TEST_SUITE(U_Base)
 BOOST_AUTO_TEST_SUITE(T_FreeDepCmd)
 
 BOOST_AUTO_TEST_CASE(test_free_dep_cmd) {
-    cout << "Base:: ...test_free_dep_cmd\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_free_dep_cmd.log"); // will create log file, and destroy log and remove file at end of scope
 
     // Create a test and add the date and time dependencies
@@ -163,7 +165,8 @@ BOOST_AUTO_TEST_CASE(test_free_dep_cmd) {
 }
 
 BOOST_AUTO_TEST_CASE(test_free_dep_cmd_single_time_slot) {
-    cout << "Base:: ...test_free_dep_cmd_single_time_slot\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_free_dep_cmd_single_time_slot.log"); // will create log file, and destroy log and remove file
                                                                 // at end of scope
 
@@ -221,7 +224,8 @@ BOOST_AUTO_TEST_CASE(test_free_dep_cmd_single_time_slot) {
 }
 
 BOOST_AUTO_TEST_CASE(test_free_dep_cmd_with_time_series) {
-    cout << "Base:: ...test_free_dep_cmd_with_time_series\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_free_dep_cmd_with_time_series.log"); // will create log file, and destroy log and remove file
                                                                 // at end of scope
 
@@ -280,7 +284,8 @@ BOOST_AUTO_TEST_CASE(test_free_dep_cmd_with_time_series) {
 }
 
 BOOST_AUTO_TEST_CASE(test_free_dep_cmd_with_time_series_2) {
-    cout << "Base:: ...test_free_dep_cmd_with_time_series_2\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_free_dep_cmd_with_time_series_2.log"); // will create log file, and destroy log and remove
                                                                   // file at end of scope
 

--- a/libs/base/test/TestInLimitAndLimit.cpp
+++ b/libs/base/test/TestInLimitAndLimit.cpp
@@ -15,6 +15,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/user/BeginCmd.hpp"
 #include "ecflow/base/cts/user/ForceCmd.hpp"
 #include "ecflow/base/cts/user/RequeueNodeCmd.hpp"
@@ -42,7 +43,8 @@ BOOST_AUTO_TEST_CASE(test_add_log) {
 }
 
 BOOST_AUTO_TEST_CASE(test_add_limit) {
-    cout << "Base:: ...test_add_limit\n";
+    ECF_NAME_THIS_TEST();
+
     suite_ptr suite = Suite::create("suite");
     suite->addLimit(Limit("fast", 1)); // " Adding limit first time should be ok");
     BOOST_REQUIRE_THROW(suite->addLimit(Limit("fast", 1)),
@@ -59,7 +61,7 @@ BOOST_AUTO_TEST_CASE(test_add_limit) {
 }
 
 BOOST_AUTO_TEST_CASE(test_limit_increment) {
-    cout << "Base:: ...test_limit_increment\n";
+    ECF_NAME_THIS_TEST();
 
     // Test than when a job is submitted multiple times, it should only consume 1 token
     //
@@ -146,7 +148,7 @@ BOOST_AUTO_TEST_CASE(test_limit_increment) {
 // This TEST is used to test limit and inLimit.
 // Both examples taken from the documentation
 BOOST_AUTO_TEST_CASE(test_limit) {
-    cout << "Base:: ...test_limit\n";
+    ECF_NAME_THIS_TEST();
 
     ///////////////////////////////////////////////////////////////////////////
     // Create the defs file
@@ -226,7 +228,8 @@ BOOST_AUTO_TEST_CASE(test_limit) {
 }
 
 BOOST_AUTO_TEST_CASE(test_limit1) {
-    cout << "Base:: ...test_limit1\n";
+    ECF_NAME_THIS_TEST();
+
     ////////////////////////////////////////////////////////////////////////////////////////////////////
     // Create the defs file
     //	suite suite
@@ -319,7 +322,7 @@ BOOST_AUTO_TEST_CASE(test_limit_references_after_delete) {
     /// In-limit have a reference to a limit. This limit can be on another node. If that node is deleted
     /// The limits are also deleted, hence we need to ensure in-limit reference to limits that are being
     /// deleted are cleared. Currently we use shared_ptr to achieve this
-    cout << "Base:: ...test_limit_references_after_delete\n";
+    ECF_NAME_THIS_TEST();
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////
     //  Create the defs file
@@ -415,7 +418,7 @@ BOOST_AUTO_TEST_CASE(test_limit_references_after_delete) {
 }
 
 BOOST_AUTO_TEST_CASE(test_limits_after_force_cmd) {
-    cout << "Base:: ...test_limits_after_force_cmd\n";
+    ECF_NAME_THIS_TEST();
 
     // Create the following defs
     // suite s1
@@ -528,7 +531,7 @@ BOOST_AUTO_TEST_CASE(test_limits_after_force_cmd) {
 }
 
 BOOST_AUTO_TEST_CASE(test_limits_after_requeue_family_ECFLOW_196) {
-    cout << "Base:: ...test_limits_after_requeue_family_ECFLOW_196\n";
+    ECF_NAME_THIS_TEST();
 
     // This test is used to ensure that, requeue causes node to release tokens held by the Limits
 
@@ -648,7 +651,7 @@ BOOST_AUTO_TEST_CASE(test_limits_after_requeue_family_ECFLOW_196) {
 }
 
 BOOST_AUTO_TEST_CASE(test_limits_after_requeue_task_ECFLOW_196) {
-    cout << "Base:: ...test_limits_after_requeue_task_ECFLOW_196\n";
+    ECF_NAME_THIS_TEST();
 
     // This test is used to ensure that, requeue causes node to release tokens held by the Limits
 
@@ -766,7 +769,7 @@ BOOST_AUTO_TEST_CASE(test_limits_after_requeue_task_ECFLOW_196) {
 }
 
 BOOST_AUTO_TEST_CASE(test_inlimit_with_family_ECFLOW_878) {
-    cout << "Base:: ...test_inlimit_with_family_ECFLOW_878\n";
+    ECF_NAME_THIS_TEST();
 
     // This test places a limit on the families. Should ignore the tasks
     // With this test only 1 family can start at a time
@@ -988,7 +991,7 @@ BOOST_AUTO_TEST_CASE(test_inlimit_with_family_ECFLOW_878) {
 }
 
 BOOST_AUTO_TEST_CASE(test_inlimit_ECFLOW_878) {
-    cout << "Base:: ...test_inlimit_ECFLOW_878\n";
+    ECF_NAME_THIS_TEST();
 
     // This test places a limit on the families. Should ignore the tasks
     // With this test only 1 family can start at a time.
@@ -1188,7 +1191,7 @@ BOOST_AUTO_TEST_CASE(test_inlimit_ECFLOW_878) {
 }
 
 BOOST_AUTO_TEST_CASE(test_inlimit_submission_only) {
-    cout << "Base:: ...test_inlimit_submission_only \n";
+    ECF_NAME_THIS_TEST();
 
     // Create the following def. with inlimit -s, we limit submission
     // suite s0

--- a/libs/base/test/TestLogCmd.cpp
+++ b/libs/base/test/TestLogCmd.cpp
@@ -11,6 +11,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/user/LogCmd.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/Log.hpp"
@@ -26,7 +27,7 @@ BOOST_AUTO_TEST_SUITE(U_Base)
 BOOST_AUTO_TEST_SUITE(T_LogCmd)
 
 BOOST_AUTO_TEST_CASE(test_log_cmd) {
-    cout << "Base:: ...test_log_cmd\n";
+    ECF_NAME_THIS_TEST();
 
     {
         LogCmd log_cmd;

--- a/libs/base/test/TestMeterCmd.cpp
+++ b/libs/base/test/TestMeterCmd.cpp
@@ -14,6 +14,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/task/MeterCmd.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
@@ -29,7 +30,8 @@ BOOST_AUTO_TEST_SUITE(U_Base)
 BOOST_AUTO_TEST_SUITE(T_MeterCmd)
 
 BOOST_AUTO_TEST_CASE(test_meter_cmd) {
-    cout << "Base:: ...test_meter_cmd\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_meter_cmd.log"); // will create log file, and destroy log and remove file at end of scope
 
     // Create the defs file.

--- a/libs/base/test/TestProgramOptions.cpp
+++ b/libs/base/test/TestProgramOptions.cpp
@@ -14,6 +14,8 @@
 #include <boost/program_options.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
+
 using namespace std;
 namespace po = boost::program_options;
 
@@ -22,7 +24,7 @@ BOOST_AUTO_TEST_SUITE(U_Base)
 BOOST_AUTO_TEST_SUITE(T_ProgramOptions)
 
 BOOST_AUTO_TEST_CASE(test_program_options_implicit_value) {
-    cout << "Base:: ...test_program_options_implicit_value\n";
+    ECF_NAME_THIS_TEST();
 
     // Declare the supported options.
     po::options_description desc("Allowed options");
@@ -85,7 +87,7 @@ BOOST_AUTO_TEST_CASE(test_program_options_implicit_value) {
 }
 
 BOOST_AUTO_TEST_CASE(test_program_options_multitoken) {
-    cout << "Base:: ...test_program_options_multitoken\n";
+    ECF_NAME_THIS_TEST();
 
     // Declare the supported options.
     po::options_description desc("Allowed options");
@@ -112,7 +114,7 @@ BOOST_AUTO_TEST_CASE(test_program_options_multitoken) {
 }
 
 BOOST_AUTO_TEST_CASE(test_program_options_multitoken_with_negative_values) {
-    cout << "Base:: ...test_program_options_multitoken_with_negative_values\n";
+    ECF_NAME_THIS_TEST();
 
     // Declare the supported options.
     po::options_description desc("Allowed options");

--- a/libs/base/test/TestQueryCmd.cpp
+++ b/libs/base/test/TestQueryCmd.cpp
@@ -13,6 +13,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/task/LabelCmd.hpp"
 #include "ecflow/base/cts/user/PathsCmd.hpp"
 #include "ecflow/base/cts/user/QueryCmd.hpp"
@@ -31,7 +32,8 @@ BOOST_AUTO_TEST_SUITE(U_Base)
 BOOST_AUTO_TEST_SUITE(T_QueryCmd)
 
 BOOST_AUTO_TEST_CASE(test_query_cmd) {
-    cout << "Base:: ...test_query_cmd\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_query_cmd.log"); // will create log file, and destroy log and remove file at end of scope
 
     // Create the defs file.

--- a/libs/base/test/TestQueueCmd.cpp
+++ b/libs/base/test/TestQueueCmd.cpp
@@ -14,6 +14,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/QueueAttr.hpp"
 #include "ecflow/base/cts/task/QueueCmd.hpp"
 #include "ecflow/node/Defs.hpp"
@@ -30,7 +31,8 @@ BOOST_AUTO_TEST_SUITE(U_Base)
 BOOST_AUTO_TEST_SUITE(T_QueueCmd)
 
 BOOST_AUTO_TEST_CASE(test_queue_cmd) {
-    cout << "Base:: ...test_queue_cmd\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_queue_cmd.log"); // will create log file, and destroy log and remove file at end of scope
 
     // Create the defs file.

--- a/libs/base/test/TestRequest.cpp
+++ b/libs/base/test/TestRequest.cpp
@@ -12,6 +12,7 @@
 
 #include "MyDefsFixture.hpp"
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/ServerToClientResponse.hpp"
 #include "ecflow/base/cts/task/AbortCmd.hpp"
 #include "ecflow/base/cts/task/CompleteCmd.hpp"
@@ -442,7 +443,8 @@ static void test_persistence(const Defs& theFixtureDefs) {
 }
 
 BOOST_AUTO_TEST_CASE(test_all_request_persistence_text) {
-    cout << "Base:: ...test_all_request_persistence_text\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_all_request_persistence_text.log"); // will create log file, and destroy log and remove file
                                                                // at end of scope
 
@@ -450,7 +452,8 @@ BOOST_AUTO_TEST_CASE(test_all_request_persistence_text) {
 }
 
 BOOST_AUTO_TEST_CASE(test_request_authenticate) {
-    cout << "Base:: ...test_request_authenticate\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log(
         "test_request_authenticate.log"); // will create log file, and destroy log and remove file at end of scope
 

--- a/libs/base/test/TestRequeueNodeCmd.cpp
+++ b/libs/base/test/TestRequeueNodeCmd.cpp
@@ -11,6 +11,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/user/AlterCmd.hpp"
 #include "ecflow/base/cts/user/ForceCmd.hpp"
 #include "ecflow/base/cts/user/PathsCmd.hpp"
@@ -33,7 +34,8 @@ BOOST_AUTO_TEST_SUITE(U_Base)
 BOOST_AUTO_TEST_SUITE(T_RequeueNodeCmd)
 
 BOOST_AUTO_TEST_CASE(test_requeue_with_suspend) {
-    cout << "Base:: ...test_requeue_with_suspend\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log(
         "test_requeue_with_suspend.log"); // will create log file, and destroy log and remove file at end of scope
 
@@ -75,7 +77,8 @@ BOOST_AUTO_TEST_CASE(test_requeue_with_suspend) {
 }
 
 BOOST_AUTO_TEST_CASE(test_requeue_family_clears_children_SUP_909) {
-    cout << "Base:: ...test_requeue_family_clears_children_SUP_909\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_requeue_family_clears_children_SUP_909.log"); // will create log file, and destroy log and
                                                                          // remove file at end of scope
 
@@ -121,7 +124,8 @@ BOOST_AUTO_TEST_CASE(test_requeue_family_clears_children_SUP_909) {
 }
 
 BOOST_AUTO_TEST_CASE(test_repeat_based_requeue_clears_children) {
-    cout << "Base:: ...test_repeat_based_requeue_clears_children\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_repeat_based_requeue_clears_children.log"); // will create log file, and destroy log and
                                                                        // remove file at end of scope
 
@@ -165,7 +169,8 @@ BOOST_AUTO_TEST_CASE(test_repeat_based_requeue_clears_children) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecflow_359) {
-    cout << "Base:: ...test_ECFLOW-359\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_ecflow_359.log"); // will create log file, and destroy log and remove file at end of scope
 
     //   suite s1
@@ -225,7 +230,8 @@ BOOST_AUTO_TEST_CASE(test_ecflow_359) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecflow_428) {
-    cout << "Base:: ...test_ECFLOW-428\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_ecflow_428.log"); // will create log file, and destroy log and remove file at end of scope
 
     //   suite s1
@@ -272,7 +278,8 @@ BOOST_AUTO_TEST_CASE(test_ecflow_428) {
 }
 
 BOOST_AUTO_TEST_CASE(test_repeat_based_requeue_resets_relative_duration) {
-    cout << "Base:: ...test_repeat_based_requeue_resets_relative_duration\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_repeat_based_requeue_resets_relative_duration.log"); // will create log file, and destroy log
                                                                                 // and remove file at end of scope
 
@@ -320,7 +327,7 @@ BOOST_AUTO_TEST_CASE(test_repeat_based_requeue_resets_relative_duration) {
 }
 
 BOOST_AUTO_TEST_CASE(test_reque_with_repeat_and_defstatus_complete) {
-    cout << "Base:: ...test_reque_with_repeat_and_defstatus_complete\n";
+    ECF_NAME_THIS_TEST();
 
     // This will test that when we have a family with a repeat AND defstatus complete
     // We ONLY log the state change complete in the log file when re-queuing

--- a/libs/base/test/TestResolveDependencies.cpp
+++ b/libs/base/test/TestResolveDependencies.cpp
@@ -13,6 +13,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/task/MeterCmd.hpp"
 #include "ecflow/base/cts/user/BeginCmd.hpp"
 #include "ecflow/base/cts/user/CtsCmd.hpp"
@@ -33,7 +34,8 @@ BOOST_AUTO_TEST_SUITE(U_Base)
 BOOST_AUTO_TEST_SUITE(T_ResolveDependencies)
 
 BOOST_AUTO_TEST_CASE(test_resolve_dependencies) {
-    cout << "Base:: ...test_resolve_dependencies\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log(
         "test_resolve_dependencies.log"); // will create log file, and destroy log and remove file at end of scope
 
@@ -154,7 +156,8 @@ BOOST_AUTO_TEST_CASE(test_resolve_dependencies) {
 }
 
 BOOST_AUTO_TEST_CASE(test_trigger_after_delete) {
-    cout << "Base:: ...test_trigger_after_delete\n";
+    ECF_NAME_THIS_TEST();
+
     ////////////////////////////////////////////////////////////////////////////////////////////////////
     // Create the defs file
     //   suite suite1    # the limit we want delete

--- a/libs/base/test/TestSSyncCmd.cpp
+++ b/libs/base/test/TestSSyncCmd.cpp
@@ -13,6 +13,7 @@
 #include "MockServer.hpp"
 #include "MyDefsFixture.hpp"
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/user/AlterCmd.hpp"
 #include "ecflow/base/cts/user/DeleteCmd.hpp"
 #include "ecflow/base/cts/user/OrderNodeCmd.hpp"
@@ -438,7 +439,8 @@ void set_defs_state(defs_ptr defs) {
 
 BOOST_AUTO_TEST_CASE(test_ssync_cmd) {
     // To DEBUG: enable the defines in Memento.hpp
-    cout << "Base:: ...test_ssync_cmd\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_ssync_cmd.log"); // will create log file, and destroy log and remove file at end of scope
 
     test_sync_scaffold(update_repeat, "update_repeat");

--- a/libs/base/test/TestSSyncCmdOrder.cpp
+++ b/libs/base/test/TestSSyncCmdOrder.cpp
@@ -12,6 +12,7 @@
 
 #include "MockServer.hpp"
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/user/ClientHandleCmd.hpp"
 #include "ecflow/base/cts/user/OrderNodeCmd.hpp"
 #include "ecflow/base/stc/SSyncCmd.hpp"
@@ -231,7 +232,8 @@ static void reorder_family_using_handles(defs_ptr theDefs) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ssync_cmd_test_order) {
-    cout << "Base:: ...test_ssync_cmd_test_order\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log(
         "test_ssync_cmd_test_order.log"); // will create log file, and destroy log and remove file at end of scope
 

--- a/libs/base/test/TestSSyncCmd_CH1.cpp
+++ b/libs/base/test/TestSSyncCmd_CH1.cpp
@@ -12,6 +12,7 @@
 
 #include "MockServer.hpp"
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/user/AlterCmd.hpp"
 #include "ecflow/base/cts/user/ClientHandleCmd.hpp"
 #include "ecflow/base/stc/SNewsCmd.hpp"
@@ -525,7 +526,8 @@ static bool s0_update_repeat(defs_ptr defs) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ssync_using_handle) {
-    cout << "Base:: ...test_ssync_using_handle\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log(
         "test_ssync_using_handle.log"); // will create log file, and destroy log and remove file at end of scope
 
@@ -604,7 +606,8 @@ BOOST_AUTO_TEST_CASE(test_ssync_full_sync_using_handle) {
     /// local change numbers to be the same as the global change numbers
     /// This is important since the NewsCmd must be in *SYNC* with SYNCCmd
 
-    cout << "Base:: ...test_ssync_full_sync_using_handle\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_ssync_full_sync_using_handle.log"); // will create log file, and destroy log and remove file
                                                                // at end of scope
 
@@ -618,10 +621,9 @@ BOOST_AUTO_TEST_CASE(test_ssync_full_sync_using_handle) {
     // Server & client should be the same, since we ignore change numbers in the comparison
     DebugEquality debug_equality; // only as affect in DEBUG build
     BOOST_CHECK_MESSAGE(*server_defs == *server_reply.client_defs(),
-                        "Starting point client and server defs should be the same"
-                            << "SERVER\n"
-                            << server_defs << "CLIENT\n"
-                            << server_reply.client_defs());
+                        "Starting point client and server defs should be the same" << "SERVER\n"
+                                                                                   << server_defs << "CLIENT\n"
+                                                                                   << server_reply.client_defs());
 
     /// register interest in **ALL** the suites
     std::vector<std::string> suite_names;

--- a/libs/base/test/TestSpecificIssues.cpp
+++ b/libs/base/test/TestSpecificIssues.cpp
@@ -11,6 +11,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/user/PathsCmd.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
@@ -50,7 +51,8 @@ static defs_ptr create_defs() {
 }
 
 BOOST_AUTO_TEST_CASE(test_ECFLOW_189) {
-    cout << "Base:: ...test_ECFLOW_189\n";
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_ECFLOW_189.log"); // will create log file, and destroy log and remove file at end of scope
 
     defs_ptr the_defs = create_defs();

--- a/libs/base/test/TestStatsCmd.cpp
+++ b/libs/base/test/TestStatsCmd.cpp
@@ -12,6 +12,7 @@
 
 #include "MockServer.hpp"
 #include "MyDefsFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/ClientToServerRequest.hpp"
 #include "ecflow/base/cts/user/CtsCmd.hpp"
 #include "ecflow/base/stc/ServerToClientCmd.hpp"

--- a/libs/client/CMakeLists.txt
+++ b/libs/client/CMakeLists.txt
@@ -104,6 +104,7 @@ ecbuild_add_test(
     Boost::boost # Boost header-only libraries must be available (namely unit_test_framework)
     Boost::timer
     $<$<BOOL:${OPENSSL_FOUND}>:OpenSSL::SSL>
+    test_support
   DEPENDS
     ecflow_server # the server is launched to support tests
   TEST_DEPENDS
@@ -138,6 +139,7 @@ if (ENABLE_ALL_TESTS AND ENABLE_SERVER)
       ecflow_all
       Boost::boost # Boost header-only libraries must be available (namely unit_test_framework)
       $<$<BOOL:${OPENSSL_FOUND}>:OpenSSL::SSL>
+      test_support
     DEPENDS
       ecflow_server # the server is launched to support tests
     TEST_DEPENDS
@@ -169,6 +171,7 @@ if (ENABLE_ALL_TESTS AND ENABLE_SERVER)
       ecflow_all
       Boost::boost # Boost header-only libraries must be available (namely unit_test_framework)
       $<$<BOOL:${OPENSSL_FOUND}>:OpenSSL::SSL>
+      test_support
     DEPENDS
       ecflow_server # the server is launched to support tests
     TEST_DEPENDS

--- a/libs/client/test/TestCheckPtDefsCmd.cpp
+++ b/libs/client/test/TestCheckPtDefsCmd.cpp
@@ -15,6 +15,7 @@
 #include "InvokeServer.hpp"
 #include "MyDefsFixture.hpp"
 #include "SCPort.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/client/ClientEnvironment.hpp"
 #include "ecflow/client/ClientInvoker.hpp"
 #include "ecflow/core/File.hpp"
@@ -31,6 +32,8 @@ BOOST_AUTO_TEST_SUITE(T_CheckPtDefsCmd)
 // Note: If you make edits to node tree, they will have no effect until the server is rebuilt
 // ************************************************************************************
 BOOST_AUTO_TEST_CASE(test_check_pt_defs_cmd) {
+    ECF_NAME_THIS_TEST();
+
     // This will remove check pt and backup file before server start, to avoid the server from loading previous test
     // data
     InvokeServer invokeServer("Client:: ...test_check_pt_defs_cmd", SCPort::next());
@@ -191,6 +194,8 @@ BOOST_AUTO_TEST_CASE(test_check_pt_defs_cmd) {
 }
 
 BOOST_AUTO_TEST_CASE(test_restore_from_check_pt) {
+    ECF_NAME_THIS_TEST();
+
     InvokeServer invokeServer("Client:: ...test_restore_from_check_pt", SCPort::next());
     BOOST_REQUIRE_MESSAGE(invokeServer.server_started(),
                           "Server failed to start on " << invokeServer.host() << ":" << invokeServer.port());
@@ -230,10 +235,12 @@ BOOST_AUTO_TEST_CASE(test_restore_from_check_pt) {
 }
 
 BOOST_AUTO_TEST_CASE(test_restore_from_check_pt_using_new_server) {
+    ECF_NAME_THIS_TEST();
+
     // This test relies on a NEW server invocation. Hence if ECF_HOST/remote server is used
     // the test will will invalid. hence ignore.
     if (!ClientEnvironment::hostSpecified().empty()) {
-        cout << "Client:: ...test_restore_from_check_pt_using_new_server: ignoring test when ECF_HOST specified\n";
+        cout << "Ignoring test when ECF_HOST specified\n";
         return;
     }
 
@@ -297,10 +304,12 @@ BOOST_AUTO_TEST_CASE(test_restore_from_check_pt_using_new_server) {
 }
 
 BOOST_AUTO_TEST_CASE(test_check_pt_edit_history) {
+    ECF_NAME_THIS_TEST();
+
     // This test relies on a NEW server invocation. Hence if ECF_HOST/remote server is used
     // the test will will invalid. hence ignore.
     if (!ClientEnvironment::hostSpecified().empty()) {
-        cout << "Client:: ...test_check_pt_edit_history: ignoring test when ECF_HOST specified\n";
+        cout << "Ignoring test when ECF_HOST specified\n";
         return;
     }
 

--- a/libs/client/test/TestClientEnvironment.cpp
+++ b/libs/client/test/TestClientEnvironment.cpp
@@ -14,6 +14,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/client/ClientEnvironment.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/Str.hpp"
@@ -30,7 +31,7 @@ BOOST_AUTO_TEST_SUITE(T_ClientEnvironment)
 // In particular test host file parsing
 // **************************************************************************************
 BOOST_AUTO_TEST_CASE(test_client_environment_host_file_parsing) {
-    std::cout << "Client:: ...test_client_environment_host_file_parsing" << endl;
+    ECF_NAME_THIS_TEST();
 
     std::string good_host_file = File::test_data("libs/client/test/data/good_hostfile", "libs/client");
 
@@ -77,7 +78,7 @@ BOOST_AUTO_TEST_CASE(test_client_environment_host_file_parsing) {
 }
 
 BOOST_AUTO_TEST_CASE(test_client_environment_host_file_defaults) {
-    std::cout << "Client:: ...test_client_environment_host_file_defaults" << endl;
+    ECF_NAME_THIS_TEST();
 
     // When the HOST file does *NOT* indicate the port, it should be taken
     // from the config/environment.
@@ -133,7 +134,7 @@ BOOST_AUTO_TEST_CASE(test_client_environment_host_file_defaults) {
 }
 
 BOOST_AUTO_TEST_CASE(test_client_environment_empty_host_file) {
-    std::cout << "Client:: ...test_client_environment_empty_host_file" << endl;
+    ECF_NAME_THIS_TEST();
 
     std::string empty_host_file = File::test_data("libs/client/test/data/empty_hostfile", "libs/client");
 

--- a/libs/client/test/TestClientHandleCmd.cpp
+++ b/libs/client/test/TestClientHandleCmd.cpp
@@ -14,6 +14,7 @@
 
 #include "InvokeServer.hpp"
 #include "SCPort.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/System.hpp"
 
@@ -25,6 +26,8 @@ BOOST_AUTO_TEST_SUITE(S_Client)
 BOOST_AUTO_TEST_SUITE(T_ClientHandleCmd)
 
 BOOST_AUTO_TEST_CASE(test_client_handle_cmd) {
+    ECF_NAME_THIS_TEST();
+
     /// This will remove checkpt and backup , to avoid server from loading it. (i.e from previous test)
     InvokeServer invokeServer("Client:: ...test_client_handle_cmd ", SCPort::next());
     BOOST_REQUIRE_MESSAGE(invokeServer.server_started(),

--- a/libs/client/test/TestClientInterface.cpp
+++ b/libs/client/test/TestClientInterface.cpp
@@ -15,6 +15,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/user/CFileCmd.hpp"
 #include "ecflow/client/ClientInvoker.hpp"
 #include "ecflow/core/Child.hpp"
@@ -37,7 +38,7 @@ BOOST_AUTO_TEST_SUITE(T_ClientInterface)
 // This will test argument parsing.
 // **************************************************************************************
 BOOST_AUTO_TEST_CASE(test_client_interface) {
-    std::cout << "Client:: ...test_client_interface" << endl;
+    ECF_NAME_THIS_TEST();
 
     ClientInvoker theClient;
     theClient.testInterface(); // stops submission to server
@@ -968,7 +969,7 @@ BOOST_AUTO_TEST_CASE(test_client_interface) {
 }
 
 BOOST_AUTO_TEST_CASE(test_client_interface_for_fail) {
-    std::cout << "Client:: ...test_client_interface_for_fail" << endl;
+    ECF_NAME_THIS_TEST();
 
     ClientInvoker theClient;
     theClient.testInterface(); // stops submission to server
@@ -1431,7 +1432,7 @@ BOOST_AUTO_TEST_CASE(test_client_interface_for_fail) {
 }
 
 BOOST_AUTO_TEST_CASE(test_client_task_interface) {
-    std::cout << "Client:: ...test_client_task_interface" << endl;
+    ECF_NAME_THIS_TEST();
 
     ClientInvoker theClient;
     theClient.testInterface(); // stops submission to server
@@ -1496,7 +1497,7 @@ BOOST_AUTO_TEST_CASE(test_client_task_interface) {
 }
 
 BOOST_AUTO_TEST_CASE(test_client_task_interface_for_fail) {
-    std::cout << "Client:: ...test_client_task_interface_for_fail" << endl;
+    ECF_NAME_THIS_TEST();
 
     {
         ClientInvoker theClient;

--- a/libs/client/test/TestClientOptions.cpp
+++ b/libs/client/test/TestClientOptions.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/task/AbortCmd.hpp"
 #include "ecflow/base/cts/task/CompleteCmd.hpp"
 #include "ecflow/base/cts/task/CtsWaitCmd.hpp"
@@ -77,6 +78,8 @@ BOOST_AUTO_TEST_SUITE(T_ClientOptions)
 BOOST_AUTO_TEST_SUITE(T_Generic) // test generic options
 
 BOOST_AUTO_TEST_CASE(test_is_able_to_process_username_and_password) {
+    ECF_NAME_THIS_TEST();
+
     const char* expected_username = "username";
     const char* plain_password    = "password";
     std::string expected_password = PasswordEncryption::encrypt(plain_password, expected_username);
@@ -101,17 +104,17 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(T_Abort) // --abort (AbortCmd)
 
 BOOST_AUTO_TEST_CASE(test_is_able_to_handle_abort) {
+    ECF_NAME_THIS_TEST();
+
     {
         auto cl = CommandLine::make_command_line("ecflow_client", "--abort");
-        test_task_command<AbortCmd>(cl, [&](const auto& command, const ClientEnvironment& env) {
-            BOOST_CHECK_EQUAL(command.reason(), "");
-        });
+        test_task_command<AbortCmd>(
+            cl, [&](const auto& command, const ClientEnvironment& env) { BOOST_CHECK_EQUAL(command.reason(), ""); });
     }
     {
         auto cl = CommandLine::make_command_line("ecflow_client", "--abort=");
-        test_task_command<AbortCmd>(cl, [&](const auto& command, const ClientEnvironment& env) {
-            BOOST_CHECK_EQUAL(command.reason(), "");
-        });
+        test_task_command<AbortCmd>(
+            cl, [&](const auto& command, const ClientEnvironment& env) { BOOST_CHECK_EQUAL(command.reason(), ""); });
     }
     {
         auto cl = CommandLine::make_command_line("ecflow_client", "--abort=somereason");
@@ -163,6 +166,7 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(T_Alter) // --alter (AlterCmd)
 
 BOOST_AUTO_TEST_CASE(test_is_able_handle_alter_change) {
+    ECF_NAME_THIS_TEST();
 
     /*
      * --alter change <type> <name> <value> <path> [<path>...]
@@ -531,6 +535,7 @@ BOOST_AUTO_TEST_CASE(test_is_able_handle_alter_change) {
 }
 
 BOOST_AUTO_TEST_CASE(test_is_able_handle_alter_add) {
+    ECF_NAME_THIS_TEST();
 
     /*
      * --alter add <type> <name> <value> <path> [<path>...]
@@ -592,6 +597,8 @@ BOOST_AUTO_TEST_CASE(test_is_able_handle_alter_add) {
 }
 
 BOOST_AUTO_TEST_CASE(test_is_able_handle_alter_delete) {
+    ECF_NAME_THIS_TEST();
+
     /*
      * --alter delete <type> <name> <path> [<path>...]
      * ************************************************************************************************************** */
@@ -828,6 +835,8 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(T_Begin) // --begin (BeginCmd)
 
 BOOST_AUTO_TEST_CASE(test_is_able_to_handle_begin) {
+    ECF_NAME_THIS_TEST();
+
     using Command = BeginCmd;
     {
         auto cl = CommandLine::make_command_line("ecflow_client", "--begin");
@@ -882,6 +891,8 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(T_Check) // --check (PathsCmd)
 
 BOOST_AUTO_TEST_CASE(test_is_able_to_handle_check) {
+    ECF_NAME_THIS_TEST();
+
     using Command = PathsCmd;
     {
         auto cl = CommandLine::make_command_line("ecflow_client", "--check=_all_");
@@ -945,6 +956,8 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(T_Complete) // --complete (CompleteCmd)
 
 BOOST_AUTO_TEST_CASE(test_is_able_to_handle_complete) {
+    ECF_NAME_THIS_TEST();
+
     using Command = CompleteCmd;
     {
         auto cl = CommandLine::make_command_line("ecflow_client", "--complete");
@@ -974,6 +987,8 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(T_Event) // --event (EventCmd)
 
 BOOST_AUTO_TEST_CASE(test_is_able_to_handle_event) {
+    ECF_NAME_THIS_TEST();
+
     using Command = EventCmd;
     {
         auto cl = CommandLine::make_command_line("ecflow_client", "--event=name");
@@ -1024,6 +1039,8 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(T_Init) // --init (InitCmd)
 
 BOOST_AUTO_TEST_CASE(test_is_able_to_handle_init) {
+    ECF_NAME_THIS_TEST();
+
     using Command = InitCmd;
     {
         auto cl = CommandLine::make_command_line("ecflow_client", "--init=1234");
@@ -1067,6 +1084,8 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(T_Label) // --label (LabelCmd)
 
 BOOST_AUTO_TEST_CASE(test_is_able_to_handle_label) {
+    ECF_NAME_THIS_TEST();
+
     using Command = LabelCmd;
     {
         auto cl = CommandLine::make_command_line("ecflow_client", "--label=name", "some value with spaces");
@@ -1138,6 +1157,8 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(T_Meter) // --meter (MeterCmd)
 
 BOOST_AUTO_TEST_CASE(test_is_able_to_handle_meter) {
+    ECF_NAME_THIS_TEST();
+
     using Command = MeterCmd;
     {
         auto cl = CommandLine::make_command_line("ecflow_client", "--meter=name", "0");
@@ -1226,6 +1247,8 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(T_Queue) // --queue (QueueCmd)
 
 BOOST_AUTO_TEST_CASE(test_is_able_to_handle_queue) {
+    ECF_NAME_THIS_TEST();
+
     using Command = QueueCmd;
     {
         auto cl = CommandLine::make_command_line("ecflow_client", "--queue=name", "active");
@@ -1325,6 +1348,8 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(T_Wait) // --wait (WaitCmd)
 
 BOOST_AUTO_TEST_CASE(test_is_able_to_handle_wait) {
+    ECF_NAME_THIS_TEST();
+
     using Command = CtsWaitCmd;
     {
         auto cl = CommandLine::make_command_line("ecflow_client", "--wait=/suite/taskx == complete");

--- a/libs/client/test/TestClientTimeout.cpp
+++ b/libs/client/test/TestClientTimeout.cpp
@@ -16,6 +16,7 @@
 
 #include "InvokeServer.hpp"
 #include "SCPort.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/client/ClientEnvironment.hpp"
 #include "ecflow/client/ClientInvoker.hpp"
 #include "ecflow/core/Str.hpp"
@@ -37,6 +38,7 @@ BOOST_AUTO_TEST_SUITE(T_ClientTimeout)
 // After timeout, the socket is closed allowing the server to be restarted without getting the `address in use` error.
 //
 BOOST_AUTO_TEST_CASE(test_client_timeout, *boost::unit_test::disabled()) {
+    ECF_NAME_THIS_TEST();
 
     //
     // Important: This test is disabled because ClientInvoker doesn't actually allow to set an overall timeout

--- a/libs/client/test/TestClientTimeout.cpp
+++ b/libs/client/test/TestClientTimeout.cpp
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(test_client_timeout, *boost::unit_test::disabled()) {
     ClientInvoker theClient(invokeServer.host(), invokeServer.port());
     theClient.set_connect_timeout(0);
 
-    std::string path = File::test_data("ANode/test/parser/data/single_defs/mega.def", "parser");
+    std::string path = File::test_data("libs/node/test/parser/data/single_defs/mega.def", "parser");
     BOOST_REQUIRE_THROW(theClient.loadDefs(path),
                         std::runtime_error); // Expect load defs to fail with a timeout of 1 second
 

--- a/libs/client/test/TestCustomUser.cpp
+++ b/libs/client/test/TestCustomUser.cpp
@@ -12,6 +12,7 @@
 
 #include "InvokeServer.hpp"
 #include "SCPort.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/client/ClientEnvironment.hpp"
 #include "ecflow/client/ClientInvoker.hpp"
 #include "ecflow/core/PasswdFile.hpp"
@@ -56,6 +57,8 @@ private:
 };
 
 BOOST_AUTO_TEST_CASE(test_custom_user) {
+    ECF_NAME_THIS_TEST();
+
     Host the_host;
     std::string host        = ClientEnvironment::hostSpecified();
     std::string port        = SCPort::next();

--- a/libs/client/test/TestGroupCmd.cpp
+++ b/libs/client/test/TestGroupCmd.cpp
@@ -14,6 +14,7 @@
 
 #include "InvokeServer.hpp"
 #include "SCPort.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/client/ClientInvoker.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/node/Submittable.hpp"
@@ -27,6 +28,8 @@ BOOST_AUTO_TEST_SUITE(S_Client)
 BOOST_AUTO_TEST_SUITE(T_GroupCmd)
 
 BOOST_AUTO_TEST_CASE(test_group_cmd) {
+    ECF_NAME_THIS_TEST();
+
     // The previous test's has created/destroyed a server process
     // If two different process both try to use the same port number, you
     // get an "Address in use" error, even if one the process is dead. This is
@@ -47,6 +50,8 @@ BOOST_AUTO_TEST_CASE(test_group_cmd) {
 }
 
 BOOST_AUTO_TEST_CASE(test_client_group_lifecyle) {
+    ECF_NAME_THIS_TEST();
+
     /// *** This test is the same as in file TestServerAndLifeCyle.cpp only this time
     /// *** we use the group command where ever possible
     // This will remove check pt and backup file before server start, to avoid the server from loading previous test

--- a/libs/client/test/TestInitAddVariables.cpp
+++ b/libs/client/test/TestInitAddVariables.cpp
@@ -13,6 +13,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/task/CompleteCmd.hpp"
 #include "ecflow/base/cts/task/InitCmd.hpp"
 #include "ecflow/base/cts/user/BeginCmd.hpp"
@@ -30,7 +31,8 @@ BOOST_AUTO_TEST_SUITE(S_Client)
 BOOST_AUTO_TEST_SUITE(T_InitAddVariables)
 
 BOOST_AUTO_TEST_CASE(test_init_add_variables) {
-    cout << "Client:: ...test_init_add_variables " << endl;
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log(
         "test_init_add_variables.log"); // will create log file, and destroy log and remove file at end of scope
 

--- a/libs/client/test/TestJobGenOnly.cpp
+++ b/libs/client/test/TestJobGenOnly.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp> // IWYU pragma: keep
 
+#include "TestNaming.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/Str.hpp"
 #include "ecflow/node/Defs.hpp"
@@ -26,7 +27,7 @@ BOOST_AUTO_TEST_SUITE(T_JobGenOnly)
 
 //  Tests the Job generation against the OLD sms
 BOOST_AUTO_TEST_CASE(test_jobgenonly) {
-    cout << "Client:: ...test_jobgenonly" << endl;
+    ECF_NAME_THIS_TEST();
 
     // Define paths to ECF_HOME and location of the defs file
 

--- a/libs/client/test/TestLifeCycle.cpp
+++ b/libs/client/test/TestLifeCycle.cpp
@@ -13,6 +13,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/task/CompleteCmd.hpp"
 #include "ecflow/base/cts/task/EventCmd.hpp"
 #include "ecflow/base/cts/task/InitCmd.hpp"
@@ -34,7 +35,8 @@ BOOST_AUTO_TEST_SUITE(S_Client)
 BOOST_AUTO_TEST_SUITE(T_LifeCycle)
 
 BOOST_AUTO_TEST_CASE(test_node_tree_lifecycle) {
-    cout << "Client:: ...test_node_tree_lifecycle" << endl;
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log(
         "test_node_tree_lifecycle.log"); // will create log file, and destroy log and remove file at end of scope
 

--- a/libs/client/test/TestLoadDefsCmd.cpp
+++ b/libs/client/test/TestLoadDefsCmd.cpp
@@ -16,6 +16,7 @@
 
 #include "InvokeServer.hpp"
 #include "SCPort.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/user/LoadDefsCmd.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
@@ -39,7 +40,8 @@ BOOST_AUTO_TEST_SUITE(T_LoadDefsCmd)
 // In the real server, we dont store, externs
 // *******************************************************************
 BOOST_AUTO_TEST_CASE(test_load_defs_cmd_handleRequest) {
-    cout << "Client:: ...test_load_defs_cmd_handleRequest" << endl;
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_load_defs_cmd_handleRequest.log"); // will create log file, and destroy log and remove file
                                                               // at end of scope
 
@@ -96,6 +98,8 @@ BOOST_AUTO_TEST_CASE(test_load_defs_cmd_handleRequest) {
 }
 
 BOOST_AUTO_TEST_CASE(test_load_defs_check_only) {
+    ECF_NAME_THIS_TEST();
+
     /// Test that when check only is called the definition is NOT loaded
     InvokeServer invokeServer("Client:: ...test_load_defs_check_only", SCPort::next());
     BOOST_REQUIRE_MESSAGE(invokeServer.server_started(),
@@ -131,6 +135,8 @@ BOOST_AUTO_TEST_CASE(test_load_defs_check_only) {
 }
 
 BOOST_AUTO_TEST_CASE(test_load_defs) {
+    ECF_NAME_THIS_TEST();
+
     /// Test that loading a defs a second time, with the same suite, throws a errors
     /// unless the -force option is used.
     InvokeServer invokeServer("Client:: ...test_load_defs", SCPort::next());

--- a/libs/client/test/TestLogAndCheckptErrors.cpp
+++ b/libs/client/test/TestLogAndCheckptErrors.cpp
@@ -15,6 +15,7 @@
 
 #include "InvokeServer.hpp"
 #include "SCPort.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/client/ClientEnvironment.hpp"
 #include "ecflow/client/ClientInvoker.hpp"
 #include "ecflow/core/File.hpp"
@@ -33,16 +34,18 @@ BOOST_AUTO_TEST_SUITE(T_LogAndCheckptErrors)
 // Note: If you make edits to node tree, they will have no effect until the server is rebuilt
 // ************************************************************************************
 BOOST_AUTO_TEST_CASE(test_log_and_checkpt_write_errors) {
+    ECF_NAME_THIS_TEST();
+
     // This test needs to change directory *BEFORE* before the server starts.
     // Hence if the server is already running ignore this test.
     if (!ClientEnvironment::hostSpecified().empty()) {
-        cout << "Client:: ...test_log_and_checkpt_write_errors. IGNORING when server is already running" << endl;
+        cout << "Ignoring test when server is already running" << endl;
         return;
     }
 
     // When this test is run in Bamboo/Docker, the users is root, hence the chmod below will not work and test will fail
     if (User::login_name() == "root") {
-        cout << "Client:: ...test_log_and_checkpt_write_errors. IGNORING when user is root." << endl;
+        cout << "Ignoring test when user is root." << endl;
         return;
     }
 

--- a/libs/client/test/TestMigration.cpp
+++ b/libs/client/test/TestMigration.cpp
@@ -15,6 +15,7 @@
 #include "InvokeServer.hpp"
 #include "SCPort.hpp"
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/client/ClientEnvironment.hpp"
 #include "ecflow/client/ClientInvoker.hpp"
 #include "ecflow/client/Rtt.hpp"
@@ -88,6 +89,8 @@ void do_test_migration(ClientInvoker& theClient,
 }
 
 BOOST_FIXTURE_TEST_CASE(test_migration, ArgsFixture) {
+    ECF_NAME_THIS_TEST();
+
     if (argc != 2) {
         std::cout << "Ignoring test! Since test directory is not provided\n";
     }

--- a/libs/client/test/TestPasswdFile.cpp
+++ b/libs/client/test/TestPasswdFile.cpp
@@ -12,6 +12,7 @@
 
 #include "InvokeServer.hpp"
 #include "SCPort.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/client/ClientEnvironment.hpp"
 #include "ecflow/client/ClientInvoker.hpp"
 #include "ecflow/core/PasswdFile.hpp"
@@ -47,6 +48,8 @@ private:
 };
 
 BOOST_AUTO_TEST_CASE(test_loading_of_passwd) {
+    ECF_NAME_THIS_TEST();
+
     Host the_host;
     std::string host        = ClientEnvironment::hostSpecified();
     std::string port        = SCPort::next();
@@ -120,6 +123,8 @@ BOOST_AUTO_TEST_CASE(test_loading_of_passwd) {
 }
 
 BOOST_AUTO_TEST_CASE(test_loading_of_passwd_fail) {
+    ECF_NAME_THIS_TEST();
+
     // TEST user *MUST* be in ECF_PASSWD file, into order to *ALLOW* reloadpasswdfile
     Host the_host;
     std::string host        = ClientEnvironment::hostSpecified();

--- a/libs/client/test/TestPlugCmd.cpp
+++ b/libs/client/test/TestPlugCmd.cpp
@@ -14,6 +14,7 @@
 
 #include "InvokeServer.hpp"
 #include "SCPort.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/cts/user/ClientHandleCmd.hpp"
 #include "ecflow/base/cts/user/PlugCmd.hpp"
 #include "ecflow/client/ClientInvoker.hpp"
@@ -54,7 +55,8 @@ BOOST_AUTO_TEST_SUITE(S_Client)
 BOOST_AUTO_TEST_SUITE(T_PlugCmd)
 
 BOOST_AUTO_TEST_CASE(test_plug_cmd) {
-    cout << "Client:: ...test_plug_cmd" << endl;
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_plug_cmd.log"); // will create log file, and destroy log and remove file at end of scope
 
     {
@@ -127,7 +129,8 @@ BOOST_AUTO_TEST_CASE(test_plug_cmd) {
 }
 
 BOOST_AUTO_TEST_CASE(test_plug_cmd_preserves_server_state) {
-    cout << "Client:: ...test_plug_cmd_preserves_server_state" << endl;
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log("test_plug_cmd_preserves_server_state.log"); // will create log file, and destroy log and remove
                                                                   // file at end of scope
 
@@ -173,7 +176,8 @@ BOOST_AUTO_TEST_CASE(test_plug_cmd_preserves_server_state) {
 }
 
 BOOST_AUTO_TEST_CASE(test_plug_cmd_with_handles) {
-    cout << "Client:: ...test_plug_cmd_with_handles" << endl;
+    ECF_NAME_THIS_TEST();
+
     TestLog test_log(
         "test_plug_cmd_with_handles.log"); // will create log file, and destroy log and remove file at end of scope
 
@@ -342,9 +346,9 @@ static void test_plug_on_multiple_server(const std::string& host1,
 }
 
 BOOST_AUTO_TEST_CASE(test_server_plug_cmd) {
-    if (ClientEnvironment::hostSpecified().empty()) {
+    ECF_NAME_THIS_TEST();
 
-        cout << "Client:: ...test_server_plug_cmd";
+    if (ClientEnvironment::hostSpecified().empty()) {
 
         // Invoke two servers. *which* will both terminate at the end of this scope
         // This will remove check pt and backup file before server start, to avoid the server from loading previous test
@@ -360,8 +364,6 @@ BOOST_AUTO_TEST_CASE(test_server_plug_cmd) {
             invokeServer1.host(), invokeServer1.port(), invokeServer2.host(), invokeServer2.port());
     }
     else {
-
-        cout << "Client:: ...test_server_plug_cmd";
 
         // Remote server all ready running, start one more additional server
         {

--- a/libs/client/test/TestRtt.cpp
+++ b/libs/client/test/TestRtt.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/client/Rtt.hpp"
 #include "ecflow/core/File.hpp"
 
@@ -23,7 +24,7 @@ BOOST_AUTO_TEST_SUITE(S_Client)
 BOOST_AUTO_TEST_SUITE(T_Rtt)
 
 BOOST_AUTO_TEST_CASE(test_client_invoker_round_trip_times) {
-    cout << "Client:: ...test_client_invoker_round_trip_times" << endl;
+    ECF_NAME_THIS_TEST();
 
     std::string root_path = File::test_data("libs/client/test/data/", "libs/client");
 

--- a/libs/client/test/TestServer.cpp
+++ b/libs/client/test/TestServer.cpp
@@ -14,6 +14,7 @@
 
 #include "InvokeServer.hpp"
 #include "SCPort.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/client/ClientEnvironment.hpp"
 #include "ecflow/client/ClientInvoker.hpp"
 #include "ecflow/core/DurationTimer.hpp"
@@ -38,6 +39,8 @@ BOOST_AUTO_TEST_SUITE(T_Server)
 // ************************************************************************************
 
 BOOST_AUTO_TEST_CASE(test_server_version) {
+    ECF_NAME_THIS_TEST();
+
     /// This will remove checkpt and backup , to avoid server from loading it. (i.e from previous test)
     InvokeServer invokeServer("Client:: ...test_server_version:", SCPort::next());
     BOOST_REQUIRE_MESSAGE(invokeServer.server_started(),
@@ -60,6 +63,8 @@ BOOST_AUTO_TEST_CASE(test_server_version) {
 }
 
 BOOST_AUTO_TEST_CASE(test_server_state_changes) {
+    ECF_NAME_THIS_TEST();
+
     /// This will remove checkpt and backup , to avoid server from loading it. (i.e from previous test)
     InvokeServer invokeServer("Client:: ...test_server_state_changes:", SCPort::next());
     BOOST_REQUIRE_MESSAGE(invokeServer.server_started(),
@@ -166,6 +171,8 @@ BOOST_AUTO_TEST_CASE(test_server_state_changes) {
 }
 
 BOOST_AUTO_TEST_CASE(test_server_state_changes_with_auto_sync) {
+    ECF_NAME_THIS_TEST();
+
     /// This will remove checkpt and backup , to avoid server from loading it. (i.e from previous test)
     InvokeServer invokeServer("Client:: ...test_server_state_changes_with_auto_sync:", SCPort::next());
     BOOST_REQUIRE_MESSAGE(invokeServer.server_started(),
@@ -230,6 +237,8 @@ BOOST_AUTO_TEST_CASE(test_server_state_changes_with_auto_sync) {
 }
 
 BOOST_AUTO_TEST_CASE(test_server_stress_test) {
+    ECF_NAME_THIS_TEST();
+
     /// This will remove checkpt and backup , to avoid server from loading it. (i.e from previous test)
     InvokeServer invokeServer("Client:: ...test_server_stress_test:", SCPort::next());
     BOOST_REQUIRE_MESSAGE(invokeServer.server_started(),
@@ -326,6 +335,8 @@ BOOST_AUTO_TEST_CASE(test_server_stress_test) {
 }
 
 BOOST_AUTO_TEST_CASE(test_server_group_stress_test) {
+    ECF_NAME_THIS_TEST();
+
     /// This is exactly the same test as above, but uses the group command
     /// This should be faster as the network traffic should be a lot less
     InvokeServer invokeServer("Client:: ...test_server_group_stress_test:", SCPort::next());
@@ -376,6 +387,8 @@ BOOST_AUTO_TEST_CASE(test_server_group_stress_test) {
 }
 
 BOOST_AUTO_TEST_CASE(test_server_stress_test_2) {
+    ECF_NAME_THIS_TEST();
+
     /// More extensive stress test, using as many user based command as possible.
     ///
     /// This will remove checkpt and backup , to avoid server from loading it. (i.e from previous test)

--- a/libs/client/test/TestServerAndLifeCycle.cpp
+++ b/libs/client/test/TestServerAndLifeCycle.cpp
@@ -12,6 +12,7 @@
 
 #include "InvokeServer.hpp"
 #include "SCPort.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/client/ClientEnvironment.hpp"
 #include "ecflow/client/ClientInvoker.hpp"
 #include "ecflow/core/File.hpp"
@@ -35,6 +36,8 @@ BOOST_AUTO_TEST_SUITE(T_ServerAndLifeCycle)
 // ************************************************************************************
 
 BOOST_AUTO_TEST_CASE(test_client_lifecyle) {
+    ECF_NAME_THIS_TEST();
+
     // *******************************************************************************************
     // This test will *ONLY* work when testing with new server invocation, since it relies
     // on disabling job generation. Hence ignore test if ECF_HOST has been defined
@@ -42,7 +45,7 @@ BOOST_AUTO_TEST_CASE(test_client_lifecyle) {
     std::string host = ClientEnvironment::hostSpecified();
     if (!host.empty()) {
         // Server allready started, since we cant disable job generation ignore this test
-        std::cout << "Client:: ...test_client_lifecycle, ignoring test when ECF_HOST specified..." << endl;
+        std::cout << "Ignoring test when ECF_HOST specified..." << endl;
         return;
     }
 

--- a/libs/client/test/TestServerLoad.cpp
+++ b/libs/client/test/TestServerLoad.cpp
@@ -14,6 +14,7 @@
 
 #include "InvokeServer.hpp"
 #include "SCPort.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/client/ClientInvoker.hpp"
 #include "ecflow/core/File.hpp"
 
@@ -25,10 +26,12 @@ BOOST_AUTO_TEST_SUITE(S_Client)
 BOOST_AUTO_TEST_SUITE(T_ServerLoad)
 
 BOOST_AUTO_TEST_CASE(test_server_load) {
+    ECF_NAME_THIS_TEST();
+
     // Check if gnuplot is found on the path, on the RPM machines gnuplot not always installed
     std::string path_to_gnuplot = File::which("gnuplot");
     if (path_to_gnuplot.empty()) {
-        cout << "Client:: ...test_server_load -----> gnuplot not found on $PATH *IGNORING* test\n";
+        cout << "Ignoring test since GNUplot was not found on $PATH" << endl;
         return;
     }
 

--- a/libs/client/test/TestSignalSIGTERM.cpp
+++ b/libs/client/test/TestSignalSIGTERM.cpp
@@ -15,6 +15,7 @@
 
 #include "InvokeServer.hpp"
 #include "SCPort.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/client/ClientEnvironment.hpp"
 #include "ecflow/client/ClientInvoker.hpp"
 
@@ -46,6 +47,8 @@ static void wait_for_sigterm_in_server(ClientInvoker& theClient) {
 // that a check point file is saved.
 // ************************************************************************************
 BOOST_AUTO_TEST_CASE(test_signal_SIGTERM) {
+    ECF_NAME_THIS_TEST();
+
     // This will remove check pt and backup file before server start, to avoid the server from loading previous test
     // data
     InvokeServer invokeServer("Client:: ...test_signal_SIGTERM", SCPort::next());

--- a/libs/client/test/TestSinglePerf.cpp
+++ b/libs/client/test/TestSinglePerf.cpp
@@ -16,6 +16,7 @@
 #include "InvokeServer.hpp"
 #include "SCPort.hpp"
 #include "TestHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/client/ClientEnvironment.hpp"
 #include "ecflow/client/ClientInvoker.hpp"
 #include "ecflow/client/Rtt.hpp"
@@ -347,6 +348,8 @@ void time_load_and_downloads(ClientInvoker& theClient,
 }
 
 BOOST_AUTO_TEST_CASE(test_perf_for_large_defs) {
+    ECF_NAME_THIS_TEST();
+
     if (const char* ecf_ssl = getenv("ECF_SSL"); ecf_ssl) {
         load_threshold_ms       = 8000; // 4500;
         begin_threshold_ms      = 800;  // 400;

--- a/libs/client/test/TestUrlCmd.cpp
+++ b/libs/client/test/TestUrlCmd.cpp
@@ -14,6 +14,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/client/UrlCmd.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/node/Defs.hpp"
@@ -28,7 +29,7 @@ BOOST_AUTO_TEST_SUITE(T_UrlCmd)
 //=============================================================================
 // This will test the UrlCmd.
 BOOST_AUTO_TEST_CASE(test_url_cmd) {
-    cout << "Client:: ...test_url_cmd" << endl;
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/client/test/data/lifecycle.txt", "libs/client");
 

--- a/libs/client/test/TestWhiteListFile.cpp
+++ b/libs/client/test/TestWhiteListFile.cpp
@@ -14,6 +14,7 @@
 
 #include "InvokeServer.hpp"
 #include "SCPort.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/client/ClientEnvironment.hpp"
 #include "ecflow/client/ClientInvoker.hpp"
 #include "ecflow/core/WhiteListFile.hpp"
@@ -34,6 +35,8 @@ BOOST_AUTO_TEST_SUITE(T_WhiteListFile)
 // ************************************************************************************
 
 BOOST_AUTO_TEST_CASE(test_loading_of_white_list_file) {
+    ECF_NAME_THIS_TEST();
+
     Host the_host;
     std::string port = SCPort::next();
     std::string host = ClientEnvironment::hostSpecified();
@@ -98,6 +101,8 @@ BOOST_AUTO_TEST_CASE(test_loading_of_white_list_file) {
 }
 
 BOOST_AUTO_TEST_CASE(test_server_has_write_access_in_non_empty_whitelist) {
+    ECF_NAME_THIS_TEST();
+
     Host the_host;
     std::string host = ClientEnvironment::hostSpecified();
     if (host.empty()) {

--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -19,6 +19,7 @@ ecbuild_add_library(
   TYPE INTERFACE
   SOURCES
     test/TestSerialisation.hpp
+    test/TestNaming.hpp
   PUBLIC_INCLUDES
     test
 )

--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -36,6 +36,7 @@ set(test_srcs
   test/TestChrono.cpp
   test/TestClassDataMemberInit.cpp
   test/TestCommandLine.cpp
+  test/TestConverter.cpp
   test/TestCore_main.cpp # contains main() function for test driver
   test/TestExtract.cpp
   test/TestFile.cpp

--- a/libs/core/src/ecflow/core/Str.cpp
+++ b/libs/core/src/ecflow/core/Str.cpp
@@ -279,7 +279,7 @@ void Str::split(const std::string& line, std::vector<std::string>& tokens, const
     //   Time for std::string_view 1000000            times = 0.769s wall, (0.770s user + 0.000s system = 0.770s) CPU
     //   (100.1%) Time for std::string_view(2) 1000000         times = 0.688s wall, (0.690s user + 0.000s system =
     //   0.690s) CPU (100.3%)
-    //  ACore:: ...test_str_split_perf_with_file
+    //  core :: test_str_split_perf_with_file
     //   This test will split each line in file ${ECF_TEST_DEFS_DIR}vsms2.31415.def
     //   Time for istreamstream 2001774                 times = 1.567s wall, (1.570s user + 0.000s system = 1.570s) CPU
     //   (100.2%) Time for std::getline 2001774                  times = 2.456s wall, (2.460s user + 0.000s system

--- a/libs/core/src/ecflow/core/Version.cpp
+++ b/libs/core/src/ecflow/core/Version.cpp
@@ -23,9 +23,9 @@ namespace ecf {
 // ********************************************************************
 // IMPORTANT:
 // The version number is extracted externally.
-//   see ACore/doc/extracting_version_number.ddoc
+//   see libs/core/doc/extracting_version_number.ddoc
 //
-//   See ACore/src/ecflow_version.h
+//   See libs/core/src/ecflow_version.h
 //   This file is generated when cmake is run, i.e.
 //     `sh -x $WK/cmake.sh debug`
 //

--- a/libs/core/test/TestCalendar.cpp
+++ b/libs/core/test/TestCalendar.cpp
@@ -14,6 +14,7 @@
 #include <boost/date_time/posix_time/time_formatters.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Cal.hpp"
 #include "ecflow/core/Calendar.hpp"
 #include "ecflow/core/Converter.hpp"
@@ -30,7 +31,7 @@ BOOST_AUTO_TEST_SUITE(U_Core)
 BOOST_AUTO_TEST_SUITE(T_Calendar)
 
 BOOST_AUTO_TEST_CASE(test_calendar_default_ptime) {
-    cout << "ACore:: ...test_calendar_default_ptime \n";
+    ECF_NAME_THIS_TEST();
 
     ptime time;
     BOOST_CHECK_MESSAGE(time.is_special(), "Default ptime is special");
@@ -41,7 +42,7 @@ BOOST_AUTO_TEST_CASE(test_calendar_default_ptime) {
 }
 
 BOOST_AUTO_TEST_CASE(test_calendar_state_parsing) {
-    cout << "ACore:: ...test_calendar_state_parsing\n";
+    ECF_NAME_THIS_TEST();
 
     Calendar calendar;
     BOOST_CHECK_MESSAGE(!calendar.hybrid(), "Default calendar type should be real");
@@ -79,7 +80,7 @@ BOOST_AUTO_TEST_CASE(test_calendar_state_parsing) {
 }
 
 BOOST_AUTO_TEST_CASE(test_calendar_1) {
-    cout << "ACore:: ...test_calendar_1\n";
+    ECF_NAME_THIS_TEST();
 
     Calendar calendar;
     BOOST_CHECK_MESSAGE(!calendar.hybrid(), "Default calendar type should be real");
@@ -94,7 +95,7 @@ BOOST_AUTO_TEST_CASE(test_calendar_1) {
 }
 
 BOOST_AUTO_TEST_CASE(test_calendar) {
-    cout << "ACore:: ...test_calendar_basic\n";
+    ECF_NAME_THIS_TEST();
 
     Calendar calendar;
     BOOST_CHECK_MESSAGE(!calendar.hybrid(), "Default calendar type should be real");
@@ -123,7 +124,7 @@ BOOST_AUTO_TEST_CASE(test_calendar) {
 }
 
 BOOST_AUTO_TEST_CASE(test_calendar_time_series_relative) {
-    cout << "ACore:: ...test_calendar_time_series_relative\n";
+    ECF_NAME_THIS_TEST();
 
     // init the calendar to 2009, Feb, 10th,  0 minutes past midnight
     Calendar calendar;
@@ -159,7 +160,7 @@ BOOST_AUTO_TEST_CASE(test_calendar_time_series_relative) {
 }
 
 BOOST_AUTO_TEST_CASE(test_calendar_time_series_relative_complex) {
-    cout << "ACore:: ...test_calendar_time_series_relative_complex\n";
+    ECF_NAME_THIS_TEST();
 
     // init the calendar to 2009, Feb, 10th,  0 minutes past midnight
     Calendar calendar;
@@ -225,7 +226,7 @@ BOOST_AUTO_TEST_CASE(test_calendar_time_series_relative_complex) {
 }
 
 BOOST_AUTO_TEST_CASE(test_calendar_time_series_real) {
-    cout << "ACore:: ...test_calendar_time_series_real\n";
+    ECF_NAME_THIS_TEST();
 
     // init the calendar to 2009, Feb, 10th,  0 minutes past midnight
     Calendar calendar;
@@ -258,7 +259,7 @@ BOOST_AUTO_TEST_CASE(test_calendar_time_series_real) {
 }
 
 BOOST_AUTO_TEST_CASE(test_calendar_time_series_real_complex) {
-    cout << "ACore:: ...test_calendar_time_series_real_complex\n";
+    ECF_NAME_THIS_TEST();
 
     // init the calendar to 2009, Feb, 10th,  0 minutes past midnight
     Calendar calendar;
@@ -323,7 +324,7 @@ BOOST_AUTO_TEST_CASE(test_calendar_time_series_real_complex) {
 }
 
 BOOST_AUTO_TEST_CASE(test_calendar_hybrid) {
-    cout << "ACore:: ...test_calendar_hybrid\n";
+    ECF_NAME_THIS_TEST();
 
     // The hybrid calendar should not change the suite date.
     // Test by updateing calendar by more than 24 hours
@@ -394,7 +395,7 @@ BOOST_AUTO_TEST_CASE(test_calendar_hybrid) {
 }
 
 BOOST_AUTO_TEST_CASE(test_day_changed_for_real) {
-    cout << "ACore:: ...test_day_changed_for_real\n";
+    ECF_NAME_THIS_TEST();
 
     // init the calendar to 2009, Feb, 10th,  0 minutes past midnight
     Calendar calendar;
@@ -439,7 +440,7 @@ BOOST_AUTO_TEST_CASE(test_day_changed_for_real) {
 }
 
 BOOST_AUTO_TEST_CASE(test_day_changed_for_hybrid) {
-    cout << "ACore:: ...test_day_changed_for_hybrid\n";
+    ECF_NAME_THIS_TEST();
 
     // init the calendar
     Calendar calendar; // default clock is real
@@ -488,7 +489,7 @@ BOOST_AUTO_TEST_CASE(test_day_changed_for_hybrid) {
 }
 
 BOOST_AUTO_TEST_CASE(test_calendar_julian) {
-    cout << "ACore:: ...test_calendar_julian\n";
+    ECF_NAME_THIS_TEST();
 
     Calendar calendar;
     calendar.init(ptime(date(2017, 1, 1), minutes(0)), Calendar::REAL);

--- a/libs/core/test/TestCalendar.cpp
+++ b/libs/core/test/TestCalendar.cpp
@@ -8,7 +8,6 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <iostream>
 #include <string>
 
 #include <boost/date_time/posix_time/time_formatters.hpp>
@@ -21,7 +20,6 @@
 #include "ecflow/core/Str.hpp"
 #include "ecflow/core/TimeSeries.hpp"
 
-using namespace std;
 using namespace ecf;
 using namespace boost::posix_time;
 using namespace boost::gregorian;
@@ -147,7 +145,6 @@ BOOST_AUTO_TEST_CASE(test_calendar_time_series_relative) {
         calendar.update(time_duration(hours(1)));
         timeSeries.calendarChanged(calendar);
 
-        //		cerr << "hour = " << hour << " suiteTime " << to_simple_string(calendar.suiteTime()) << "\n";
         if (hour >= timeSeries.start().hour() && hour <= timeSeries.finish().hour()) {
             BOOST_CHECK_MESSAGE(timeSeries.isFree(calendar),
                                 "Calendar should match relative time series at hour " << hour);
@@ -198,12 +195,12 @@ BOOST_AUTO_TEST_CASE(test_calendar_time_series_relative_complex) {
                                         << suiteTm.tm_hour << Str::COLON() << suiteTm.tm_min
                                         << " suite time = " << to_simple_string(calendar.suiteTime()));
                 if (!matches) {
-                    cerr << "suiteTm.tm_hour =" << suiteTm.tm_hour << " suiteTm.tm_min = " << suiteTm.tm_min
-                         << " timeSeries.start().hour() " << timeSeries.start().hour()
-                         << " timeSeries.start().minute() " << timeSeries.start().minute()
-                         << " timeSeries.finish().hour() " << timeSeries.finish().hour()
-                         << " timeSeries.finish().minute() " << timeSeries.finish().minute()
-                         << " suiteTm.tm_min % 15 = " << suiteTm.tm_min % 15 << "\n";
+                    ECF_TEST_ERR(<< "suiteTm.tm_hour =" << suiteTm.tm_hour << " suiteTm.tm_min = " << suiteTm.tm_min
+                                 << " timeSeries.start().hour() " << timeSeries.start().hour()
+                                 << " timeSeries.start().minute() " << timeSeries.start().minute()
+                                 << " timeSeries.finish().hour() " << timeSeries.finish().hour()
+                                 << " timeSeries.finish().minute() " << timeSeries.finish().minute()
+                                 << " suiteTm.tm_min % 15 = " << suiteTm.tm_min % 15);
                 }
             }
             else {
@@ -213,12 +210,12 @@ BOOST_AUTO_TEST_CASE(test_calendar_time_series_relative_complex) {
                                         << " suite time = " << to_simple_string(calendar.suiteTime()));
 
                 if (matches) {
-                    cerr << "suiteTm.tm_hour =" << suiteTm.tm_hour << " suiteTm.tm_min = " << suiteTm.tm_min
-                         << " timeSeries.start().hour() " << timeSeries.start().hour()
-                         << " timeSeries.start().minute() " << timeSeries.start().minute()
-                         << " timeSeries.finish().hour() " << timeSeries.finish().hour()
-                         << " timeSeries.finish().minute() " << timeSeries.finish().minute()
-                         << " suiteTm.tm_min % 15 = " << suiteTm.tm_min % 15 << "\n";
+                    ECF_TEST_ERR(<< "suiteTm.tm_hour =" << suiteTm.tm_hour << " suiteTm.tm_min = " << suiteTm.tm_min
+                                 << " timeSeries.start().hour() " << timeSeries.start().hour()
+                                 << " timeSeries.start().minute() " << timeSeries.start().minute()
+                                 << " timeSeries.finish().hour() " << timeSeries.finish().hour()
+                                 << " timeSeries.finish().minute() " << timeSeries.finish().minute()
+                                 << " suiteTm.tm_min % 15 = " << suiteTm.tm_min % 15);
                 }
             }
         }
@@ -248,7 +245,6 @@ BOOST_AUTO_TEST_CASE(test_calendar_time_series_real) {
         // for testing this will need to be overriden below.
         calendar.update(time_duration(hours(1)));
 
-        // cerr << "hour = " << hour << " suiteTime " << to_simple_string(calendar.suiteTime())  << "\n";
         if (hour >= timeSeries.start().hour() && hour <= timeSeries.finish().hour()) {
             BOOST_CHECK_MESSAGE(timeSeries.isFree(calendar), "Calendar should match time series at hour " << hour);
         }
@@ -296,12 +292,12 @@ BOOST_AUTO_TEST_CASE(test_calendar_time_series_real_complex) {
                                         << suiteTm.tm_hour << ":" << suiteTm.tm_min
                                         << " suite time = " << to_simple_string(calendar.suiteTime()));
                 if (!matches) {
-                    cerr << "suiteTm.tm_hour =" << suiteTm.tm_hour << " suiteTm.tm_min = " << suiteTm.tm_min
-                         << " timeSeries.start().hour() " << timeSeries.start().hour()
-                         << " timeSeries.start().minute() " << timeSeries.start().minute()
-                         << " timeSeries.finish().hour() " << timeSeries.finish().hour()
-                         << " timeSeries.finish().minute() " << timeSeries.finish().minute()
-                         << " suiteTm.tm_min % 15 = " << suiteTm.tm_min % 15 << "\n";
+                    ECF_TEST_ERR(<< "suiteTm.tm_hour =" << suiteTm.tm_hour << " suiteTm.tm_min = " << suiteTm.tm_min
+                                 << " timeSeries.start().hour() " << timeSeries.start().hour()
+                                 << " timeSeries.start().minute() " << timeSeries.start().minute()
+                                 << " timeSeries.finish().hour() " << timeSeries.finish().hour()
+                                 << " timeSeries.finish().minute() " << timeSeries.finish().minute()
+                                 << " suiteTm.tm_min % 15 = " << suiteTm.tm_min % 15);
                 }
             }
             else {
@@ -311,12 +307,12 @@ BOOST_AUTO_TEST_CASE(test_calendar_time_series_real_complex) {
                                         << " suite time = " << to_simple_string(calendar.suiteTime()));
 
                 if (matches) {
-                    cerr << "suiteTm.tm_hour =" << suiteTm.tm_hour << " suiteTm.tm_min = " << suiteTm.tm_min
-                         << " timeSeries.start().hour() " << timeSeries.start().hour()
-                         << " timeSeries.start().minute() " << timeSeries.start().minute()
-                         << " timeSeries.finish().hour() " << timeSeries.finish().hour()
-                         << " timeSeries.finish().minute() " << timeSeries.finish().minute()
-                         << " suiteTm.tm_min % 15 = " << suiteTm.tm_min % 15 << "\n";
+                    ECF_TEST_ERR(<< "suiteTm.tm_hour =" << suiteTm.tm_hour << " suiteTm.tm_min = " << suiteTm.tm_min
+                                 << " timeSeries.start().hour() " << timeSeries.start().hour()
+                                 << " timeSeries.start().minute() " << timeSeries.start().minute()
+                                 << " timeSeries.finish().hour() " << timeSeries.finish().hour()
+                                 << " timeSeries.finish().minute() " << timeSeries.finish().minute()
+                                 << " suiteTm.tm_min % 15 = " << suiteTm.tm_min % 15);
                 }
             }
         }
@@ -356,9 +352,6 @@ BOOST_AUTO_TEST_CASE(test_calendar_hybrid) {
         calendar.update(time_duration(hours(1)));
 
         ptime timeAfterUpdate = calendar.suiteTime();
-
-        //		cerr << "hour = " << hour << " timeBeforeUpdate " << to_simple_string(timeBeforeUpdate)
-        //		    << "   timeAfterUpdate = " << to_simple_string(timeAfterUpdate) <<  "\n";
 
         if (hour != 24 && hour != 48 && hour != 72) {
             time_period diff(timeBeforeUpdate, timeAfterUpdate);

--- a/libs/core/test/TestCereal.cpp
+++ b/libs/core/test/TestCereal.cpp
@@ -8,8 +8,6 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <iostream>
-
 #include <boost/test/unit_test.hpp>
 
 #include "TestNaming.hpp"
@@ -18,7 +16,6 @@
 
 using namespace ecf;
 using namespace boost;
-using namespace std;
 
 class MyClass {
 public:

--- a/libs/core/test/TestCereal.cpp
+++ b/libs/core/test/TestCereal.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "TestSerialisation.hpp"
 #include "ecflow/core/Filesystem.hpp"
 
@@ -78,7 +79,8 @@ BOOST_AUTO_TEST_SUITE(U_Core)
 BOOST_AUTO_TEST_SUITE(T_Cereal)
 
 BOOST_AUTO_TEST_CASE(test_cereal_json) {
-    cout << "ACore:: ...test_cereal_json \n";
+    ECF_NAME_THIS_TEST();
+
     std::string path = "test_cereal_json";
     {
         std::ofstream os(path);
@@ -102,7 +104,8 @@ BOOST_AUTO_TEST_CASE(test_cereal_json) {
 }
 
 BOOST_AUTO_TEST_CASE(test_cereal_json2) {
-    cout << "ACore:: ...test_cereal_json2\n";
+    ECF_NAME_THIS_TEST();
+
     MyTop m1;
     m1.set(10, 10, 10);
     std::string path = "test_cereal_json2";

--- a/libs/core/test/TestCerealOptionalNVP.cpp
+++ b/libs/core/test/TestCerealOptionalNVP.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Filesystem.hpp"
 #include "ecflow/core/Serialization.hpp"
 
@@ -56,7 +57,8 @@ BOOST_AUTO_TEST_SUITE(U_Core)
 BOOST_AUTO_TEST_SUITE(T_CerealOptionalNVP)
 
 BOOST_AUTO_TEST_CASE(test_cereal_optional) {
-    cout << "ACore:: ...test_cereal_optional\n";
+    ECF_NAME_THIS_TEST();
+
     Base original;
     Base original1(true);
     std::string path = "test_cereal_optional";

--- a/libs/core/test/TestCerealOptionalNVP.cpp
+++ b/libs/core/test/TestCerealOptionalNVP.cpp
@@ -8,8 +8,6 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <iostream>
-
 #include <boost/test/unit_test.hpp>
 
 #include "TestNaming.hpp"
@@ -18,7 +16,6 @@
 
 using namespace ecf;
 using namespace boost;
-using namespace std;
 
 class Base {
 public:

--- a/libs/core/test/TestCerealWithHierarchy.cpp
+++ b/libs/core/test/TestCerealWithHierarchy.cpp
@@ -16,7 +16,6 @@
 
 using namespace ecf;
 using namespace boost;
-using namespace std;
 
 // ======================================================================================
 
@@ -138,7 +137,6 @@ BOOST_AUTO_TEST_CASE(test_cereal_save_as_string_and_save_as_filename) {
                               "restoredCmd " << restoredCmd << "  originalCmd " << originalCmd);
     }
     {
-        // cout <<  saved_cmd_as_string << "\n";
         CmdContainer restoredCmd;
         ecf::restore_from_string(saved_cmd_as_string, restoredCmd); // restore form string fails, due to missing '}'
         BOOST_REQUIRE_MESSAGE(restoredCmd == originalCmd,

--- a/libs/core/test/TestCerealWithHierarchy.cpp
+++ b/libs/core/test/TestCerealWithHierarchy.cpp
@@ -126,14 +126,14 @@ BOOST_AUTO_TEST_CASE(test_cereal_save_as_string_and_save_as_filename) {
 
     // SAVE as string and file
     {
-        BOOST_REQUIRE_NO_THROW(ecf::save("ACore.txt", originalCmd)); // save as filename
+        BOOST_REQUIRE_NO_THROW(ecf::save("core.txt", originalCmd)); // save as filename
         ecf::save_as_string(saved_cmd_as_string, originalCmd); // save as string, this is buggy forgets trailing '}'
     }
 
     // RESTORE from filename and string
     {
         CmdContainer restoredCmd;
-        BOOST_REQUIRE_NO_THROW(ecf::restore("ACore.txt", restoredCmd)); // restore from filename
+        BOOST_REQUIRE_NO_THROW(ecf::restore("core.txt", restoredCmd)); // restore from filename
         BOOST_REQUIRE_MESSAGE(restoredCmd == originalCmd,
                               "restoredCmd " << restoredCmd << "  originalCmd " << originalCmd);
     }
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(test_cereal_save_as_string_and_save_as_filename) {
                               "restoredCmd " << restoredCmd << "  originalCmd " << originalCmd);
     }
 
-    fs::remove("ACore.txt");
+    fs::remove("core.txt");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/core/test/TestCerealWithHierarchy.cpp
+++ b/libs/core/test/TestCerealWithHierarchy.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Filesystem.hpp"
 #include "ecflow/core/Serialization.hpp"
 
@@ -117,7 +118,7 @@ BOOST_AUTO_TEST_SUITE(U_Core)
 BOOST_AUTO_TEST_SUITE(T_CerealWithHierarchy)
 
 BOOST_AUTO_TEST_CASE(test_cereal_save_as_string_and_save_as_filename) {
-    cout << "ACore:: ...test_cereal_save_as_string_and_save_as_filename\n";
+    ECF_NAME_THIS_TEST();
 
     std::shared_ptr<BaseCmd> cmd = std::make_shared<Derived1>(10);
     CmdContainer originalCmd(cmd);

--- a/libs/core/test/TestChrono.cpp
+++ b/libs/core/test/TestChrono.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Chrono.hpp"
 
 using namespace ecf;
@@ -19,11 +20,15 @@ BOOST_AUTO_TEST_SUITE(U_Core)
 BOOST_AUTO_TEST_SUITE(T_Chrono)
 
 BOOST_AUTO_TEST_CASE(test_chrono_is_able_to_create_reference_instant) {
+    ECF_NAME_THIS_TEST();
+
     Instant instant;
     BOOST_CHECK_EQUAL(Instant::format(instant), "19700101T000000");
 }
 
 BOOST_AUTO_TEST_CASE(test_chrono__is_able_to_create_instant_based_on_std_chrono_time_point) {
+    ECF_NAME_THIS_TEST();
+
     Instant original{std::chrono::system_clock::now()};
 
     auto timestamp        = Instant::format(original);
@@ -34,6 +39,8 @@ BOOST_AUTO_TEST_CASE(test_chrono__is_able_to_create_instant_based_on_std_chrono_
 }
 
 BOOST_AUTO_TEST_CASE(test_chrono_is_able_to_parse_and_format_instant) {
+    ECF_NAME_THIS_TEST();
+
     {
         std::string value = "19700101T000000";
         Instant instant   = Instant::parse(value);
@@ -47,6 +54,8 @@ BOOST_AUTO_TEST_CASE(test_chrono_is_able_to_parse_and_format_instant) {
 }
 
 BOOST_AUTO_TEST_CASE(test_chrono_is_able_to_compare_instants_for_equality) {
+    ECF_NAME_THIS_TEST();
+
     Instant instant0 = Instant::parse("20000101T235959");
 
     Instant instant1 = instant0;
@@ -69,6 +78,8 @@ BOOST_AUTO_TEST_CASE(test_chrono_is_able_to_compare_instants_for_equality) {
 }
 
 BOOST_AUTO_TEST_CASE(test_chrono_is_able_to_compare_instants_for_inequality) {
+    ECF_NAME_THIS_TEST();
+
     Instant instant1 = Instant::parse("20000101T235959");
     Instant instant2 = Instant::parse("20000102T000000");
     Instant instant3 = Instant::parse("20000102T000001");
@@ -84,6 +95,8 @@ BOOST_AUTO_TEST_CASE(test_chrono_is_able_to_compare_instants_for_inequality) {
 }
 
 BOOST_AUTO_TEST_CASE(test_chrono_is_able_to_add_duration_to_instant) {
+    ECF_NAME_THIS_TEST();
+
     {
         Instant instant = Instant::parse("20000101T235959");
         Instant next    = instant + Duration{std::chrono::seconds{1}};
@@ -97,6 +110,8 @@ BOOST_AUTO_TEST_CASE(test_chrono_is_able_to_add_duration_to_instant) {
 }
 
 BOOST_AUTO_TEST_CASE(test_chrono_is_able_to_subtract_duration_from_instant) {
+    ECF_NAME_THIS_TEST();
+
     {
         Instant instant = Instant::parse("20000101T235959");
         Instant next    = instant - Duration{std::chrono::seconds{1}};
@@ -110,6 +125,8 @@ BOOST_AUTO_TEST_CASE(test_chrono_is_able_to_subtract_duration_from_instant) {
 }
 
 BOOST_AUTO_TEST_CASE(test_chrono_parsing_invalid_value_throws) {
+    ECF_NAME_THIS_TEST();
+
     using expected = std::runtime_error;
     BOOST_CHECK_THROW(Instant::parse("20000101T235961"), expected);
     BOOST_CHECK_THROW(Instant::parse("20000101T236059"), expected);

--- a/libs/core/test/TestClassDataMemberInit.cpp
+++ b/libs/core/test/TestClassDataMemberInit.cpp
@@ -8,7 +8,6 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <iostream>
 #include <string>
 #include <vector>
 
@@ -25,26 +24,26 @@ class MyType {
 public:
     explicit MyType(std::string str) : mName(std::move(str)) {
 #ifdef DEBUG_ME
-        std::cout << "MyType::MyType " << mName << " my_int:" << my_int_ << '\n';
+        ECF_TEST_DBG("MyType::MyType " << mName << " my_int:" << my_int_);
 #endif
     }
 
     ~MyType() {
 #ifdef DEBUG_ME
-        std::cout << "MyType::~MyType " << mName << " my_int:" << my_int_ << '\n';
+        ECF_TEST_DBG("MyType::~MyType " << mName << " my_int:" << my_int_);
 #endif
     }
 
     MyType(const MyType& other) : mName(other.mName) {
 #ifdef DEBUG_ME
-        std::cout << "MyType::MyType(const MyType&) " << mName << " my_int:" << my_int_ << '\n';
+        ECF_TEST_DBG(<< "MyType::MyType(const MyType&) " << mName << " my_int:" << my_int_);
 #endif
     }
 
     MyType(MyType&& other) noexcept
         : mName(std::move(other.mName)) { // vector needs noexcept to call move copy constructor during resize.
 #ifdef DEBUG_ME
-        std::cout << "MyType::MyType(MyType&&) " << mName << " my_int:" << my_int_ << '\n';
+        ECF_TEST_DBG("MyType::MyType(MyType&&) " << mName << " my_int:" << my_int_);
 #endif
     }
 
@@ -52,7 +51,7 @@ public:
         if (this != &other)
             mName = other.mName;
 #ifdef DEBUG_ME
-        std::cout << "MyType::operator=(const MyType&) " << mName << " my_int:" << my_int_ << '\n';
+        ECF_TEST_DBG("MyType::operator=(const MyType&) " << mName << " my_int:" << my_int_);
 #endif
         return *this;
     }
@@ -61,7 +60,7 @@ public:
         if (this != &other)
             mName = std::move(other.mName);
 #ifdef DEBUG_ME
-        std::cout << "MyType::operator=(MyType&&) " << mName << " my_int:" << my_int_ << '\n';
+        ECF_TEST_DBG("MyType::operator=(MyType&&) " << mName << " my_int:" << my_int_);
 #endif
         return *this;
     }

--- a/libs/core/test/TestClassDataMemberInit.cpp
+++ b/libs/core/test/TestClassDataMemberInit.cpp
@@ -14,6 +14,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
+
 using namespace boost;
 using namespace std;
 
@@ -78,7 +80,7 @@ BOOST_AUTO_TEST_SUITE(U_Core)
 BOOST_AUTO_TEST_SUITE(T_ClassDataMemberInit)
 
 BOOST_AUTO_TEST_CASE(test_class_data_member_init) {
-    cout << "ACore:: ...test_class_data_member_init \n";
+    ECF_NAME_THIS_TEST();
 
     {
         MyType type("ABC");

--- a/libs/core/test/TestCommandLine.cpp
+++ b/libs/core/test/TestCommandLine.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/CommandLine.hpp"
 #include "ecflow/core/Converter.hpp"
 
@@ -35,21 +36,29 @@ static void doCheck(const std::vector<std::string>& theArgs) {
 }
 
 BOOST_AUTO_TEST_CASE(test_command_line_with_0_args) {
+    ECF_NAME_THIS_TEST();
+
     std::vector<std::string> theArgs;
     doCheck(theArgs);
 }
 
 BOOST_AUTO_TEST_CASE(test_command_line_with_1_arg) {
+    ECF_NAME_THIS_TEST();
+
     std::vector theArgs = {"arg1"s};
     doCheck(theArgs);
 }
 
 BOOST_AUTO_TEST_CASE(test_command_line_with_2_args) {
+    ECF_NAME_THIS_TEST();
+
     std::vector theArgs = {"arg1"s, "arg2"s};
     doCheck(theArgs);
 }
 
 BOOST_AUTO_TEST_CASE(test_command_line_with_10_args) {
+    ECF_NAME_THIS_TEST();
+
     std::vector<std::string> theArgs(10);
     for (int i = 0; i < 10; i++) {
         theArgs.push_back("arg"s + ecf::convert_to<std::string>(i));
@@ -58,6 +67,8 @@ BOOST_AUTO_TEST_CASE(test_command_line_with_10_args) {
 }
 
 BOOST_AUTO_TEST_CASE(test_command_line_is_able_to_handle_command_line_with_even_quotes) {
+    ECF_NAME_THIS_TEST();
+
     CommandLine cl{R"(ecflow_client --alter=change variable VARIABLE "some long value string" /path/to/task)"};
 
     BOOST_REQUIRE_EQUAL(cl.size(), 6ul);
@@ -67,17 +78,23 @@ BOOST_AUTO_TEST_CASE(test_command_line_is_able_to_handle_command_line_with_even_
 }
 
 BOOST_AUTO_TEST_CASE(test_command_line_is_able_to_handle_command_line_with_incorrect_quotes) {
+    ECF_NAME_THIS_TEST();
+
     BOOST_REQUIRE_THROW(
         CommandLine{R"(ecflow_client --alter=change variable name "some incorrectly ' quoted value" "/some/path)"},
         std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(test_command_line_is_able_to_handle_command_line_with_unmatched_quotes) {
+    ECF_NAME_THIS_TEST();
+
     BOOST_REQUIRE_THROW(CommandLine{R"(ecflow_client --alter=change variable name "some unclosed value /some/path)"},
                         std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(test_command_line_is_able_to_handle_command_line_with_matched_quotes) {
+    ECF_NAME_THIS_TEST();
+
     CommandLine cl{R"(ecflow_client --alter=change variable name "some correctly 'inner' quotes value" '/some/path')"};
 
     BOOST_REQUIRE_EQUAL(cl.size(), 6ul);
@@ -87,6 +104,8 @@ BOOST_AUTO_TEST_CASE(test_command_line_is_able_to_handle_command_line_with_match
 }
 
 BOOST_AUTO_TEST_CASE(test_command_line_is_able_to_handle_single_option) {
+    ECF_NAME_THIS_TEST();
+
     CommandLine cl{R"(executable --option)"};
 
     BOOST_CHECK_EQUAL(cl.tokens().size(), 2ul);
@@ -95,6 +114,8 @@ BOOST_AUTO_TEST_CASE(test_command_line_is_able_to_handle_single_option) {
 }
 
 BOOST_AUTO_TEST_CASE(test_command_line_is_able_to_handle_empty_value_parameters) {
+    ECF_NAME_THIS_TEST();
+
     CommandLine cl{R"(   executable --option parameter  type name    ""   "   "   " value " "\"" /some/path  )"};
 
     BOOST_REQUIRE_EQUAL(cl.tokens().size(), 10ul);
@@ -111,6 +132,8 @@ BOOST_AUTO_TEST_CASE(test_command_line_is_able_to_handle_empty_value_parameters)
 }
 
 BOOST_AUTO_TEST_CASE(test_command_line_is_able_to_handle_single_quotes_in_double_quotes) {
+    ECF_NAME_THIS_TEST();
+
     CommandLine cl{R"(ecflow_client --alter change variable name "'value'" /some/path  )"};
 
     BOOST_REQUIRE_EQUAL(cl.tokens().size(), 7ul);

--- a/libs/core/test/TestCommandLine.cpp
+++ b/libs/core/test/TestCommandLine.cpp
@@ -8,7 +8,7 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <iostream>
+#include <string>
 
 #include <boost/test/unit_test.hpp>
 
@@ -17,7 +17,6 @@
 #include "ecflow/core/Converter.hpp"
 
 using namespace boost;
-using namespace std;
 
 BOOST_AUTO_TEST_SUITE(U_Core)
 
@@ -30,7 +29,7 @@ static void doCheck(const std::vector<std::string>& theArgs) {
 
     for (size_t i = 0; i < cl.size(); i++) {
         const auto& arg = cl.tokens()[i];
-        BOOST_CHECK_MESSAGE(string(arg) == theArgs[i],
+        BOOST_CHECK_MESSAGE(std::string(arg) == theArgs[i],
                             "Mismatch in args expected " << theArgs[i] << " but found " << arg);
     }
 }
@@ -45,6 +44,8 @@ BOOST_AUTO_TEST_CASE(test_command_line_with_0_args) {
 BOOST_AUTO_TEST_CASE(test_command_line_with_1_arg) {
     ECF_NAME_THIS_TEST();
 
+    using namespace std::string_literals;
+
     std::vector theArgs = {"arg1"s};
     doCheck(theArgs);
 }
@@ -52,12 +53,16 @@ BOOST_AUTO_TEST_CASE(test_command_line_with_1_arg) {
 BOOST_AUTO_TEST_CASE(test_command_line_with_2_args) {
     ECF_NAME_THIS_TEST();
 
+    using namespace std::string_literals;
+
     std::vector theArgs = {"arg1"s, "arg2"s};
     doCheck(theArgs);
 }
 
 BOOST_AUTO_TEST_CASE(test_command_line_with_10_args) {
     ECF_NAME_THIS_TEST();
+
+    using namespace std::string_literals;
 
     std::vector<std::string> theArgs(10);
     for (int i = 0; i < 10; i++) {

--- a/libs/core/test/TestConverter.cpp
+++ b/libs/core/test/TestConverter.cpp
@@ -8,7 +8,7 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <iostream>
+#include <string>
 
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/test/unit_test.hpp>

--- a/libs/core/test/TestConverter.cpp
+++ b/libs/core/test/TestConverter.cpp
@@ -13,6 +13,7 @@
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Converter.hpp"
 
 /*
@@ -37,6 +38,8 @@ BOOST_AUTO_TEST_SUITE(U_Core)
 BOOST_AUTO_TEST_SUITE(T_Converter)
 
 BOOST_AUTO_TEST_CASE(can_convert_from_numeric_to_string) {
+    ECF_NAME_THIS_TEST();
+
     BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(0), "0");
     BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(123), "123");
     BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(123L), "123");
@@ -50,6 +53,8 @@ BOOST_AUTO_TEST_CASE(can_convert_from_numeric_to_string) {
 }
 
 BOOST_AUTO_TEST_CASE(can_convert_from_string_to_numeric) {
+    ECF_NAME_THIS_TEST();
+
     BOOST_CHECK_EQUAL(ecf::convert_to<int>("-0"), 0);
     BOOST_CHECK_EQUAL(ecf::convert_to<int>("-123"), -123);
     BOOST_CHECK_EXCEPTION(ecf::convert_to<int>("s"), ecf::bad_conversion, [](const auto& e) { return true; });
@@ -72,12 +77,16 @@ BOOST_AUTO_TEST_CASE(can_convert_from_string_to_numeric) {
 }
 
 BOOST_AUTO_TEST_CASE(can_convert_from_boost_object_to_string) {
+    ECF_NAME_THIS_TEST();
+
     BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(boost::gregorian::greg_day{23}), "23");
     BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(boost::gregorian::greg_month{2}), "Feb");
     BOOST_CHECK_EQUAL(ecf::convert_to<std::string>(boost::gregorian::greg_year{2000}), "2000");
 }
 
 BOOST_AUTO_TEST_CASE(can_use_custom_conversion_traits) {
+    ECF_NAME_THIS_TEST();
+
     // By compiling, the following expression confirms that a Widget can be converted to a Gizmo.
     ecf::convert_to<Gizmo>(Widget{});
 }

--- a/libs/core/test/TestExtract.cpp
+++ b/libs/core/test/TestExtract.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Extract.hpp"
 
 BOOST_AUTO_TEST_SUITE(U_Core)
@@ -19,6 +20,8 @@ BOOST_AUTO_TEST_SUITE(U_Core)
 BOOST_AUTO_TEST_SUITE(T_Extract)
 
 BOOST_AUTO_TEST_CASE(can_extract_path_and_name) {
+    ECF_NAME_THIS_TEST();
+
     using namespace std::string_literals;
     {
         auto token = "/suite/family:obj"s;
@@ -47,6 +50,8 @@ BOOST_AUTO_TEST_CASE(can_extract_path_and_name) {
 }
 
 BOOST_AUTO_TEST_CASE(can_extract_second_token) {
+    ECF_NAME_THIS_TEST();
+
     using namespace std::string_literals;
     {
         auto token = "First:Second"s;
@@ -63,6 +68,8 @@ BOOST_AUTO_TEST_CASE(can_extract_second_token) {
 }
 
 BOOST_AUTO_TEST_CASE(can_extract_integer) {
+    ECF_NAME_THIS_TEST();
+
     using namespace std::string_literals;
     { BOOST_CHECK_THROW(Extract::theInt("", "error message"s), std::runtime_error); }
     { BOOST_CHECK_THROW(Extract::theInt("a", "error message"s), std::runtime_error); }
@@ -77,6 +84,8 @@ BOOST_AUTO_TEST_CASE(can_extract_integer) {
 }
 
 BOOST_AUTO_TEST_CASE(can_extract_optional_integer) {
+    ECF_NAME_THIS_TEST();
+
     using namespace std::string_literals;
     {
         auto tokens = std::vector{"repeat"s, "integer"s, "variable"s, "1"s, "2"s, "#a"s, "comment"s};

--- a/libs/core/test/TestExtract.cpp
+++ b/libs/core/test/TestExtract.cpp
@@ -8,8 +8,6 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <iostream>
-
 #include <boost/test/unit_test.hpp>
 
 #include "TestNaming.hpp"

--- a/libs/core/test/TestFile.cpp
+++ b/libs/core/test/TestFile.cpp
@@ -24,6 +24,7 @@
     #include "ecflow/core/Str.hpp"
 #endif
 
+#include "TestNaming.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/NodePath.hpp"
 #include "ecflow/core/User.hpp"
@@ -37,8 +38,9 @@ BOOST_AUTO_TEST_SUITE(U_Core)
 BOOST_AUTO_TEST_SUITE(T_File)
 
 BOOST_AUTO_TEST_CASE(test_splitFileIntoLines) {
+    ECF_NAME_THIS_TEST();
+
     // This is sanity test for splitFileIntoLines used extensively
-    cout << "ACore:: ...test_splitFileIntoLines\n";
 
     std::string path = File::test_data("libs/core/test/data/test_splitFileIntoLines.txt", "libs/core");
 
@@ -120,7 +122,7 @@ BOOST_AUTO_TEST_CASE(test_splitFileIntoLines) {
 }
 
 BOOST_AUTO_TEST_CASE(test_file_tokenizer) {
-    cout << "ACore:: ...test_file_tokenizer\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/core/test/data/test_file_tokenizer.txt", "libs/core");
 
@@ -175,7 +177,7 @@ BOOST_AUTO_TEST_CASE(test_file_tokenizer) {
 }
 
 BOOST_AUTO_TEST_CASE(test_file_backwardSearch) {
-    cout << "ACore:: ...test_file_backwardSearch\n";
+    ECF_NAME_THIS_TEST();
 
     std::string nodePath = "dir0/dir1/dir2/dir3/dir4/dir5";
     std::string rootPath = File::test_data("libs/core/test/data", "libs/core");
@@ -246,7 +248,7 @@ BOOST_AUTO_TEST_CASE(test_file_backwardSearch) {
 }
 
 BOOST_AUTO_TEST_CASE(test_file_forwardSearch) {
-    cout << "ACore:: ...test_file_forwardSearch user:" << ecf::User::login_name() << "\n";
+    ECF_NAME_THIS_TEST();
 
     std::string dir_path = "/dir0/dir1/dir2/dir3/dir4";
     std::string nodePath = dir_path + "/task";
@@ -326,14 +328,13 @@ BOOST_AUTO_TEST_CASE(test_file_forwardSearch) {
 }
 
 BOOST_AUTO_TEST_CASE(test_create_missing_directories) {
-    cout << "ACore:: ...test_create_missing_directories";
+    ECF_NAME_THIS_TEST();
 
     // This test FAIL's randomly on the cray in BATCH mode, but passes in interactive mode.
     if (getenv("ECFLOW_CRAY_BATCH")) {
         cout << " **** SKIPPING test, until HPC team can  fix File::createMissingDirectories.(like mkdir -p)  *****\n";
         return;
     }
-    cout << "\n";
 
     std::string nodePath = "dir0/dir1/dir2/dir3/dir4/dir5";
     std::string rootPath = File::test_data("libs/core/test/data", "libs/core");
@@ -403,7 +404,7 @@ BOOST_AUTO_TEST_CASE(test_create_missing_directories) {
 }
 
 BOOST_AUTO_TEST_CASE(test_get_last_lines_of_a_file) {
-    cout << "ACore:: ...test_get_last_lines_of_a_file\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/core/test/data/test_get_last_lines_of_a_file.txt", "libs/core");
     std::string last_100_lines;
@@ -496,7 +497,7 @@ BOOST_AUTO_TEST_CASE(test_get_last_lines_of_a_file) {
 }
 
 BOOST_AUTO_TEST_CASE(test_directory_traversal) {
-    cout << "ACore:: ...test_directory_traversal\n";
+    ECF_NAME_THIS_TEST();
 
     int regular_file = 0;
     //    int directory    = 0;
@@ -534,7 +535,8 @@ BOOST_AUTO_TEST_CASE(test_directory_traversal) {
 }
 
 BOOST_AUTO_TEST_CASE(test_get_all_files_by_extension) {
-    cout << "ACore:: ...test_get_all_files_by_extension\n";
+    ECF_NAME_THIS_TEST();
+
     {
         std::string rootPath = File::test_data("libs/core/test/data/badPasswdFiles", "libs/core");
         std::vector<fs::path> vec;

--- a/libs/core/test/TestFile.cpp
+++ b/libs/core/test/TestFile.cpp
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(test_file_backwardSearch) {
         path += "/" + dir + ecf::convert_to<std::string>(i);
     }
     // Should have test/data/dir0/dir1/dir3/dir3/dir4/dir5
-    //         or  ACore/test/data/dir0/dir1/dir3/dir3/dir4/dir5
+    //         or  libs/core/test/data/dir0/dir1/dir3/dir3/dir4/dir5
     BOOST_REQUIRE_MESSAGE(path == expected, " Error expected " << expected << " but found " << path);
 
     // Create the missing directories
@@ -264,7 +264,7 @@ BOOST_AUTO_TEST_CASE(test_file_forwardSearch) {
             path += "/" + dir + ecf::convert_to<std::string>(i);
     }
     // Should have test/data/dir0/dir1/dir3/dir3/dir4/task
-    //         or  ACore/test/data/dir0/dir1/dir3/dir3/dir4/task
+    //         or  libs/core/test/data/dir0/dir1/dir3/dir3/dir4/task
     BOOST_REQUIRE_MESSAGE(path == expected, " Error expected " << expected << " but found " << path);
 
     string combined_dir_path = rootPath + dir_path;
@@ -342,7 +342,7 @@ BOOST_AUTO_TEST_CASE(test_create_missing_directories) {
 
     std::string dir_remove = rootPath + "/dir0";
     {
-        // Test basics first, expect "ACore/test/data/dir0/dir1/dir2/dir3/dir4/dir5" to be created
+        // Test basics first, expect "libs/core/test/data/dir0/dir1/dir2/dir3/dir4/dir5" to be created
         BOOST_CHECK_MESSAGE(File::createMissingDirectories(expected),
                             expected << " expected directories to be created");
         BOOST_CHECK_MESSAGE(fs::exists(expected), expected << " directory not created");
@@ -361,7 +361,7 @@ BOOST_AUTO_TEST_CASE(test_create_missing_directories) {
         //      std::cout << "extension " << fs_path.extension()  << "\n";
     }
     {
-        // Test "ACore/test/data/dir0/dir1/dir2/dir3/dir4/dir5/fred.ecf" to be created
+        // Test "libs/core/test/data/dir0/dir1/dir2/dir3/dir4/dir5/fred.ecf" to be created
         std::string dir_with_file = expected + "/fred.ecf";
         BOOST_CHECK_MESSAGE(File::createMissingDirectories(dir_with_file),
                             "Expected '" << dir_with_file << "' to be created");

--- a/libs/core/test/TestFile.cpp
+++ b/libs/core/test/TestFile.cpp
@@ -30,7 +30,6 @@
 #include "ecflow/core/User.hpp"
 
 using namespace boost;
-using namespace std;
 using namespace ecf;
 
 BOOST_AUTO_TEST_SUITE(U_Core)
@@ -167,8 +166,8 @@ BOOST_AUTO_TEST_CASE(test_file_tokenizer) {
             BOOST_CHECK_MESSAGE(File::splitFileIntoLines(path, lines),
                                 " Failed to open file " << path << " (" << strerror(errno) << ")");
         }
-        cout << "Time for opening file " << openFileNTimes << " times = " << timer.format(3, Str::cpu_timer_format())
-             << "\n";
+        ECF_TEST_DBG(<< "Time for opening file " << openFileNTimes
+                     << " times = " << timer.format(3, Str::cpu_timer_format()));
     }
 #endif
 
@@ -198,7 +197,7 @@ BOOST_AUTO_TEST_CASE(test_file_backwardSearch) {
     // Create a file in each of the directories. See Page 21 SMS User Guide.
     std::vector<std::string> fileContents;
     fileContents.emplace_back("something");
-    vector<std::string> nodePathTokens;
+    std::vector<std::string> nodePathTokens;
     NodePath::split(nodePath, nodePathTokens);
     while (nodePathTokens.size() > 0) {
 
@@ -210,7 +209,6 @@ BOOST_AUTO_TEST_CASE(test_file_backwardSearch) {
 
         combinedPath += File::ECF_EXTN(); // .ecf, .man , etc
 
-        // std::cout << "Creating file " << combinedPath << "\n";
         std::string errorMsg;
         BOOST_REQUIRE_MESSAGE(File::create(combinedPath, fileContents, errorMsg),
                               "Failed to create " << combinedPath << " because " << errorMsg);
@@ -227,7 +225,6 @@ BOOST_AUTO_TEST_CASE(test_file_backwardSearch) {
                               << nodePath);
         if (!theFile.empty()) {
             filesFound++;
-            //			std::cout << "About to remove file " << theFile << "\n";
             fs::remove(theFile); // remove it so we don't find it again.
         }
     }
@@ -267,23 +264,18 @@ BOOST_AUTO_TEST_CASE(test_file_forwardSearch) {
     //         or  libs/core/test/data/dir0/dir1/dir3/dir3/dir4/task
     BOOST_REQUIRE_MESSAGE(path == expected, " Error expected " << expected << " but found " << path);
 
-    string combined_dir_path = rootPath + dir_path;
-    // cout << " creating directories  : " << combined_dir_path  << "\n";
+    std::string combined_dir_path = rootPath + dir_path;
     BOOST_REQUIRE_MESSAGE(File::createDirectories(combined_dir_path), "Failed to create dirs" << combined_dir_path);
 
-    // cout << " Create a file(task.ecf) in each of the directories  nodePath: " << nodePath << "\n";
     std::vector<std::string> fileContents;
     fileContents.emplace_back("something");
-    vector<std::string> nodePathTokens;
+    std::vector<std::string> nodePathTokens;
     NodePath::split(nodePath, nodePathTokens);
     while (nodePathTokens.size() > 0) {
 
         std::string path = NodePath::createPath(nodePathTokens);
-        // cout << "   Reconstituted path  : " << path << " from nodePathTokens.size() " << nodePathTokens.size() <<
-        // "\n";
 
         std::string combinedPath = rootPath + path + File::ECF_EXTN(); // .ecf, .man , etc
-        // cout << "   Creating file       : " << combinedPath << "\n";
 
         std::string errorMsg;
         BOOST_REQUIRE_MESSAGE(File::create(combinedPath, fileContents, errorMsg),
@@ -300,14 +292,12 @@ BOOST_AUTO_TEST_CASE(test_file_forwardSearch) {
 
     // Now do a forward search for them:
     // Expect the following files to be found:
-    // test/data/dir0/dir1/dir2/dir3/dir4/task.ecf
-    // test/data/dir0/dir1/dir2/dir3/task.ecf
-    // test/data/dir0/dir1/dir2/task.ecf
-    // test/data/dir0/dir1/task.ecf
-    // test/data/dir0/task.ecf
-    // test/data/task.ecf
-    // cout << "rootPath: " << rootPath << "\n";
-    // cout << "ECF_EXTN: " << File::ECF_EXTN()  << "\n";
+    //   test/data/dir0/dir1/dir2/dir3/dir4/task.ecf
+    //   test/data/dir0/dir1/dir2/dir3/task.ecf
+    //   test/data/dir0/dir1/dir2/task.ecf
+    //   test/data/dir0/dir1/task.ecf
+    //   test/data/dir0/task.ecf
+    //   test/data/task.ecf
     int filesFound = 0;
     for (int i = 0; i < 6; i++) {
         BOOST_REQUIRE_MESSAGE(i >= 0, "Dummy to debug on macos");
@@ -317,7 +307,6 @@ BOOST_AUTO_TEST_CASE(test_file_forwardSearch) {
                               << nodePath);
         if (!theFile.empty()) {
             filesFound++;
-            // std::cout << "Found file at: " << theFile << "\n";
             fs::remove(theFile); // *remove* so we don't find it again
         }
     }
@@ -332,7 +321,7 @@ BOOST_AUTO_TEST_CASE(test_create_missing_directories) {
 
     // This test FAIL's randomly on the cray in BATCH mode, but passes in interactive mode.
     if (getenv("ECFLOW_CRAY_BATCH")) {
-        cout << " **** SKIPPING test, until HPC team can  fix File::createMissingDirectories.(like mkdir -p)  *****\n";
+        ECF_TEST_DBG(<< "Test skipped until HPC team can  fix File::createMissingDirectories.(like mkdir -p)");
         return;
     }
 
@@ -349,16 +338,6 @@ BOOST_AUTO_TEST_CASE(test_create_missing_directories) {
 
         // remove the directory
         BOOST_CHECK_MESSAGE(File::removeDir(dir_remove), "Failed to remove dir " << dir_remove);
-
-        //      fs::path fs_path(expected);
-        //      std::cout << "parent path " << fs_path.parent_path() << "\n";
-        //      std::cout << "root path " << fs_path.root_path()  << "\n";
-        //      std::cout << "root name " << fs_path.root_name()  << "\n";
-        //      std::cout << "root directory " << fs_path.root_directory()  << "\n";
-        //      std::cout << "relative_path " << fs_path.relative_path()  << "\n";
-        //      std::cout << "filename " << fs_path.filename()  << "\n";
-        //      std::cout << "stem " << fs_path.stem()  << "\n";
-        //      std::cout << "extension " << fs_path.extension()  << "\n";
     }
     {
         // Test "libs/core/test/data/dir0/dir1/dir2/dir3/dir4/dir5/fred.ecf" to be created
@@ -369,16 +348,6 @@ BOOST_AUTO_TEST_CASE(test_create_missing_directories) {
 
         // remove the directory
         BOOST_CHECK_MESSAGE(File::removeDir(dir_remove), "Failed to remove dir " << dir_remove);
-
-        //      fs::path fs_path(dir_with_file);
-        //      std::cout << "parent path " << fs_path.parent_path() << "\n";
-        //      std::cout << "root path " << fs_path.root_path()  << "\n";
-        //      std::cout << "root name " << fs_path.root_name()  << "\n";
-        //      std::cout << "root directory " << fs_path.root_directory()  << "\n";
-        //      std::cout << "relative_path " << fs_path.relative_path()  << "\n";
-        //      std::cout << "filename " << fs_path.filename()  << "\n";
-        //      std::cout << "stem " << fs_path.stem()  << "\n";
-        //      std::cout << "extension " << fs_path.extension()  << "\n";
     }
 
     {
@@ -507,15 +476,6 @@ BOOST_AUTO_TEST_CASE(test_directory_traversal) {
     for (auto& entry : fs::directory_iterator(fs::current_path())) {
         if (is_regular_file(entry))
             regular_file++;
-        //        if (is_directory(entry))
-        //            directory++;
-        //        if (is_symlink(entry))
-        //            symlink++;
-        //        if (is_other(entry))
-        //            other++;
-        //      cout << "name.path()            " << entry.path() << "\n";
-        //      cout << "name.path().string()   " << entry.path().string() << "\n";
-        //      cout << "name.path().filename() " << entry.path().filename() << "\n";
         if (is_regular_file(entry)) {
             boost::uintmax_t entry_size = fs::file_size(entry);
             boost::uintmax_t path_size  = fs::file_size(entry.path());
@@ -524,13 +484,8 @@ BOOST_AUTO_TEST_CASE(test_directory_traversal) {
                                                                << path_size);
             BOOST_REQUIRE_MESSAGE(fs::last_write_time(entry) == fs::last_write_time(entry.path()),
                                   "Directory entry last write time, not the same as entry.path()");
-            //         cout << "file_size " << fs::file_size(entry) << "\n";
         }
     }
-    //   cout << "regular_file " << regular_file << "\n";
-    //   cout << "directory  " <<  directory << "\n";
-    //   cout << "symlink  " << symlink  << "\n";
-    //   cout << "other  " << other  << "\n";
     BOOST_REQUIRE_MESSAGE(regular_file > 0, "Expected some files in directory");
 }
 
@@ -541,14 +496,12 @@ BOOST_AUTO_TEST_CASE(test_get_all_files_by_extension) {
         std::string rootPath = File::test_data("libs/core/test/data/badPasswdFiles", "libs/core");
         std::vector<fs::path> vec;
         File::find_files_with_extn(rootPath, ".passwd", vec);
-        // for(auto& file: vec)  std::cout << file << "\n";
         BOOST_REQUIRE_MESSAGE(vec.size() == 6, "Expected 6 files in directory " << rootPath);
     }
     {
         std::string rootPath = File::test_data("libs/core/test/data/badWhiteListFiles", "libs/core");
         std::vector<fs::path> vec;
         File::find_files_with_extn(rootPath, ".lists", vec);
-        // for(auto& file: vec)  std::cout << file << "\n";
         BOOST_REQUIRE_MESSAGE(vec.size() == 7, "Expected 7 files in directory " << rootPath);
     }
 }

--- a/libs/core/test/TestGetUserDetails.cpp
+++ b/libs/core/test/TestGetUserDetails.cpp
@@ -17,6 +17,8 @@
 #include <boost/test/unit_test.hpp>
 #include <sys/types.h>
 
+#include "TestNaming.hpp"
+
 using namespace std;
 
 BOOST_AUTO_TEST_SUITE(U_Core)
@@ -24,7 +26,7 @@ BOOST_AUTO_TEST_SUITE(U_Core)
 BOOST_AUTO_TEST_SUITE(T_GetUserDetails)
 
 BOOST_AUTO_TEST_CASE(test_get_user_details, *boost::unit_test::disabled()) {
-    cout << "ACore:: ...test_get_user_details\n";
+    ECF_NAME_THIS_TEST();
 
     /* Get the uid of the running processand use it to get a record from /etc/passwd */
     struct passwd* passwd = getpwuid(getuid());

--- a/libs/core/test/TestGetUserDetails.cpp
+++ b/libs/core/test/TestGetUserDetails.cpp
@@ -9,7 +9,6 @@
  */
 
 #include <cstdio>
-#include <iostream>
 #include <pwd.h> /* getpwdid */
 #include <string>
 #include <unistd.h>
@@ -18,8 +17,6 @@
 #include <sys/types.h>
 
 #include "TestNaming.hpp"
-
-using namespace std;
 
 BOOST_AUTO_TEST_SUITE(U_Core)
 

--- a/libs/core/test/TestLog.cpp
+++ b/libs/core/test/TestLog.cpp
@@ -8,7 +8,6 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <iostream>
 #include <stdexcept>
 #include <string>
 
@@ -21,8 +20,19 @@
 #include "ecflow/core/Pid.hpp"
 
 using namespace ecf;
-using namespace std;
 using namespace boost;
+
+void dump_path(const fs::path& path) {
+    ECF_TEST_DBG(<< "path = " << path);
+    ECF_TEST_DBG(<< "path.root_path(): " << path.root_path());
+    ECF_TEST_DBG(<< "path.root_name() : " << path.root_name());
+    ECF_TEST_DBG(<< "path.root_directory()  : " << path.root_directory());
+    ECF_TEST_DBG(<< "path.relative_path()  : " << path.relative_path());
+    ECF_TEST_DBG(<< "path.parent_path()  : " << path.parent_path());
+    ECF_TEST_DBG(<< "path.filename()  : " << path.filename());
+    ECF_TEST_DBG(<< "path.stem()  : " << path.stem());
+    ECF_TEST_DBG(<< "path.extension()  : " << path.extension());
+}
 
 BOOST_AUTO_TEST_SUITE(U_Core)
 
@@ -77,12 +87,13 @@ BOOST_AUTO_TEST_CASE(test_log_append) {
     // Load the log file into a vector, of strings, and test content
     std::vector<std::string> lines;
     BOOST_REQUIRE_MESSAGE(File::splitFileIntoLines(path, lines, true /*IGNORE EMPTY LINE AT THE END*/),
-                          "Failed to open log file" << " (" << strerror(errno) << ")");
+                          "Failed to open log file"
+                              << " (" << strerror(errno) << ")");
     BOOST_REQUIRE(lines.size() != 0);
     BOOST_CHECK_MESSAGE(lines.size() == 10, " Expected 10 lines in log, but found " << lines.size() << "\n");
-    BOOST_CHECK_MESSAGE(lines[0].find("First Message") != string::npos,
+    BOOST_CHECK_MESSAGE(lines[0].find("First Message") != std::string::npos,
                         "Expected first line to contain 'First Message' but found " << lines[0] << "\n");
-    BOOST_CHECK_MESSAGE(lines.back().find("Last Message") != string::npos,
+    BOOST_CHECK_MESSAGE(lines.back().find("Last Message") != std::string::npos,
                         "Expected last line to contain 'Last Message' but found " << lines.back() << "\n");
 
     // Clear the log file. Comment out for debugging
@@ -132,25 +143,13 @@ BOOST_AUTO_TEST_CASE(test_log_new_path_errors) {
     fs::path current_path = fs::current_path();
     std::string path2     = current_path.string();
     path2 += "/a/made/up/path/fred.log";
-    // cout << path2<< "\n";
     BOOST_REQUIRE_THROW(Log::instance()->new_path(path2), std::runtime_error);
 
     // Make sure path does not correspond to a directory
-    // cout << "parent directory: " << current_path.parent_path() << "\n";
     BOOST_REQUIRE_THROW(Log::instance()->new_path(current_path.parent_path().string()), std::runtime_error);
 
-    //   {
-    //      fs::path valid_path = getLogPath();
-    //      std::cout << "valid_path = " << valid_path << "\n";
-    //      std::cout << "valid_path.root_path(): " << valid_path.root_path() << "\n";
-    //      std::cout << "valid_path.root_name() : " << valid_path.root_name()  << "\n";
-    //      std::cout << "valid_path.root_directory()  : " << valid_path.root_directory()   << "\n";
-    //      std::cout << "valid_path.relative_path()  : " << valid_path.relative_path()   << "\n";
-    //      std::cout << "valid_path.parent_path()  : " << valid_path.parent_path()   << "\n";
-    //      std::cout << "valid_path.filename()  : " << valid_path.filename()   << "\n";
-    //      std::cout << "valid_path.stem()  : " << valid_path.stem()   << "\n";
-    //      std::cout << "valid_path.extension()  : " << valid_path.extension()   << "\n";
-    //   }
+    // fs::path valid_path = getLogPath();
+    // dump_path(valid_path);
 
     // Remove the log file. Comment out for debugging
     fs::remove(Log::instance()->path());
@@ -376,7 +375,7 @@ BOOST_AUTO_TEST_CASE(test_get_log_timing) {
     Log::destroy();
 
 #if PRINT_TIMING_RESULTS
-    cout << timer.duration() << "s\n" << flush;
+    ECF_TEST_DBG(timer.duration() << "s\n");
 #endif
 }
 

--- a/libs/core/test/TestLog.cpp
+++ b/libs/core/test/TestLog.cpp
@@ -14,6 +14,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/DurationTimer.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/Log.hpp"
@@ -38,7 +39,7 @@ static std::string getLogPath() {
 
 BOOST_AUTO_TEST_CASE(test_log) {
     std::string path = getLogPath();
-    cout << "ACore:: ...test_log " << path << "\n";
+    ECF_NAME_THIS_TEST(<< ", using log file:" << path);
 
     // delete the log file if it exists.
     fs::remove(path);
@@ -62,7 +63,7 @@ BOOST_AUTO_TEST_CASE(test_log) {
 }
 
 BOOST_AUTO_TEST_CASE(test_log_append) {
-    cout << "ACore:: ...test_log_append\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = getLogPath();
 
@@ -76,8 +77,7 @@ BOOST_AUTO_TEST_CASE(test_log_append) {
     // Load the log file into a vector, of strings, and test content
     std::vector<std::string> lines;
     BOOST_REQUIRE_MESSAGE(File::splitFileIntoLines(path, lines, true /*IGNORE EMPTY LINE AT THE END*/),
-                          "Failed to open log file"
-                              << " (" << strerror(errno) << ")");
+                          "Failed to open log file" << " (" << strerror(errno) << ")");
     BOOST_REQUIRE(lines.size() != 0);
     BOOST_CHECK_MESSAGE(lines.size() == 10, " Expected 10 lines in log, but found " << lines.size() << "\n");
     BOOST_CHECK_MESSAGE(lines[0].find("First Message") != string::npos,
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(test_log_append) {
 }
 
 BOOST_AUTO_TEST_CASE(test_log_path) {
-    cout << "ACore:: ...test_log_path\n";
+    ECF_NAME_THIS_TEST();
 
     Log::create("test_log_path.log");
 
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(test_log_path) {
 }
 
 BOOST_AUTO_TEST_CASE(test_log_new_path_errors) {
-    cout << "ACore:: ...test_log_new_path_errors\n";
+    ECF_NAME_THIS_TEST();
 
     // delete the log file if it exists.
     std::string path = getLogPath();
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(test_log_new_path_errors) {
 }
 
 BOOST_AUTO_TEST_CASE(test_log_new_path) {
-    cout << "ACore:: ...test_log_new_path\n";
+    ECF_NAME_THIS_TEST();
 
     // delete the log file if it exists.
     std::string path = getLogPath();
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(test_log_new_path) {
 }
 
 BOOST_AUTO_TEST_CASE(test_get_last_n_lines_from_log) {
-    cout << "ACore:: ...test_get_last_n_lines_from_log\n";
+    ECF_NAME_THIS_TEST();
 
     // delete the log file if it exists.
     std::string path = getLogPath();
@@ -265,7 +265,7 @@ BOOST_AUTO_TEST_CASE(test_get_last_n_lines_from_log) {
 }
 
 BOOST_AUTO_TEST_CASE(test_get_first_n_lines_from_log) {
-    cout << "ACore:: ...test_get_first_n_lines_from_log\n";
+    ECF_NAME_THIS_TEST();
 
     // delete the log file if it exists.
     std::string path = getLogPath();
@@ -337,7 +337,7 @@ BOOST_AUTO_TEST_CASE(test_get_first_n_lines_from_log) {
 }
 
 BOOST_AUTO_TEST_CASE(test_get_log_timing) {
-    cout << "ACore:: ...test_get_log_timing: " << flush;
+    ECF_NAME_THIS_TEST();
 
     // *************************************************************************************
     // This test was used with *DIFFERENT* implementations for Log::instance()->contents(1)
@@ -375,7 +375,9 @@ BOOST_AUTO_TEST_CASE(test_get_log_timing) {
     // Explicitly destroy log. To keep valgrind happy
     Log::destroy();
 
+#if PRINT_TIMING_RESULTS
     cout << timer.duration() << "s\n" << flush;
+#endif
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/core/test/TestMessage.cpp
+++ b/libs/core/test/TestMessage.cpp
@@ -8,8 +8,6 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <iostream>
-
 #include <boost/test/unit_test.hpp>
 
 #include "TestNaming.hpp"

--- a/libs/core/test/TestMessage.cpp
+++ b/libs/core/test/TestMessage.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Message.hpp"
 
 BOOST_AUTO_TEST_SUITE(U_Core)
@@ -19,6 +20,8 @@ BOOST_AUTO_TEST_SUITE(U_Core)
 BOOST_AUTO_TEST_SUITE(T_Message)
 
 BOOST_AUTO_TEST_CASE(test_message_can_create_from_various_arguments) {
+    ECF_NAME_THIS_TEST();
+
     using namespace ecf;
     using namespace std::string_literals;
 
@@ -32,6 +35,8 @@ BOOST_AUTO_TEST_CASE(test_message_can_create_from_various_arguments) {
 }
 
 BOOST_AUTO_TEST_CASE(test_message_can_convert_to_string) {
+    ECF_NAME_THIS_TEST();
+
     using namespace ecf;
     using namespace std::string_literals;
 
@@ -40,6 +45,8 @@ BOOST_AUTO_TEST_CASE(test_message_can_convert_to_string) {
 }
 
 BOOST_AUTO_TEST_CASE(test_message_can_stream) {
+    ECF_NAME_THIS_TEST();
+
     using namespace ecf;
     using namespace std::string_literals;
 

--- a/libs/core/test/TestMigration.cpp
+++ b/libs/core/test/TestMigration.cpp
@@ -19,7 +19,6 @@
 #include "ecflow/core/NState.hpp"
 #include "ecflow/core/TimeSeries.hpp"
 
-using namespace std;
 using namespace ecf;
 using namespace boost::posix_time;
 using namespace boost::gregorian;
@@ -44,7 +43,7 @@ BOOST_AUTO_TEST_CASE(test_migration_restore_cereal) {
 
     DebugEquality debug_equality; // only as affect in DEBUG build
 
-    string cereal_version = "_1_2_2_";
+    std::string cereal_version = "_1_2_2_";
 
 #ifdef UPDATE_TESTS
     doSave<TimeSlot>(file_name + "timeslot_default_constructor" + cereal_version);

--- a/libs/core/test/TestMigration.cpp
+++ b/libs/core/test/TestMigration.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "TestSerialisation.hpp"
 #include "ecflow/core/Calendar.hpp"
 #include "ecflow/core/DState.hpp"
@@ -31,7 +32,7 @@ BOOST_AUTO_TEST_SUITE(T_Migration)
 // #define UPDATE_TESTS 1
 
 BOOST_AUTO_TEST_CASE(test_migration_restore_cereal) {
-    cout << "ACore:: ...test_migration_restore_cereal\n";
+    ECF_NAME_THIS_TEST();
 
     std::string file_name = File::test_data("libs/core/test/data/migration/", "libs/core");
 

--- a/libs/core/test/TestNaming.hpp
+++ b/libs/core/test/TestNaming.hpp
@@ -12,6 +12,7 @@
 #define ecflow_core_TestNaming_HPP
 
 #include <algorithm>
+#include <iomanip>
 #include <iostream>
 #include <string>
 
@@ -37,6 +38,16 @@ inline std::string name_this_test() {
 #define ECF_NAME_THIS_TEST(ARGS)                                             \
     do {                                                                     \
         std::cout << " * " << ecf::test::name_this_test() ARGS << std::endl; \
+    } while (0)
+
+#define ECF_TEST_DBG(ARGS)                      \
+    do {                                        \
+        std::cout << " +++ " ARGS << std::endl; \
+    } while (0)
+
+#define ECF_TEST_ERR(ARGS)                      \
+    do {                                        \
+        std::cerr << " +++ " ARGS << std::endl; \
     } while (0)
 
 #endif /* ecflow_core_TestNaming_HPP */

--- a/libs/core/test/TestNaming.hpp
+++ b/libs/core/test/TestNaming.hpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2009- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#ifndef ecflow_core_TestNaming_HPP
+#define ecflow_core_TestNaming_HPP
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+
+#include <boost/test/unit_test.hpp>
+
+namespace ecf::test {
+
+inline std::string name_this_test() {
+    std::string fullname = boost::unit_test::framework::current_test_case().p_name;
+    long parent_id       = boost::unit_test::framework::current_test_case().p_parent_id;
+    long master_id       = boost::unit_test::framework::master_test_suite().p_id;
+
+    while (parent_id != master_id) {
+        const auto& parent = boost::unit_test::framework::get<boost::unit_test::test_suite>(parent_id);
+        fullname           = std::string(parent.p_name) + std::string(" / ") + fullname;
+        parent_id          = parent.p_parent_id;
+    }
+    return fullname;
+}
+
+} // namespace ecf::test
+
+#define ECF_NAME_THIS_TEST(ARGS)                                             \
+    do {                                                                     \
+        std::cout << " * " << ecf::test::name_this_test() ARGS << std::endl; \
+    } while (0)
+
+#endif /* ecflow_core_TestNaming_HPP */

--- a/libs/core/test/TestNodePath.cpp
+++ b/libs/core/test/TestNodePath.cpp
@@ -15,6 +15,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/timer/timer.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/NodePath.hpp"
 
 using namespace std;
@@ -37,7 +38,8 @@ static void checkPath(const std::vector<std::string>& expectedPath, const std::s
 }
 
 BOOST_AUTO_TEST_CASE(test_path_extractor_constructor) {
-    cout << "ACore:: ...test_path_extractor_constructor\n";
+    ECF_NAME_THIS_TEST();
+
     BOOST_CHECK(true); // stop boost test from complaining about no checks
 
     std::vector<std::string> theExpectedPath;
@@ -49,7 +51,8 @@ BOOST_AUTO_TEST_CASE(test_path_extractor_constructor) {
 }
 
 BOOST_AUTO_TEST_CASE(test_path_extractor) {
-    cout << "ACore:: ...test_path_extractor\n";
+    ECF_NAME_THIS_TEST();
+
     BOOST_CHECK(true); // stop boost test from complaining about no checks
 
     std::vector<std::string> theExpectedPath;
@@ -62,7 +65,8 @@ BOOST_AUTO_TEST_CASE(test_path_extractor) {
 }
 
 BOOST_AUTO_TEST_CASE(test_unix_path_extractor) {
-    cout << "ACore:: ...test_unix_path_extractor\n";
+    ECF_NAME_THIS_TEST();
+
     BOOST_CHECK(true); // stop boost test from complaining about no checks
 
     // On Unix multiple '/' are treated as one.
@@ -79,7 +83,7 @@ BOOST_AUTO_TEST_CASE(test_unix_path_extractor) {
 }
 
 BOOST_AUTO_TEST_CASE(test_extractHostPort) {
-    cout << "ACore:: ...test_extractHostPort\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path;
     std::string host;
@@ -120,7 +124,7 @@ BOOST_AUTO_TEST_CASE(test_extractHostPort) {
 }
 
 BOOST_AUTO_TEST_CASE(test_NodePath_perf, *boost::unit_test::disabled()) {
-    cout << "ACore:: ...test_NodePath_perf \n";
+    ECF_NAME_THIS_TEST();
 
     // Timing using:
     //    StringSplitter : 6.35

--- a/libs/core/test/TestNodePath.cpp
+++ b/libs/core/test/TestNodePath.cpp
@@ -8,7 +8,6 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <iostream>
 #include <iterator> // std::ostream_iterator
 #include <string>
 
@@ -29,11 +28,12 @@ static void checkPath(const std::vector<std::string>& expectedPath, const std::s
     NodePath::split(path, thePath);
     if (thePath != expectedPath) {
         BOOST_CHECK_MESSAGE(false, "Failed for " << path);
-        std::cout << "Expected '";
-        std::copy(expectedPath.begin(), expectedPath.end(), std::ostream_iterator<std::string>(std::cout, " "));
-        std::cout << "'\nbut found '";
-        std::copy(thePath.begin(), thePath.end(), std::ostream_iterator<std::string>(std::cout, " "));
-        std::cout << "'\n";
+        std::ostringstream oss;
+        oss << "Expected '";
+        std::copy(expectedPath.begin(), expectedPath.end(), std::ostream_iterator<std::string>(oss, " "));
+        oss << "'\nbut found '";
+        std::copy(thePath.begin(), thePath.end(), std::ostream_iterator<std::string>(oss, " "));
+        ECF_TEST_DBG(<< oss.str());
     }
 }
 
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(test_NodePath_perf, *boost::unit_test::disabled()) {
         thePath.clear();
         NodePath::split("/this/is/a/test/string/that/will/be/used/to/check/perf/of/node/path/extraction", thePath);
     }
-    cout << "Timing for " << n << " NodePath is  " << timer.elapsed().wall << endl;
+    ECF_TEST_DBG(<< "Timing for " << n << " NodePath is  " << timer.elapsed().wall);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/core/test/TestPasswdFile.cpp
+++ b/libs/core/test/TestPasswdFile.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/PasswdFile.hpp"
 #include "ecflow/core/PasswordEncryption.hpp"
@@ -76,7 +77,7 @@ void test_passwd_files(const std::string& directory, bool pass) {
 }
 
 BOOST_AUTO_TEST_CASE(test_parsing_for_good_passwd_files) {
-    cout << "ACore:: ...test_parsing_for_good_passwd_files\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/core/test/data/goodPasswdFiles", "libs/core");
 
@@ -85,7 +86,7 @@ BOOST_AUTO_TEST_CASE(test_parsing_for_good_passwd_files) {
 }
 
 BOOST_AUTO_TEST_CASE(test_parsing_for_bad_passwd_files) {
-    cout << "ACore:: ...test_parsing_for_bad_passwd_files\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/core/test/data/badPasswdFiles", "libs/core");
 
@@ -94,7 +95,7 @@ BOOST_AUTO_TEST_CASE(test_parsing_for_bad_passwd_files) {
 }
 
 BOOST_AUTO_TEST_CASE(test_passwd_empty_file) {
-    cout << "ACore:: ...test_passwd_empty_file\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/core/test/data/goodPasswdFiles/empty.passwd", "libs/core");
 
@@ -112,7 +113,7 @@ BOOST_AUTO_TEST_CASE(test_passwd_empty_file) {
 }
 
 BOOST_AUTO_TEST_CASE(test_passwd) {
-    cout << "ACore:: ...test_passwd\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/core/test/data/goodPasswdFiles/ecf.passwd", "libs/core");
 

--- a/libs/core/test/TestPasswdFile.cpp
+++ b/libs/core/test/TestPasswdFile.cpp
@@ -17,7 +17,6 @@
 #include "ecflow/core/PasswdFile.hpp"
 #include "ecflow/core/PasswordEncryption.hpp"
 
-using namespace std;
 using namespace ecf;
 
 // #define DEBUG_ME 1
@@ -33,7 +32,7 @@ void test_passwd_files(const std::string& directory, bool pass) {
     BOOST_CHECK(fs::is_directory(full_path));
 
 #if DEBUG_ME
-    std::cout << "...In directory: " << full_path.relative_path() << "\n";
+    ECF_TEST_DBG(<< "...In directory: " << full_path.relative_path());
 #endif
 
     fs::directory_iterator end_iter;
@@ -47,7 +46,7 @@ void test_passwd_files(const std::string& directory, bool pass) {
                 continue;
             }
 #if DEBUG_ME
-            std::cout << "......Parsing file " << relPath.string() << "\n";
+            ECF_TEST_DBG(<< "......Parsing file " << relPath.string());
 #endif
             PasswdFile theFile;
             std::string errorMsg;
@@ -66,12 +65,12 @@ void test_passwd_files(const std::string& directory, bool pass) {
                                                                   << errorMsg << "\n"
                                                                   << theFile.dump());
 #if DEBUG_ME
-                cout << "\n" << errorMsg << "\n";
+                ECF_TEST_DBG(<< errorMsg);
 #endif
             }
         }
         catch (const std::exception& ex) {
-            std::cout << dir_itr->path().filename() << " " << ex.what() << std::endl;
+            ECF_TEST_DBG(<< dir_itr->path().filename() << " " << ex.what());
         }
     }
 }
@@ -104,7 +103,7 @@ BOOST_AUTO_TEST_CASE(test_passwd_empty_file) {
     BOOST_CHECK_MESSAGE(theFile.load(path, false, errorMsg), "Failed to parse file " << path << "\n" << errorMsg);
 
     BOOST_REQUIRE_MESSAGE(theFile.passwds().empty(), "expected empty file ");
-    BOOST_REQUIRE_MESSAGE(theFile.get_passwd("fred", "host", "port") == string(), "expected empty string");
+    BOOST_REQUIRE_MESSAGE(theFile.get_passwd("fred", "host", "port") == std::string(), "expected empty string");
     BOOST_REQUIRE_MESSAGE(theFile.authenticate("fred", ""),
                           "expected to authenticate. TEST CASE with empty password file");
     BOOST_REQUIRE_MESSAGE(!theFile.authenticate("fred", "passwd"), "expected not to authenticate");

--- a/libs/core/test/TestPasswordEncryption.cpp
+++ b/libs/core/test/TestPasswordEncryption.cpp
@@ -14,6 +14,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/PasswordEncryption.hpp"
 
 BOOST_AUTO_TEST_SUITE(U_Core)
@@ -21,6 +22,8 @@ BOOST_AUTO_TEST_SUITE(U_Core)
 BOOST_AUTO_TEST_SUITE(T_PasswordEncryption)
 
 BOOST_AUTO_TEST_CASE(test_is_able_to_encrypt_password) {
+    ECF_NAME_THIS_TEST();
+
     PasswordEncryption::username_t user               = "username";
     PasswordEncryption::plain_password_t plain        = "password";
     PasswordEncryption::encrypted_password_t expected = "usjRS48E8ZADM";

--- a/libs/core/test/TestPerfTimer.cpp
+++ b/libs/core/test/TestPerfTimer.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Converter.hpp"
 #include "ecflow/core/perf_timer.hpp"
 
@@ -29,15 +30,11 @@ static void func(int const count = 100000) {
 }
 
 BOOST_AUTO_TEST_CASE(test_perf_with_chrono) {
-    cout << "ACore:: ...test_perf_with_chrono\n";
+    ECF_NAME_THIS_TEST();
 
     // using namespace std::chrono_literals;
 
     auto t = perf_timer<>::duration(func, 100000);
-
-    std::cout << "   " << std::chrono::duration<double, std::micro>(t).count() << " micro" << std::endl;
-    std::cout << "   " << std::chrono::duration<double, std::milli>(t).count() << " milli" << std::endl;
-    std::cout << "   " << std::chrono::duration<double, std::nano>(t).count() << " nano" << std::endl;
 
     // This does not work, ie calling func with no arguments ?? with our hacked invoke, wait till c++ 17
     // auto t0= perf_timer<std::chrono::nanoseconds>::duration(func);
@@ -45,24 +42,32 @@ BOOST_AUTO_TEST_CASE(test_perf_with_chrono) {
     auto t1 = perf_timer<std::chrono::nanoseconds>::duration(func, 10);
     auto t2 = perf_timer<std::chrono::microseconds>::duration(func, 100);
     auto t3 = perf_timer<std::chrono::milliseconds>::duration(func, 100000);
+
+#if PRINT_TIMING_RESULTS
+    std::cout << "   " << std::chrono::duration<double, std::micro>(t).count() << " micro" << std::endl;
+    std::cout << "   " << std::chrono::duration<double, std::milli>(t).count() << " milli" << std::endl;
+    std::cout << "   " << std::chrono::duration<double, std::nano>(t).count() << " nano" << std::endl;
     std::cout << "   " << std::chrono::duration<double, std::milli>(t1 + t2 + t3).count() << " milli" << std::endl;
+#endif
+
     BOOST_CHECK_MESSAGE(true, "dummy to keep unit test happy");
 }
 
 BOOST_AUTO_TEST_CASE(test_chrono_timer) {
-    cout << "ACore:: ... test_chrono_timer\n";
+    ECF_NAME_THIS_TEST();
 
     // using namespace std::chrono_literals;
     {
         Timer<std::chrono::milliseconds> timer;
         func();
         timer.elapsed("   func with default args , milliseconds");
-        std::cout << "    " << std::chrono::duration<double, std::micro>(timer.elapsed()).count() << " micro"
-                  << std::endl;
-        std::cout << "    " << std::chrono::duration<double, std::milli>(timer.elapsed()).count() << " milli"
-                  << std::endl;
-        std::cout << "    " << std::chrono::duration<double, std::nano>(timer.elapsed()).count() << " nano"
-                  << std::endl;
+
+#if PRINT_TIMING_RESULTS
+        using namespace std::chrono;
+        std::cout << "    " << duration<double, std::micro>(timer.elapsed()).count() << " micro" << std::endl;
+        std::cout << "    " << duration<double, std::milli>(timer.elapsed()).count() << " milli" << std::endl;
+        std::cout << "    " << duration<double, std::nano>(timer.elapsed()).count() << " nano" << std::endl;
+#endif
     }
     {
         Timer<std::chrono::microseconds> timer;

--- a/libs/core/test/TestPerfTimer.cpp
+++ b/libs/core/test/TestPerfTimer.cpp
@@ -22,7 +22,6 @@ BOOST_AUTO_TEST_SUITE(U_Core)
 BOOST_AUTO_TEST_SUITE(T_PerfTimer)
 
 static void func(int const count = 100000) {
-    // std::cout << " func : count " << count << "\n";
     for (int i = 0; i < count; i++) {
         std::string s = std::string("fred");
         s += ecf::convert_to<std::string>(i);
@@ -34,20 +33,20 @@ BOOST_AUTO_TEST_CASE(test_perf_with_chrono) {
 
     // using namespace std::chrono_literals;
 
-    auto t = perf_timer<>::duration(func, 100000);
+    [[maybe_unused]] auto t = perf_timer<>::duration(func, 100000);
 
     // This does not work, ie calling func with no arguments ?? with our hacked invoke, wait till c++ 17
     // auto t0= perf_timer<std::chrono::nanoseconds>::duration(func);
 
-    auto t1 = perf_timer<std::chrono::nanoseconds>::duration(func, 10);
-    auto t2 = perf_timer<std::chrono::microseconds>::duration(func, 100);
-    auto t3 = perf_timer<std::chrono::milliseconds>::duration(func, 100000);
+    [[maybe_unused]] auto t1 = perf_timer<std::chrono::nanoseconds>::duration(func, 10);
+    [[maybe_unused]] auto t2 = perf_timer<std::chrono::microseconds>::duration(func, 100);
+    [[maybe_unused]] auto t3 = perf_timer<std::chrono::milliseconds>::duration(func, 100000);
 
 #if PRINT_TIMING_RESULTS
-    std::cout << "   " << std::chrono::duration<double, std::micro>(t).count() << " micro" << std::endl;
-    std::cout << "   " << std::chrono::duration<double, std::milli>(t).count() << " milli" << std::endl;
-    std::cout << "   " << std::chrono::duration<double, std::nano>(t).count() << " nano" << std::endl;
-    std::cout << "   " << std::chrono::duration<double, std::milli>(t1 + t2 + t3).count() << " milli" << std::endl;
+    ECF_TEST_DBG(<< "   " << std::chrono::duration<double, std::micro>(t).count() << " micro");
+    ECF_TEST_DBG(<< "   " << std::chrono::duration<double, std::milli>(t).count() << " milli");
+    ECF_TEST_DBG(<< "   " << std::chrono::duration<double, std::nano>(t).count() << " nano");
+    ECF_TEST_DBG(<< "   " << std::chrono::duration<double, std::milli>(t1 + t2 + t3).count() << " milli");
 #endif
 
     BOOST_CHECK_MESSAGE(true, "dummy to keep unit test happy");
@@ -56,7 +55,6 @@ BOOST_AUTO_TEST_CASE(test_perf_with_chrono) {
 BOOST_AUTO_TEST_CASE(test_chrono_timer) {
     ECF_NAME_THIS_TEST();
 
-    // using namespace std::chrono_literals;
     {
         Timer<std::chrono::milliseconds> timer;
         func();
@@ -64,9 +62,9 @@ BOOST_AUTO_TEST_CASE(test_chrono_timer) {
 
 #if PRINT_TIMING_RESULTS
         using namespace std::chrono;
-        std::cout << "    " << duration<double, std::micro>(timer.elapsed()).count() << " micro" << std::endl;
-        std::cout << "    " << duration<double, std::milli>(timer.elapsed()).count() << " milli" << std::endl;
-        std::cout << "    " << duration<double, std::nano>(timer.elapsed()).count() << " nano" << std::endl;
+        ECF_TEST_DBG(<< "    " << duration<double, std::micro>(timer.elapsed()).count() << " micro");
+        ECF_TEST_DBG(<< "    " << duration<double, std::milli>(timer.elapsed()).count() << " milli");
+        ECF_TEST_DBG(<< "    " << duration<double, std::nano>(timer.elapsed()).count() << " nano");
 #endif
     }
     {

--- a/libs/core/test/TestRealCalendar.cpp
+++ b/libs/core/test/TestRealCalendar.cpp
@@ -14,6 +14,7 @@
 #include <boost/date_time/posix_time/time_formatters.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Calendar.hpp"
 #include "ecflow/core/TimeSeries.hpp"
 
@@ -27,7 +28,7 @@ BOOST_AUTO_TEST_SUITE(U_Core)
 BOOST_AUTO_TEST_SUITE(T_RealCalendar)
 
 BOOST_AUTO_TEST_CASE(test_REAL_calendar) {
-    cout << "ACore:: ...test_REAL_calendar\n";
+    ECF_NAME_THIS_TEST();
 
     // init the calendar to 2009, Feb, 10th,
     boost::gregorian::date theDate(2009, 2, 10);
@@ -70,7 +71,7 @@ BOOST_AUTO_TEST_CASE(test_REAL_calendar) {
 }
 
 BOOST_AUTO_TEST_CASE(test_REAL_calendar_time_series_relative_complex) {
-    cout << "ACore:: ...test_REAL_calendar_time_series_relative_complex\n";
+    ECF_NAME_THIS_TEST();
 
     // init the calendar to 2009, Feb, 10th,  0 minutes past midnight
     Calendar calendar;
@@ -141,7 +142,7 @@ BOOST_AUTO_TEST_CASE(test_REAL_calendar_time_series_relative_complex) {
 }
 
 BOOST_AUTO_TEST_CASE(test_REAL_calendar_time_series) {
-    cout << "ACore:: ...test_REAL_calendar_time_series\n";
+    ECF_NAME_THIS_TEST();
 
     // init the calendar to 2009, Feb, 10th,  0 minutes past midnight
     Calendar calendar;
@@ -175,7 +176,7 @@ BOOST_AUTO_TEST_CASE(test_REAL_calendar_time_series) {
 }
 
 BOOST_AUTO_TEST_CASE(test_REAL_calendar_time_series_complex) {
-    cout << "ACore:: ...test_REAL_calendar_time_series_complex\n";
+    ECF_NAME_THIS_TEST();
 
     // init the calendar to 2009, Feb, 10th,  0 minutes past midnight
     Calendar calendar;
@@ -243,7 +244,7 @@ BOOST_AUTO_TEST_CASE(test_REAL_calendar_time_series_complex) {
 }
 
 BOOST_AUTO_TEST_CASE(test_REAL_calendar_hybrid_date) {
-    cout << "ACore:: ...test_REAL_calendar_hybrid_date\n";
+    ECF_NAME_THIS_TEST();
 
     // The hybrid calendar should not change the suite date.
     // Test by updateing calendar by more than 24 hours
@@ -284,7 +285,7 @@ BOOST_AUTO_TEST_CASE(test_REAL_calendar_hybrid_date) {
 }
 
 BOOST_AUTO_TEST_CASE(test_REAL_day_changed) {
-    cout << "ACore:: ...test_REAL_day_changed \n";
+    ECF_NAME_THIS_TEST();
 
     // init the calendar to 2009, Feb, 10th,  0 minutes past midnight
     Calendar calendar;
@@ -312,7 +313,7 @@ BOOST_AUTO_TEST_CASE(test_REAL_day_changed) {
 }
 
 BOOST_AUTO_TEST_CASE(test_REAL_day_changed_for_hybrid) {
-    cout << "ACore:: ...test_REAL_day_changed_for_hybrid\n";
+    ECF_NAME_THIS_TEST();
 
     // init the calendar to 2009, Feb, 10th,  0 minutes past midnight
     Calendar calendar;

--- a/libs/core/test/TestRealCalendar.cpp
+++ b/libs/core/test/TestRealCalendar.cpp
@@ -8,7 +8,6 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <iostream>
 #include <string>
 
 #include <boost/date_time/posix_time/time_formatters.hpp>
@@ -18,7 +17,6 @@
 #include "ecflow/core/Calendar.hpp"
 #include "ecflow/core/TimeSeries.hpp"
 
-using namespace std;
 using namespace ecf;
 using namespace boost::posix_time;
 using namespace boost::gregorian;
@@ -114,12 +112,12 @@ BOOST_AUTO_TEST_CASE(test_REAL_calendar_time_series_relative_complex) {
                                         << suiteTm.tm_hour << ":" << suiteTm.tm_min
                                         << " suite time = " << to_simple_string(calendar.suiteTime()));
                 if (!matches) {
-                    cerr << "suiteTm.tm_hour =" << suiteTm.tm_hour << " suiteTm.tm_min = " << suiteTm.tm_min
-                         << " timeSeries.start().hour() " << timeSeries.start().hour()
-                         << " timeSeries.start().minute() " << timeSeries.start().minute()
-                         << " timeSeries.finish().hour() " << timeSeries.finish().hour()
-                         << " timeSeries.finish().minute() " << timeSeries.finish().minute()
-                         << " suiteTm.tm_min % 15 = " << suiteTm.tm_min % 15 << "\n";
+                    ECF_TEST_DBG(<< "suiteTm.tm_hour =" << suiteTm.tm_hour << " suiteTm.tm_min = " << suiteTm.tm_min
+                                 << " timeSeries.start().hour() " << timeSeries.start().hour()
+                                 << " timeSeries.start().minute() " << timeSeries.start().minute()
+                                 << " timeSeries.finish().hour() " << timeSeries.finish().hour()
+                                 << " timeSeries.finish().minute() " << timeSeries.finish().minute()
+                                 << " suiteTm.tm_min % 15 = " << suiteTm.tm_min % 15);
                 }
             }
             else {
@@ -129,12 +127,12 @@ BOOST_AUTO_TEST_CASE(test_REAL_calendar_time_series_relative_complex) {
                                         << " suite time = " << to_simple_string(calendar.suiteTime()));
 
                 if (matches) {
-                    cerr << "suiteTm.tm_hour =" << suiteTm.tm_hour << " suiteTm.tm_min = " << suiteTm.tm_min
-                         << " timeSeries.start().hour() " << timeSeries.start().hour()
-                         << " timeSeries.start().minute() " << timeSeries.start().minute()
-                         << " timeSeries.finish().hour() " << timeSeries.finish().hour()
-                         << " timeSeries.finish().minute() " << timeSeries.finish().minute()
-                         << " suiteTm.tm_min % 15 = " << suiteTm.tm_min % 15 << "\n";
+                    ECF_TEST_DBG(<< "suiteTm.tm_hour =" << suiteTm.tm_hour << " suiteTm.tm_min = " << suiteTm.tm_min
+                                 << " timeSeries.start().hour() " << timeSeries.start().hour()
+                                 << " timeSeries.start().minute() " << timeSeries.start().minute()
+                                 << " timeSeries.finish().hour() " << timeSeries.finish().hour()
+                                 << " timeSeries.finish().minute() " << timeSeries.finish().minute()
+                                 << " suiteTm.tm_min % 15 = " << suiteTm.tm_min % 15);
                 }
             }
         }
@@ -165,7 +163,6 @@ BOOST_AUTO_TEST_CASE(test_REAL_calendar_time_series) {
 
         calendar.update(time_now);
 
-        // cerr << "hour = " << hour << " suiteTime " << to_simple_string(calendar.suiteTime())  << "\n";
         if (hour >= timeSeries.start().hour() && hour <= timeSeries.finish().hour()) {
             BOOST_CHECK_MESSAGE(timeSeries.isFree(calendar), "Calendar should match time series at hour " << hour);
         }
@@ -216,12 +213,12 @@ BOOST_AUTO_TEST_CASE(test_REAL_calendar_time_series_complex) {
                                         << suiteTm.tm_hour << ":" << suiteTm.tm_min
                                         << " suite time = " << to_simple_string(calendar.suiteTime()));
                 if (!matches) {
-                    cerr << "suiteTm.tm_hour =" << suiteTm.tm_hour << " suiteTm.tm_min = " << suiteTm.tm_min
-                         << " timeSeries.start().hour() " << timeSeries.start().hour()
-                         << " timeSeries.start().minute() " << timeSeries.start().minute()
-                         << " timeSeries.finish().hour() " << timeSeries.finish().hour()
-                         << " timeSeries.finish().minute() " << timeSeries.finish().minute()
-                         << " suiteTm.tm_min % 15 = " << suiteTm.tm_min % 15 << "\n";
+                    ECF_TEST_DBG(<< "suiteTm.tm_hour =" << suiteTm.tm_hour << " suiteTm.tm_min = " << suiteTm.tm_min
+                                 << " timeSeries.start().hour() " << timeSeries.start().hour()
+                                 << " timeSeries.start().minute() " << timeSeries.start().minute()
+                                 << " timeSeries.finish().hour() " << timeSeries.finish().hour()
+                                 << " timeSeries.finish().minute() " << timeSeries.finish().minute()
+                                 << " suiteTm.tm_min % 15 = " << suiteTm.tm_min % 15);
                 }
             }
             else {
@@ -231,12 +228,12 @@ BOOST_AUTO_TEST_CASE(test_REAL_calendar_time_series_complex) {
                                         << " suite time = " << to_simple_string(calendar.suiteTime()));
 
                 if (matches) {
-                    cerr << "suiteTm.tm_hour =" << suiteTm.tm_hour << " suiteTm.tm_min = " << suiteTm.tm_min
-                         << " timeSeries.start().hour() " << timeSeries.start().hour()
-                         << " timeSeries.start().minute() " << timeSeries.start().minute()
-                         << " timeSeries.finish().hour() " << timeSeries.finish().hour()
-                         << " timeSeries.finish().minute() " << timeSeries.finish().minute()
-                         << " suiteTm.tm_min % 15 = " << suiteTm.tm_min % 15 << "\n";
+                    ECF_TEST_DBG(<< "suiteTm.tm_hour =" << suiteTm.tm_hour << " suiteTm.tm_min = " << suiteTm.tm_min
+                                 << " timeSeries.start().hour() " << timeSeries.start().hour()
+                                 << " timeSeries.start().minute() " << timeSeries.start().minute()
+                                 << " timeSeries.finish().hour() " << timeSeries.finish().hour()
+                                 << " timeSeries.finish().minute() " << timeSeries.finish().minute()
+                                 << " suiteTm.tm_min % 15 = " << suiteTm.tm_min % 15);
                 }
             }
         }
@@ -267,9 +264,6 @@ BOOST_AUTO_TEST_CASE(test_REAL_calendar_hybrid_date) {
         calendar.update(time_now);
 
         ptime timeAfterUpdate = calendar.suiteTime();
-
-        //		cerr << "hour = " << hour << " timeBeforeUpdate " << to_simple_string(timeBeforeUpdate)
-        //		    << "   timeAfterUpdate = " << to_simple_string(timeAfterUpdate) <<  "\n";
 
         if (hour != 24 && hour != 48) {
             time_period diff(timeBeforeUpdate, timeAfterUpdate);

--- a/libs/core/test/TestSanitizerAS.cpp
+++ b/libs/core/test/TestSanitizerAS.cpp
@@ -8,12 +8,30 @@
  * nor does it submit to any jurisdiction.
  */
 
+#include <cstdlib>
 #include <iostream>
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
+
 using namespace boost;
 using namespace std;
+
+static bool is_sanitizer_available() {
+
+    /*
+     * This condition is used to skip the test if the sanitizer is not available.
+     *
+     * The implementation to skip a test is currently to short-circuit into early termination.
+     * A better approach would be to use the boost::unit_test::precondition() decorator to skip the test based on
+     * a runtime condition.
+     * Unfortunatelly this approach does not work when using Boost 1.66 @ Rocky 8.6.
+     */
+
+    bool is_available = ::getenv("ECF_TEST_SANITIZER_AS") != nullptr;
+    return is_available;
+}
 
 BOOST_AUTO_TEST_SUITE(U_Core)
 
@@ -33,20 +51,21 @@ int integer_returning_function() {
 
 // *** This test does not seem work with address sanitiser ****
 BOOST_AUTO_TEST_CASE(test_sanitizer_use_of_out_of_scope_stack_memory) {
-    char* test_me = getenv("ECF_TEST_SANITIZER_AS");
-    if (test_me) {
-        cout << "ACore:: ...test_sanitizer_use_of_out_of_scope_stack_memory\n";
+    ECF_NAME_THIS_TEST();
 
-        int* pointer = NULL;
-        if (bool_returning_function()) {
-            int value = integer_returning_function();
-            pointer   = &value;
-        }
-        cout << "dodgy pointer:" << *pointer << "\n"; // Error: invalid access of stack memory out of declaration scope
-        *pointer = 42;
-        cout << "dodgy pointer:" << *pointer << "\n";
-        BOOST_CHECK_MESSAGE(true, "stop boost test from complaining");
+    if (!is_sanitizer_available()) {
+        return;
     }
+
+    int* pointer = NULL;
+    if (bool_returning_function()) {
+        int value = integer_returning_function();
+        pointer   = &value;
+    }
+    cout << "dodgy pointer:" << *pointer << "\n"; // Error: invalid access of stack memory out of declaration scope
+    *pointer = 42;
+    cout << "dodgy pointer:" << *pointer << "\n";
+    BOOST_CHECK_MESSAGE(true, "stop boost test from complaining");
 }
 
 #if defined(__GNUC__) and !defined(__clang__)
@@ -59,19 +78,21 @@ BOOST_AUTO_TEST_CASE(test_sanitizer_use_of_out_of_scope_stack_memory) {
 #endif
 
 BOOST_AUTO_TEST_CASE(test_sanitizer_vector_overflow) {
-    char* test_me = getenv("ECF_TEST_SANITIZER_AS");
-    if (test_me) {
-        cout << "ACore:: ...test_sanitizer_vector_overflow\n";
-        // This check detects when a libc++ container is accessed beyond the region [container.begin(), container.end())
-        // — even when the accessed memory is in a heap-allocated buffer used internally by a container.
+    ECF_NAME_THIS_TEST();
 
-        // the following example, the vector variable has valid indexes in the range [0, 2], but is accessed at index 3,
-        // causing an overflow.
-        std::vector<int> vector{0, 1, 2};
-        auto* pointer = &vector[0];
-        cout << pointer[3]; // Error: out of bounds access for vector
-        BOOST_CHECK_MESSAGE(true, "stop boost test from complaining");
+    if (!is_sanitizer_available()) {
+        return;
     }
+
+    // This check detects when a libc++ container is accessed beyond the region [container.begin(), container.end())
+    // — even when the accessed memory is in a heap-allocated buffer used internally by a container.
+
+    // the following example, the vector variable has valid indexes in the range [0, 2], but is accessed at index 3,
+    // causing an overflow.
+    std::vector<int> vector{0, 1, 2};
+    auto* pointer = &vector[0];
+    cout << pointer[3]; // Error: out of bounds access for vector
+    BOOST_CHECK_MESSAGE(true, "stop boost test from complaining");
 }
 
 #if defined(__GNUC__) and !defined(__clang__)

--- a/libs/core/test/TestSanitizerAS.cpp
+++ b/libs/core/test/TestSanitizerAS.cpp
@@ -9,7 +9,6 @@
  */
 
 #include <cstdlib>
-#include <iostream>
 
 #include <boost/test/unit_test.hpp>
 

--- a/libs/core/test/TestSanitizerUB.cpp
+++ b/libs/core/test/TestSanitizerUB.cpp
@@ -8,12 +8,30 @@
  * nor does it submit to any jurisdiction.
  */
 
+#include <cstdlib>
 #include <iostream>
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
+
 using namespace boost;
 using namespace std;
+
+static bool is_sanitizer_available() {
+
+    /*
+     * This condition is used to skip the test if the sanitizer is not available.
+     *
+     * The implementation to skip a test is currently to short-circuit into early termination.
+     * A better approach would be to use the boost::unit_test::precondition() decorator to skip the test based on
+     * a runtime condition.
+     * Unfortunatelly this approach does not work when using Boost 1.66 @ Rocky 8.6.
+     */
+
+    bool is_available = ::getenv("ECF_TEST_SANITIZER_UB") != nullptr;
+    return is_available;
+}
 
 BOOST_AUTO_TEST_SUITE(U_Core)
 
@@ -37,15 +55,16 @@ Derived* getDerived() {
 #endif
 
 BOOST_AUTO_TEST_CASE(test_sanitizer_invalid_object_size) {
-    char* test_me = getenv("ECF_TEST_SANITIZER_UB");
-    if (test_me) {
-        cout << "ACore:: ...test_sanitizer_invalid_object_size\n";
+    ECF_NAME_THIS_TEST();
 
-        // This check detects pointer casts in which the size of the source type is less than the size of the
-        // destination type. Using the result of such a cast to access out-of-bounds data has undefined behaviour
-        cout << getDerived()->pad2 << "\n";
-        BOOST_CHECK_MESSAGE(true, "stop boost test from complaining");
+    if (!is_sanitizer_available()) {
+        return;
     }
+
+    // This check detects pointer casts in which the size of the source type is less than the size of the
+    // destination type. Using the result of such a cast to access out-of-bounds data has undefined behaviour
+    cout << getDerived()->pad2 << "\n";
+    BOOST_CHECK_MESSAGE(true, "stop boost test from complaining");
 }
 
 #if defined(__GNUC__) and !defined(__clang__)
@@ -53,43 +72,45 @@ BOOST_AUTO_TEST_CASE(test_sanitizer_invalid_object_size) {
 #endif
 
 BOOST_AUTO_TEST_CASE(test_sanitizer_misaligned_structure_pointer_assignment) {
-    char* test_me = getenv("ECF_TEST_SANITIZER_UB");
-    if (test_me) {
-        cout << "ACore:: ...test_sanitizer_misaligned_structure_pointer_assignment\n";
-        // In the following example, the pointer variable is required to have 8-byte alignment, but is only 1-byte
-        // aligned.
+    ECF_NAME_THIS_TEST();
 
-        struct A
-        {
-            int32_t i32;
-            int64_t i64;
-        };
-        int8_t* buffer    = (int8_t*)malloc(32);
-        struct A* pointer = (struct A*)(buffer + 1);
-        pointer->i32      = 7; // Error: pointer is misaligned
-
-        BOOST_CHECK_MESSAGE(pointer->i32 == 7, "expected error");
-
-        // solution
-        // One solution is to mark the struct as packed. In the following example, the A structure is packed,
-        // preventing the compiler from adding padding between members.
-        // struct A { ... } __attribute__((packed));
-        BOOST_CHECK_MESSAGE(true, "stop boost test from complaining");
+    if (!is_sanitizer_available()) {
+        return;
     }
+
+    // In the following example, the pointer variable is required to have 8-byte alignment, but is only 1-byte
+
+    struct A
+    {
+        int32_t i32;
+        int64_t i64;
+    };
+    int8_t* buffer    = (int8_t*)malloc(32);
+    struct A* pointer = (struct A*)(buffer + 1);
+    pointer->i32      = 7; // Error: pointer is misaligned
+
+    BOOST_CHECK_MESSAGE(pointer->i32 == 7, "expected error");
+
+    // solution
+    // One solution is to mark the struct as packed. In the following example, the A structure is packed,
+    // preventing the compiler from adding padding between members.
+    // struct A { ... } __attribute__((packed));
+    BOOST_CHECK_MESSAGE(true, "stop boost test from complaining");
 }
 
 BOOST_AUTO_TEST_CASE(test_sanitizer_out_of_bounds_array_access) {
-    char* test_me = getenv("ECF_TEST_SANITIZER_UB");
-    if (test_me) {
-        cout << "ACore:: ...test_sanitizer_out_of_bounds_array_access\n";
+    ECF_NAME_THIS_TEST();
 
-        // This check detects out-of-bounds access of arrays with fixed or variable-length sizes.
-        // Out-of-bounds array accesses have undefined behaviour, and can result in crashes or incorrect program output.
-        int array[5] = {0, 0, 0, 0, 0};
-        for (int i = 0; i <= 5; ++i) {
-            array[i] += 1; // Error: out-of-bounds access on the last iteration
-            BOOST_REQUIRE_NO_THROW(array[i] += 1);
-        }
+    if (!is_sanitizer_available()) {
+        return;
+    }
+
+    // This check detects out-of-bounds access of arrays with fixed or variable-length sizes.
+    // Out-of-bounds array accesses have undefined behaviour, and can result in crashes or incorrect program output.
+    int array[5] = {0, 0, 0, 0, 0};
+    for (int i = 0; i <= 5; ++i) {
+        array[i] += 1; // Error: out-of-bounds access on the last iteration
+        BOOST_REQUIRE_NO_THROW(array[i] += 1);
     }
 }
 
@@ -105,14 +126,15 @@ struct A
 };
 
 BOOST_AUTO_TEST_CASE(test_sanitizer_member_access_through_null_pointer) {
-    char* test_me = getenv("ECF_TEST_SANITIZER_UB");
-    if (test_me) {
-        cout << "ACore:: ...test_sanitizer_member_access_through_null_pointer \n";
+    ECF_NAME_THIS_TEST();
 
-        A* a  = nullptr;
-        int x = a->getX(); // Error: member access through null pointer
-        BOOST_CHECK_MESSAGE(x, "stop boost test from complaining");
+    if (!is_sanitizer_available()) {
+        return;
     }
+
+    A* a  = nullptr;
+    int x = a->getX(); // Error: member access through null pointer
+    BOOST_CHECK_MESSAGE(x, "stop boost test from complaining");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/core/test/TestSanitizerUB.cpp
+++ b/libs/core/test/TestSanitizerUB.cpp
@@ -9,7 +9,6 @@
  */
 
 #include <cstdlib>
-#include <iostream>
 
 #include <boost/test/unit_test.hpp>
 

--- a/libs/core/test/TestSerialisation.cpp
+++ b/libs/core/test/TestSerialisation.cpp
@@ -16,7 +16,6 @@
 #include "ecflow/core/Calendar.hpp"
 #include "ecflow/core/TimeSeries.hpp"
 
-using namespace std;
 using namespace ecf;
 using namespace boost::posix_time;
 using namespace boost::gregorian;

--- a/libs/core/test/TestSerialisation.cpp
+++ b/libs/core/test/TestSerialisation.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Calendar.hpp"
 #include "ecflow/core/TimeSeries.hpp"
 
@@ -27,14 +28,14 @@ BOOST_AUTO_TEST_SUITE(U_Core)
 BOOST_AUTO_TEST_SUITE(T_Serialisation)
 
 BOOST_AUTO_TEST_CASE(test_calendar_serialisation) {
-    cout << "ACore:: ...test_calendar_serialisation \n";
+    ECF_NAME_THIS_TEST();
 
     Calendar cal;
     doSaveAndRestore(fileName, cal);
 }
 
 BOOST_AUTO_TEST_CASE(test_TimeSlot_serialisation) {
-    cout << "ACore:: ...test_TimeSlot_serialisation \n";
+    ECF_NAME_THIS_TEST();
 
     { doSaveAndRestore<TimeSlot>(fileName); }
 
@@ -50,7 +51,7 @@ BOOST_AUTO_TEST_CASE(test_TimeSlot_serialisation) {
 }
 
 BOOST_AUTO_TEST_CASE(test_TimeSeries_serialisation) {
-    cout << "ACore:: ...test_TimeSeries_serialisation \n";
+    ECF_NAME_THIS_TEST();
 
     { doSaveAndRestore<TimeSeries>(fileName); }
     {

--- a/libs/core/test/TestSerialisation.hpp
+++ b/libs/core/test/TestSerialisation.hpp
@@ -11,6 +11,9 @@
 #ifndef ecflow_core_TestSerialisation_HPP
 #define ecflow_core_TestSerialisation_HPP
 
+#include <exception>
+#include <string>
+
 #include <boost/test/unit_test.hpp>
 
 #include "ecflow/core/Serialization.hpp"

--- a/libs/core/test/TestStr.cpp
+++ b/libs/core/test/TestStr.cpp
@@ -16,6 +16,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/timer/timer.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Converter.hpp"
 #include "ecflow/core/Str.hpp"
 #include "ecflow/core/StringSplitter.hpp"
@@ -29,7 +30,7 @@ BOOST_AUTO_TEST_SUITE(U_Core)
 BOOST_AUTO_TEST_SUITE(T_Str)
 
 BOOST_AUTO_TEST_CASE(test_str) {
-    cout << "ACore:: ...test_str\n";
+    ECF_NAME_THIS_TEST();
 
     {
         std::string str;
@@ -213,7 +214,7 @@ static void check_splitters(const std::string& line, const std::vector<std::stri
 }
 
 BOOST_AUTO_TEST_CASE(test_str_split) {
-    cout << "ACore:: ...test_str_split\n";
+    ECF_NAME_THIS_TEST();
 
     std::vector<std::string> expected;
 
@@ -308,7 +309,7 @@ BOOST_AUTO_TEST_CASE(test_str_split) {
 }
 
 BOOST_AUTO_TEST_CASE(test_str_split_make_split_iterator) {
-    cout << "ACore:: ...test_str_split_make_split_iterator\n";
+    ECF_NAME_THIS_TEST();
 
     std::string line = "This is a string";
     std::vector<std::string> expected;
@@ -440,7 +441,7 @@ static void test_replace_all(std::string& testStr,
 }
 
 BOOST_AUTO_TEST_CASE(test_str_replace) {
-    cout << "ACore:: ...test_str_replace\n";
+    ECF_NAME_THIS_TEST();
 
     std::string testStr = "This is a string";
     test_replace(testStr, "This", "That", "That is a string");
@@ -466,7 +467,7 @@ BOOST_AUTO_TEST_CASE(test_str_replace) {
 }
 
 BOOST_AUTO_TEST_CASE(test_str_replace_all) {
-    cout << "ACore:: ...test_str_replace_all\n";
+    ECF_NAME_THIS_TEST();
 
     std::string testStr = "This is a string";
     test_replace_all(testStr, "This", "That", "That is a string");
@@ -488,7 +489,8 @@ BOOST_AUTO_TEST_CASE(test_str_replace_all) {
 }
 
 BOOST_AUTO_TEST_CASE(test_str_to_int) {
-    cout << "ACore:: ...test_str(to_int)\n";
+    ECF_NAME_THIS_TEST();
+
     BOOST_CHECK_MESSAGE(Str::to_int("0") == 0, "Expected 0");
     BOOST_CHECK_MESSAGE(Str::to_int("1") == 1, "Expected 1");
     BOOST_CHECK_MESSAGE(Str::to_int("-0") == 0, "Expected 0");
@@ -504,7 +506,8 @@ BOOST_AUTO_TEST_CASE(test_str_to_int) {
 }
 
 BOOST_AUTO_TEST_CASE(test_extract_data_member_value) {
-    cout << "ACore:: ...test_extract_data_member_value\n";
+    ECF_NAME_THIS_TEST();
+
     std::string expected = "value";
     std::string actual;
     std::string str = "aa bb c fred:value";
@@ -540,7 +543,7 @@ std::string toString(const std::vector<std::string>& c) {
 }
 
 BOOST_AUTO_TEST_CASE(test_str_less_greater) {
-    cout << "ACore:: ...test_str_less_greater\n";
+    ECF_NAME_THIS_TEST();
 
     std::vector<std::string> expected;
     expected.emplace_back("a1");
@@ -663,6 +666,8 @@ private:
 };
 
 BOOST_AUTO_TEST_CASE(test_loop, *boost::unit_test::disabled()) {
+    ECF_NAME_THIS_TEST();
+
     const size_t size = 200000000;
     std::vector<Fred> vec;
     vec.reserve(size);
@@ -763,7 +768,7 @@ static void method3(const std::string& str, std::vector<std::string>& stringRes,
 }
 
 BOOST_AUTO_TEST_CASE(test_lexical_cast_perf, *boost::unit_test::disabled()) {
-    cout << "ACore:: ...test_string_to_int_conversion\n";
+    ECF_NAME_THIS_TEST();
 
     size_t the_size = 1000000;
     std::vector<std::string> stringTokens;
@@ -848,7 +853,7 @@ BOOST_AUTO_TEST_CASE(test_lexical_cast_perf, *boost::unit_test::disabled()) {
 }
 
 BOOST_AUTO_TEST_CASE(test_int_to_str_perf, *boost::unit_test::disabled()) {
-    cout << "ACore:: ...test_int_to_str_perf\n";
+    ECF_NAME_THIS_TEST();
 
     // Lexical_cast is approx twice as fast as using streams
     // time for ostream = 0.97
@@ -877,7 +882,7 @@ BOOST_AUTO_TEST_CASE(test_int_to_str_perf, *boost::unit_test::disabled()) {
 }
 
 BOOST_AUTO_TEST_CASE(test_str_valid_name) {
-    cout << "ACore:: ...test_str_valid_name\n";
+    ECF_NAME_THIS_TEST();
 
     std::vector<std::string> valid;
     valid.emplace_back("a");

--- a/libs/core/test/TestStr.cpp
+++ b/libs/core/test/TestStr.cpp
@@ -10,7 +10,6 @@
 
 #include <algorithm>
 #include <functional>
-#include <iostream>
 #include <string>
 
 #include <boost/test/unit_test.hpp>
@@ -21,7 +20,6 @@
 #include "ecflow/core/Str.hpp"
 #include "ecflow/core/StringSplitter.hpp"
 
-using namespace std;
 using namespace ecf;
 using namespace boost;
 
@@ -75,11 +73,11 @@ BOOST_AUTO_TEST_CASE(test_str) {
         BOOST_CHECK_MESSAGE(str == expected, " Expected " << expected << " but found " << str);
     }
     {
-        string test;
+        std::string test;
         BOOST_CHECK_MESSAGE(!Str::truncate_at_start(test, 7), "Empty sring should return false");
 
-        test            = "this\nis\na\nstring\nwith\nlots\nof\nnew\nline";
-        string expected = "line";
+        test                 = "this\nis\na\nstring\nwith\nlots\nof\nnew\nline";
+        std::string expected = "line";
         BOOST_CHECK_MESSAGE(Str::truncate_at_start(test, 1) && test == expected,
                             "Expected:\n"
                                 << expected << "\nbut found:\n"
@@ -100,11 +98,11 @@ BOOST_AUTO_TEST_CASE(test_str) {
                                 << test);
     }
     {
-        string test;
+        std::string test;
         BOOST_CHECK_MESSAGE(!Str::truncate_at_end(test, 7), "Empty string should return false");
 
-        test            = "this\nis\na\nstring\nwith\nlots\nof\nnew\nline";
-        string expected = "this\n";
+        test                 = "this\nis\na\nstring\nwith\nlots\nof\nnew\nline";
+        std::string expected = "this\n";
         BOOST_CHECK_MESSAGE(Str::truncate_at_end(test, 1) && test == expected,
                             "Expected:\n"
                                 << expected << "\nbut found:\n"
@@ -140,17 +138,15 @@ check(const std::string& line, const std::vector<std::string>& result, const std
                                          << "'");
     BOOST_CHECK_MESSAGE(result == expected, "failed for '" << line << "'");
     if (result != expected) {
-        cout << "Line    :'" << line << "'\n";
-        cout << "Actual  :";
-        for (const string& t : result) {
-            cout << "'" << t << "'";
+        ECF_TEST_DBG(<< "Line    :'" << line);
+        ECF_TEST_DBG(<< "Actual  :");
+        for (const std::string& t : result) {
+            ECF_TEST_DBG(<< "   '" << t << "'");
         }
-        cout << "\n";
-        cout << "Expected:";
-        for (const string& t : expected) {
-            cout << "'" << t << "'";
+        ECF_TEST_DBG(<< "Expected:");
+        for (const std::string& t : expected) {
+            ECF_TEST_DBG(<< "'" << t << "'");
         }
-        cout << "\n";
     }
 }
 
@@ -645,17 +641,17 @@ BOOST_AUTO_TEST_CASE(test_str_less_greater) {
 //// ==============================================================
 class Fred {
 public:
-    explicit Fred(int i = 0) : i_(i) { /*std::cout << "Fred constructor\n"*/
+    explicit Fred(int i = 0) : i_(i) {
         // Do nothing...
     }
-    Fred(const Fred& rhs) : i_(rhs.i_) { /*std::cout << "Fred copy constructor\n";*/
+    Fred(const Fred& rhs) : i_(rhs.i_) {
         // Do nothing...
     }
-    Fred& operator=(const Fred& rhs) { /*std::cout << "assignment operator\n";*/
+    Fred& operator=(const Fred& rhs) {
         i_ = rhs.i_;
         return *this;
     }
-    ~Fred() { /*std::cout << "Fred destructor\n";*/
+    ~Fred() {
         // Do nothing...
     }
 
@@ -680,25 +676,25 @@ BOOST_AUTO_TEST_CASE(test_loop, *boost::unit_test::disabled()) {
         for (auto& fred : vec) {
             fred.inc();
         }
-        cout << "Time: for(auto &fred : vec) { fred.inc(); }                                                "
-             << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< "Time: for(auto &fred : vec) { fred.inc(); }                                                "
+                     << timer.format(3, Str::cpu_timer_format()));
     }
 
     {
         boost::timer::cpu_timer timer;
         std::for_each(vec.begin(), vec.end(), [](Fred& fred) { fred.inc(); });
-        cout << "Time: std::for_each(vec.begin(),vec.end(),[](Fred& fred) { fred.inc();} );                 "
-             << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< "Time: std::for_each(vec.begin(),vec.end(),[](Fred& fred) { fred.inc();} );                 "
+                     << timer.format(3, Str::cpu_timer_format()));
     }
 
     {
         boost::timer::cpu_timer timer;
-        std::vector<Fred>::iterator theEnd = vec.end();
-        for (std::vector<Fred>::iterator i = vec.begin(); i < theEnd; i++) {
+        auto theEnd = vec.end();
+        for (auto i = vec.begin(); i < theEnd; i++) {
             (*i).inc();
         }
-        cout << "Time: for (std::vector<Fred>::iterator  i = vec.begin(); i < theEnd ; i++) { (*i).inc(); } "
-             << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< "Time: for (std::vector<Fred>::iterator  i = vec.begin(); i < theEnd ; i++) { (*i).inc(); } "
+                     << timer.format(3, Str::cpu_timer_format()));
     }
 
     {
@@ -707,8 +703,8 @@ BOOST_AUTO_TEST_CASE(test_loop, *boost::unit_test::disabled()) {
         for (size_t i = 0; i < theSize; i++) {
             vec[i].inc();
         }
-        cout << "Time: for (size_t i = 0; i < theSize ; i++) { vec[i].inc(); }                              "
-             << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< "Time: for (size_t i = 0; i < theSize ; i++) { vec[i].inc(); }                              "
+                     << timer.format(3, Str::cpu_timer_format()));
     }
 }
 
@@ -795,7 +791,7 @@ BOOST_AUTO_TEST_CASE(test_lexical_cast_perf, *boost::unit_test::disabled()) {
         for (size_t i = 0; i < numberTokens.size(); i++) {
             method1(numberTokens[i], stringRes, numberRes);
         }
-        cout << "Time for method1  elapsed time = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< "Time for method1  elapsed time = " << timer.format(3, Str::cpu_timer_format()));
         BOOST_CHECK_MESSAGE(numberRes == expectedNumberRes, " method 1 wrong");
         BOOST_CHECK_MESSAGE(stringTokens == stringRes, "method 1 wrong");
         numberRes.clear();
@@ -810,7 +806,7 @@ BOOST_AUTO_TEST_CASE(test_lexical_cast_perf, *boost::unit_test::disabled()) {
         for (size_t i = 0; i < numberTokens.size(); i++) {
             methodX(numberTokens[i], stringRes, numberRes);
         }
-        cout << "Time for methodX  elapsed time = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< "Time for methodX  elapsed time = " << timer.format(3, Str::cpu_timer_format()));
         BOOST_CHECK_MESSAGE(numberRes == expectedNumberRes, " method X wrong");
         BOOST_CHECK_MESSAGE(stringTokens == stringRes, "method X wrong");
         numberRes.clear();
@@ -825,7 +821,7 @@ BOOST_AUTO_TEST_CASE(test_lexical_cast_perf, *boost::unit_test::disabled()) {
         for (size_t i = 0; i < numberTokens.size(); i++) {
             method2(numberTokens[i], stringRes, numberRes);
         }
-        cout << "Time for method2  elapsed time = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG("Time for method2  elapsed time = " << timer.format(3, Str::cpu_timer_format()));
         BOOST_CHECK_MESSAGE(numberRes == expectedNumberRes, "method 2 wrong");
         BOOST_CHECK_MESSAGE(stringTokens == stringRes, "method 2 wrong");
         numberRes.clear();
@@ -840,7 +836,7 @@ BOOST_AUTO_TEST_CASE(test_lexical_cast_perf, *boost::unit_test::disabled()) {
         for (size_t i = 0; i < numberTokens.size(); i++) {
             method3(numberTokens[i], stringRes, numberRes);
         }
-        cout << "Time for method3  elapsed time = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< "Time for method3  elapsed time = " << timer.format(3, Str::cpu_timer_format()));
         BOOST_CHECK_MESSAGE(numberRes == expectedNumberRes,
                             " method3 wrong numberRes.size()=" << numberRes.size()
                                                                << " expected size = " << expectedNumberRes.size());
@@ -867,8 +863,8 @@ BOOST_AUTO_TEST_CASE(test_int_to_str_perf, *boost::unit_test::disabled()) {
             st << i;
             std::string s = st.str();
         }
-        cout << "Time for int to string using ostringstream  elapsed time = "
-             << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(
+            "Time for int to string using ostringstream  elapsed time = " << timer.format(3, Str::cpu_timer_format()));
     }
 
     {
@@ -876,8 +872,8 @@ BOOST_AUTO_TEST_CASE(test_int_to_str_perf, *boost::unit_test::disabled()) {
         for (size_t i = 0; i < the_size; i++) {
             std::string s = ecf::convert_to<std::string>(i);
         }
-        cout << "Time for int to string using ecf::convert_to elapsed time = "
-             << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(
+            "Time for int to string using ecf::convert_to elapsed time = " << timer.format(3, Str::cpu_timer_format()));
     }
 }
 

--- a/libs/core/test/TestStringSplitPerf.cpp
+++ b/libs/core/test/TestStringSplitPerf.cpp
@@ -22,6 +22,7 @@
 
     #include <boost/timer/timer.hpp>
 
+    #include "TestNaming.hpp"
     #include "ecflow/core/File.hpp"
     #include "ecflow/core/Str.hpp"
     #include "ecflow/core/StringSplitter.hpp"
@@ -48,7 +49,8 @@ std::vector<std::string> split_using_getline(const std::string& s, char delimite
 }
 
 BOOST_AUTO_TEST_CASE(test_str_split_perf) {
-    cout << "ACore:: ...test_str_split_perf\n";
+    ECF_NAME_THIS_TEST();
+
     //   Time for istreamstream 1000000 times = 2.59404
     //   Time for std::getline 1000000 times = 1.83148
     //   Time for boost::split 1000000 times = 1.18149
@@ -242,7 +244,8 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf) {
 }
 
 BOOST_AUTO_TEST_CASE(test_str_split_perf_with_file) {
-    cout << "ACore:: ...test_str_split_perf_with_file\n";
+    ECF_NAME_THIS_TEST();
+
     //   Time for istreamstream 2001774 times = 1.81123
     //   Time for std::getline 2001774 times = 2.89138
     //   Time for boost::split 2001774 times = 1.98556
@@ -412,7 +415,7 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf_with_file) {
 }
 
 BOOST_AUTO_TEST_CASE(test_str_get_token_perf) {
-    cout << "ACore:: ...test_str_get_token_perf\n";
+    ECF_NAME_THIS_TEST();
 
     std::vector<std::string> result;
     std::string line = "This is a long string that is going to be used to test the performance of splitting with "

--- a/libs/core/test/TestStringSplitPerf.cpp
+++ b/libs/core/test/TestStringSplitPerf.cpp
@@ -18,7 +18,6 @@
 
 #ifdef STRING_SPLIT_IMPLEMENTATIONS_PERF_CHECK_
     #include <fstream>
-    #include <iostream>
 
     #include <boost/timer/timer.hpp>
 
@@ -27,7 +26,6 @@
     #include "ecflow/core/Str.hpp"
     #include "ecflow/core/StringSplitter.hpp"
 
-using namespace std;
 using namespace ecf;
 using namespace boost;
 #endif
@@ -62,9 +60,9 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf) {
     std::string line = "This is a long string that is going to be used to test the performance of splitting with "
                        "different Implementations the fastest times wins ";
     size_t times     = 1000000;
-    cout << " This test will split a line " << times << " times: '" << line << "'\n";
+    ECF_TEST_DBG(<< " This test will split a line " << times << " times: '" << line);
 
-    string reconstructed;
+    std::string reconstructed;
     reconstructed.reserve(line.size());
 
     { // istreamstream    https://www.fluentcpp.com/2017/04/21/how-to-split-a-string-in-c/
@@ -79,8 +77,8 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf) {
                 reconstructed += " ";
             }
         }
-        cout << " Time for istreamstream " << times
-             << "                 times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< " Time for istreamstream " << times
+                     << "                 times = " << timer.format(3, Str::cpu_timer_format()));
         BOOST_CHECK_MESSAGE(line == reconstructed, "\n'" << line << "'\n'" << reconstructed << "'");
     }
 
@@ -94,8 +92,8 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf) {
                 reconstructed += " ";
             }
         }
-        cout << " Time for std::getline " << times
-             << "                  times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< " Time for std::getline " << times
+                     << "                  times = " << timer.format(3, Str::cpu_timer_format()));
         BOOST_CHECK_MESSAGE(line == reconstructed, "\n'" << line << "'\n'" << reconstructed << "'");
     }
 
@@ -113,8 +111,8 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf) {
                 reconstructed += " ";
             }
         }
-        cout << " Time for boost::split " << times
-             << "                  times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< " Time for boost::split " << times
+                     << "                  times = " << timer.format(3, Str::cpu_timer_format()));
         // BOOST_CHECK_MESSAGE(line==reconstructed,"\n'" << line << "'\n'" << reconstructed << "'"); // add extra space
     }
 
@@ -131,8 +129,8 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf) {
                 reconstructed += " ";
             }
         }
-        cout << " Time for Str::split_orig " << times
-             << "               times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< " Time for Str::split_orig " << times
+                     << "               times = " << timer.format(3, Str::cpu_timer_format()));
         BOOST_CHECK_MESSAGE(line == reconstructed, " error");
     }
     { // Str::split_orig1
@@ -148,8 +146,8 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf) {
                 reconstructed += " ";
             }
         }
-        cout << " Time for Str::split_orig1 " << times
-             << "              times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< " Time for Str::split_orig1 " << times
+                     << "              times = " << timer.format(3, Str::cpu_timer_format()));
         BOOST_CHECK_MESSAGE(line == reconstructed, " error");
     }
     { // Str::split_using_string_view2
@@ -165,8 +163,8 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf) {
                 reconstructed += " ";
             }
         }
-        cout << " Time for Str::split_using_string_view2 " << times
-             << " times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< " Time for Str::split_using_string_view2 " << times
+                     << " times = " << timer.format(3, Str::cpu_timer_format()));
         BOOST_CHECK_MESSAGE(line == reconstructed, " error");
     }
     { // Str::split_using_string_view
@@ -182,28 +180,26 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf) {
                 reconstructed += " ";
             }
         }
-        cout << " Time for Str::split_using_string_view " << times
-             << "  times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< " Time for Str::split_using_string_view " << times
+                     << "  times = " << timer.format(3, Str::cpu_timer_format()));
         BOOST_CHECK_MESSAGE(line == reconstructed, " error");
     }
 
-    typedef boost::split_iterator<string::const_iterator> split_iter_t;
     { // boost::make_split_iterator
         boost::timer::cpu_timer timer;
         for (size_t i = 0; i < times; i++) {
 
-            split_iter_t tokens = Str::make_split_iterator(line);
+            auto tokens = Str::make_split_iterator(line);
 
             std::stringstream ss;
             for (; !tokens.eof(); ++tokens) {
-                boost::iterator_range<string::const_iterator> range = *tokens;
+                boost::iterator_range<std::string::const_iterator> range = *tokens;
                 ss << range << " ";
             }
             reconstructed = ss.str();
         }
-        cout << " Time for make_split_iterator::split " << times
-             << "    times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
-        // BOOST_CHECK_MESSAGE(line==reconstructed,"\n'" << line << "'\n'" << reconstructed << "'");
+        ECF_TEST_DBG(<< " Time for make_split_iterator::split " << times
+                     << "    times = " << timer.format(3, Str::cpu_timer_format()));
     }
 
     { // std::string_view
@@ -218,8 +214,8 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf) {
                 reconstructed += " ";
             }
         }
-        cout << " Time for std::string_view " << times
-             << "            times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< " Time for std::string_view " << times
+                     << "            times = " << timer.format(3, Str::cpu_timer_format()));
         BOOST_CHECK_MESSAGE(line == reconstructed, "\n'" << line << "'\n'" << reconstructed << "'");
     }
 
@@ -237,8 +233,8 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf) {
                 reconstructed += " ";
             }
         }
-        cout << " Time for std::string_view(2) " << times
-             << "         times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< " Time for std::string_view(2) " << times
+                     << "         times = " << timer.format(3, Str::cpu_timer_format()));
         BOOST_CHECK_MESSAGE(line == reconstructed, "\n'" << line << "'\n'" << reconstructed << "'");
     }
 }
@@ -257,7 +253,7 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf_with_file) {
     // Now test performance of splitting with a big DEFS file
     char* ecf_test_defs_dir = getenv("ECF_TEST_DEFS_DIR");
     if (!ecf_test_defs_dir) {
-        std::cout << "Ingoring test, since directory defined by environment variable(ECF_TEST_DEFS_DIR) is missing";
+        ECF_TEST_DBG(<< "Igoring test, since directory defined by environment variable(ECF_TEST_DEFS_DIR) is missing");
         return;
     }
     std::string path = std::string(ecf_test_defs_dir) + "/vsms2.31415.def";
@@ -270,13 +266,13 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf_with_file) {
     std::vector<std::string> file_contents;
     if (File::splitFileIntoLines(path, file_contents, true /* ignore empty lines*/)) {
 
-        cout << " This test will split each line in file " << path << "\n";
+        ECF_TEST_DBG(<< " This test will split each line in file " << path);
 
         std::vector<std::string> result;
         result.reserve(300);
 
         auto reconstruct_line = [](const std::vector<std::string>& result) {
-            string reconstructed;
+            std::string reconstructed;
             for (const auto& s : result) {
                 reconstructed += s;
                 reconstructed += " ";
@@ -291,16 +287,16 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf_with_file) {
                                                  std::istream_iterator<std::string>());
                 reconstruct_line(result1);
             }
-            cout << " Time for istreamstream " << file_contents.size()
-                 << " times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+            ECF_TEST_DBG(<< " Time for istreamstream " << file_contents.size()
+                         << " times = " << timer.format(3, Str::cpu_timer_format()));
         }
         { // std::getline
             boost::timer::cpu_timer timer;
             for (size_t i = 0; i < file_contents.size(); i++) {
                 reconstruct_line(split_using_getline(file_contents[i], ' '));
             }
-            cout << " Time for std::getline " << file_contents.size()
-                 << " times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+            ECF_TEST_DBG(<< " Time for std::getline " << file_contents.size()
+                         << " times = " << timer.format(3, Str::cpu_timer_format()));
         }
         {
             boost::timer::cpu_timer timer;
@@ -312,8 +308,8 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf_with_file) {
 
                 reconstruct_line(result);
             }
-            cout << " Time for boost::split " << file_contents.size()
-                 << " times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+            ECF_TEST_DBG(<< " Time for boost::split " << file_contents.size()
+                         << " times = " << timer.format(3, Str::cpu_timer_format()));
         }
         {
             boost::timer::cpu_timer timer;
@@ -323,8 +319,8 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf_with_file) {
 
                 reconstruct_line(result);
             }
-            cout << " Time for Str::split_orig " << file_contents.size()
-                 << " times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+            ECF_TEST_DBG(<< " Time for Str::split_orig " << file_contents.size()
+                         << " times = " << timer.format(3, Str::cpu_timer_format()));
         }
         {
             boost::timer::cpu_timer timer;
@@ -334,8 +330,8 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf_with_file) {
 
                 reconstruct_line(result);
             }
-            cout << " Time for Str::split_orig1 " << file_contents.size()
-                 << " times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+            ECF_TEST_DBG(<< " Time for Str::split_orig1 " << file_contents.size()
+                         << " times = " << timer.format(3, Str::cpu_timer_format()));
         }
         {
             boost::timer::cpu_timer timer;
@@ -345,8 +341,8 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf_with_file) {
 
                 reconstruct_line(result);
             }
-            cout << " Time for Str::split_using_string_view " << file_contents.size()
-                 << " times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+            ECF_TEST_DBG(<< " Time for Str::split_using_string_view " << file_contents.size()
+                         << " times = " << timer.format(3, Str::cpu_timer_format()));
         }
         {
             boost::timer::cpu_timer timer;
@@ -356,25 +352,24 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf_with_file) {
 
                 reconstruct_line(result);
             }
-            cout << " Time for Str::split_using_string_view2 " << file_contents.size()
-                 << " times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+            ECF_TEST_DBG(<< " Time for Str::split_using_string_view2 " << file_contents.size()
+                         << " times = " << timer.format(3, Str::cpu_timer_format()));
         }
         {
-            typedef boost::split_iterator<string::const_iterator> split_iter_t;
             boost::timer::cpu_timer timer;
             for (size_t i = 0; i < file_contents.size(); i++) {
 
                 std::stringstream ss;
-                split_iter_t tokens = Str::make_split_iterator(file_contents[i]);
+                auto tokens = Str::make_split_iterator(file_contents[i]);
 
                 for (; !tokens.eof(); ++tokens) {
-                    boost::iterator_range<string::const_iterator> range = *tokens;
+                    auto range = *tokens;
                     ss << range << " ";
                 }
-                string reconstructed = ss.str();
+                std::string reconstructed = ss.str();
             }
-            cout << " Time for boost::make_split_iterator " << file_contents.size()
-                 << " times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+            ECF_TEST_DBG(<< " Time for boost::make_split_iterator " << file_contents.size()
+                         << " times = " << timer.format(3, Str::cpu_timer_format()));
         }
 
         {
@@ -383,15 +378,15 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf_with_file) {
 
                 StringSplitter string_splitter(file_contents[i]);
 
-                string reconstructed;
+                std::string reconstructed;
                 while (!string_splitter.finished()) {
                     std::string_view sv = string_splitter.next();
                     reconstructed += std::string(sv.begin(), sv.end());
                     reconstructed += " ";
                 }
             }
-            cout << " Time for std::string_view " << file_contents.size()
-                 << " times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+            ECF_TEST_DBG(<< " Time for std::string_view " << file_contents.size()
+                         << " times = " << timer.format(3, Str::cpu_timer_format()));
         }
 
         {
@@ -401,15 +396,15 @@ BOOST_AUTO_TEST_CASE(test_str_split_perf_with_file) {
 
                 StringSplitter::split2(file_contents[i], result1);
 
-                string reconstructed;
+                std::string reconstructed;
                 for (const auto& s : result1) {
                     reconstructed += std::string(s.begin(), s.end());
                     reconstructed += " ";
                 }
                 result1.clear();
             }
-            cout << " Time std::string_view(2) " << file_contents.size()
-                 << " times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+            ECF_TEST_DBG(<< " Time std::string_view(2) " << file_contents.size()
+                         << " times = " << timer.format(3, Str::cpu_timer_format()));
         }
     }
 }
@@ -421,7 +416,7 @@ BOOST_AUTO_TEST_CASE(test_str_get_token_perf) {
     std::string line = "This is a long string that is going to be used to test the performance of splitting with "
                        "different Implementations the fastest times wins ";
     size_t times     = 250000;
-    cout << " This test will split a line " << times << " times: '" << line << "'\n";
+    ECF_TEST_DBG(<< " This test will split a line " << times << " times: '" << line);
 
     Str::split_using_string_view(line, result);
     size_t result_size = result.size();
@@ -435,8 +430,8 @@ BOOST_AUTO_TEST_CASE(test_str_get_token_perf) {
                 (void)StringSplitter::get_token(line, r, token);
             }
         }
-        cout << " Time for StringSplitter::get_token " << times
-             << " times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< " Time for StringSplitter::get_token " << times
+                     << " times = " << timer.format(3, Str::cpu_timer_format()));
         BOOST_CHECK_MESSAGE(true, "Keep compiler happy");
     }
     {
@@ -447,8 +442,8 @@ BOOST_AUTO_TEST_CASE(test_str_get_token_perf) {
                 (void)Str::get_token(line, r, token);
             }
         }
-        cout << " Time for Str::get_token            " << times
-             << " times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< " Time for Str::get_token            " << times
+                     << " times = " << timer.format(3, Str::cpu_timer_format()));
         BOOST_CHECK_MESSAGE(true, "Keep compiler happy");
     }
     {
@@ -459,8 +454,8 @@ BOOST_AUTO_TEST_CASE(test_str_get_token_perf) {
                 (void)Str::get_token2(line, r, token);
             }
         }
-        cout << " Time for Str::get_token2           " << times
-             << " times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< " Time for Str::get_token2           " << times
+                     << " times = " << timer.format(3, Str::cpu_timer_format()));
         BOOST_CHECK_MESSAGE(true, "Keep compiler happy");
     }
     {
@@ -471,8 +466,8 @@ BOOST_AUTO_TEST_CASE(test_str_get_token_perf) {
                 (void)Str::get_token3(line, r, token);
             }
         }
-        cout << " Time for Str::get_token3           " << times
-             << " times = " << timer.format(3, Str::cpu_timer_format()) << "\n";
+        ECF_TEST_DBG(<< " Time for Str::get_token3           " << times
+                     << " times = " << timer.format(3, Str::cpu_timer_format()));
         BOOST_CHECK_MESSAGE(true, "Keep compiler happy");
     }
 }

--- a/libs/core/test/TestStringSplitter.cpp
+++ b/libs/core/test/TestStringSplitter.cpp
@@ -8,7 +8,9 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
 
 #include <boost/test/unit_test.hpp>
 
@@ -16,7 +18,6 @@
 #include "ecflow/core/Str.hpp"
 #include "ecflow/core/StringSplitter.hpp"
 
-using namespace std;
 using namespace ecf;
 using namespace boost;
 
@@ -29,7 +30,6 @@ check(const std::string& line, const StringSplitter& string_splitter, const std:
     std::vector<std::string> result;
     while (!string_splitter.finished()) {
         std::string_view ref = string_splitter.next();
-        // std::cout << "ref:'" << ref << "'\n";
         result.emplace_back(ref.begin(), ref.end());
     }
     BOOST_CHECK_MESSAGE(result.size() == expected.size(),
@@ -37,17 +37,15 @@ check(const std::string& line, const StringSplitter& string_splitter, const std:
                                          << "'");
     BOOST_CHECK_MESSAGE(result == expected, "failed for '" << line << "'");
     if (result != expected) {
-        cout << "Line    :'" << line << "'\n";
-        cout << "Actual  :";
-        for (const string& t : result) {
-            cout << "'" << t << "'";
+        ECF_TEST_DBG(<< "Line    :'" << line);
+        ECF_TEST_DBG(<< "Actual  :");
+        for (const std::string& t : result) {
+            ECF_TEST_DBG(<< "   '" << t << "'");
         }
-        cout << "\n";
-        cout << "Expected:";
-        for (const string& t : expected) {
-            cout << "'" << t << "'";
+        ECF_TEST_DBG(<< "Expected:");
+        for (const std::string& t : expected) {
+            ECF_TEST_DBG(<< "'" << t << "'");
         }
-        cout << "\n";
     }
 }
 
@@ -64,17 +62,15 @@ static void check(const std::string& line, const std::vector<std::string>& expec
                                          << "'");
     BOOST_CHECK_MESSAGE(result == expected, "failed for '" << line << "'");
     if (result != expected) {
-        cout << "Line    :'" << line << "'\n";
-        cout << "Actual  :";
-        for (const string& t : result) {
-            cout << "'" << t << "'";
+        ECF_TEST_DBG(<< "Line    :'" << line);
+        ECF_TEST_DBG(<< "Actual  :");
+        for (const std::string& t : result) {
+            ECF_TEST_DBG(<< "   '" << t << "'");
         }
-        cout << "\n";
-        cout << "Expected:";
-        for (const string& t : expected) {
-            cout << "'" << t << "'";
+        ECF_TEST_DBG(<< "Expected:");
+        for (const std::string& t : expected) {
+            ECF_TEST_DBG(<< "'" << t << "'");
         }
-        cout << "\n";
     }
 }
 

--- a/libs/core/test/TestStringSplitter.cpp
+++ b/libs/core/test/TestStringSplitter.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Str.hpp"
 #include "ecflow/core/StringSplitter.hpp"
 
@@ -78,7 +79,7 @@ static void check(const std::string& line, const std::vector<std::string>& expec
 }
 
 BOOST_AUTO_TEST_CASE(test_StringSplitter) {
-    cout << "ACore:: ...test_StringSplitter\n";
+    ECF_NAME_THIS_TEST();
 
     std::string line = "This is a string please split me";
     std::vector<std::string> expected;
@@ -100,7 +101,7 @@ BOOST_AUTO_TEST_CASE(test_StringSplitter) {
 }
 
 BOOST_AUTO_TEST_CASE(test_str_split_StringSplitter) {
-    cout << "ACore:: ...test_str_split_StringSplitter\n";
+    ECF_NAME_THIS_TEST();
 
     // If end is delimeter, then preserved as empty token
 
@@ -289,7 +290,7 @@ static void test_get_token(const std::string& line, const char* delims = " \t") 
 }
 
 BOOST_AUTO_TEST_CASE(test_StringSplitter_get_token) {
-    cout << "ACore:: ...test_StringSplitter_get_token \n";
+    ECF_NAME_THIS_TEST();
 
     std::vector<std::string> test_data = {"This is a string",
                                           "a",

--- a/libs/core/test/TestTimeSeries.cpp
+++ b/libs/core/test/TestTimeSeries.cpp
@@ -8,8 +8,8 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <iostream>
 #include <string>
+#include <vector>
 
 #include <boost/date_time/posix_time/time_formatters.hpp>
 #include <boost/test/unit_test.hpp>
@@ -193,9 +193,6 @@ BOOST_AUTO_TEST_CASE(test_time_series_increment_real) {
         timeSeries2.calendarChanged(c);
         timeSeries3.calendarChanged(c);
 
-        //		cerr << "hour = " << hour << " calendar_duration " << to_simple_string(timeSeries.duration(c))
-        //		    << " timeSeries=" << timeSeries.toString() << " timeSeries2=" << timeSeries2.toString() << "
-        // timeSeries3=" << timeSeries3.toString() << "\n";
         if (hour < timeSeries.start().hour()) {
             BOOST_CHECK_MESSAGE(timeSeries.checkForRequeue(c, t1_min, t1_max, cmd_context),
                                 " Time series " << timeSeries.toString() << " checkForRequeue should pass at "
@@ -302,9 +299,6 @@ BOOST_AUTO_TEST_CASE(test_time_series_requeueable_and_compute_next_time_slot) {
         timeSeries2.calendarChanged(c);
         timeSeries3.calendarChanged(c);
 
-        //    cerr << "hour = " << hour << " calendar_duration " << to_simple_string(timeSeries.duration(c))
-        //        << " timeSeries=" << timeSeries.toString() << " timeSeries2=" << timeSeries2.toString() << "
-        //        timeSeries3=" << timeSeries3.toString() << "\n";
         if (hour < timeSeries.start().hour()) {
             TimeSlot next_time_slot = timeSeries.compute_next_time_slot(c);
             TimeSlot expected(10, 0);
@@ -473,8 +467,6 @@ BOOST_AUTO_TEST_CASE(test_time_series_finish_not_divisble_by_increment) {
             calendar.update(minutes(1));
             timeSeries.calendarChanged(calendar);
             timeSeries2.calendarChanged(calendar);
-
-            // cout << to_simple_string(calendar.suiteTime()) << "\n";
 
             if (calendar.dayChanged()) {
                 BOOST_CHECK_MESSAGE(timeSeries.checkForRequeue(calendar, t1_min, t1_max),

--- a/libs/core/test/TestTimeSeries.cpp
+++ b/libs/core/test/TestTimeSeries.cpp
@@ -14,6 +14,7 @@
 #include <boost/date_time/posix_time/time_formatters.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Calendar.hpp"
 #include "ecflow/core/Str.hpp"
 #include "ecflow/core/TimeSeries.hpp"
@@ -30,7 +31,7 @@ BOOST_AUTO_TEST_SUITE(U_Core)
 BOOST_AUTO_TEST_SUITE(T_TimeSeries)
 
 BOOST_AUTO_TEST_CASE(test_default_boost_time_duration) {
-    cout << "ACore:: ...test_default_boost_time_duration\n";
+    ECF_NAME_THIS_TEST();
 
     boost::posix_time::time_duration td;
     BOOST_CHECK_MESSAGE(td.is_special() == false,
@@ -41,7 +42,7 @@ BOOST_AUTO_TEST_CASE(test_default_boost_time_duration) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_series_min_max_time_slots) {
-    cout << "ACore:: ...test_time_series_min_max_time_slots\n";
+    ECF_NAME_THIS_TEST();
 
     TimeSlot the_min;
     TimeSlot the_max;
@@ -68,7 +69,7 @@ BOOST_AUTO_TEST_CASE(test_time_series_min_max_time_slots) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_series_constrcution) {
-    cout << "ACore:: ...test_time_series_constrcution\n";
+    ECF_NAME_THIS_TEST();
 
     {
         TimeSeries x;
@@ -131,7 +132,7 @@ BOOST_AUTO_TEST_CASE(test_time_series_constrcution) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_series) {
-    cout << "ACore:: ...test_time_series\n";
+    ECF_NAME_THIS_TEST();
 
     /// Basic test for time series of getters and setters
     TimeSeries timeSeries(TimeSlot(0, 1), TimeSlot(0, 4), TimeSlot(0, 1));
@@ -154,7 +155,7 @@ BOOST_AUTO_TEST_CASE(test_time_series) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_series_increment_real) {
-    cout << "ACore:: ...test_time_series_increment_real\n";
+    ECF_NAME_THIS_TEST();
 
     // Test time series with  a calendar, we update calendar then
     // test time series isFree(), and checkForRequeue
@@ -276,7 +277,7 @@ BOOST_AUTO_TEST_CASE(test_time_series_increment_real) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_series_requeueable_and_compute_next_time_slot) {
-    cout << "ACore:: ...test_time_series_requeueable_and_compute_next_time_slot\n";
+    ECF_NAME_THIS_TEST();
 
     // Test time series with  a calendar, we update calendar then
     // test time series requeueable(), and compute_next_time_slot
@@ -435,7 +436,7 @@ BOOST_AUTO_TEST_CASE(test_time_series_requeueable_and_compute_next_time_slot) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_series_finish_not_divisble_by_increment) {
-    cout << "ACore:: ...test_time_series_finish_not_divisble_by_increment\n";
+    ECF_NAME_THIS_TEST();
 
     // HANDLE CASE WHERE FINISH MINUTES IS NOT DIVISIBLE BY THE INCREMENT
 
@@ -528,7 +529,7 @@ BOOST_AUTO_TEST_CASE(test_time_series_finish_not_divisble_by_increment) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_series_miss_time_slot) {
-    cout << "ACore:: ...test_time_series_miss_time_slot\n";
+    ECF_NAME_THIS_TEST();
 
     Calendar calendar;
     calendar.init(ptime(date(2008, 10, 8), hours(10)), Calendar::REAL);
@@ -552,7 +553,7 @@ BOOST_AUTO_TEST_CASE(test_time_series_miss_time_slot) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_series_miss_time_slot_1) {
-    cout << "ACore:: ...test_time_series_miss_time_slot_1\n";
+    ECF_NAME_THIS_TEST();
 
     // Create calendar before time series
     {
@@ -609,7 +610,7 @@ BOOST_AUTO_TEST_CASE(test_time_series_miss_time_slot_1) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_series_reset) {
-    cout << "ACore:: ...test_time_series_reset\n";
+    ECF_NAME_THIS_TEST();
 
     // Create a test when we can match a time series.
     // NOTE: Finish minute is not a multiple of INCREMENT hence last valid time slot is 23:50
@@ -665,7 +666,7 @@ BOOST_AUTO_TEST_CASE(test_time_series_reset) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_series_parsing) {
-    cout << "ACore:: ...test_time_series_parsing\n";
+    ECF_NAME_THIS_TEST();
 
     BOOST_CHECK_MESSAGE(TimeSeries::create("00:30") == ecf::TimeSeries(0, 30), "Error ");
     BOOST_CHECK_MESSAGE(TimeSeries::create("+00:30") == ecf::TimeSeries(0, 30, true), "Error ");
@@ -679,7 +680,7 @@ BOOST_AUTO_TEST_CASE(test_time_series_parsing) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_series_state_parsing) {
-    cout << "ACore:: ...test_time_series_state_parsing\n";
+    ECF_NAME_THIS_TEST();
 
     /// extract string like
     ///     time +00:00 20:00 00:10 # this is a comment which will be ignored. index = 1

--- a/libs/core/test/TestTimeSlot.cpp
+++ b/libs/core/test/TestTimeSlot.cpp
@@ -8,14 +8,11 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <iostream>
-
 #include <boost/test/unit_test.hpp>
 
 #include "TestNaming.hpp"
 #include "ecflow/core/TimeSlot.hpp"
 
-using namespace std;
 using namespace ecf;
 using namespace boost;
 using namespace boost::posix_time;

--- a/libs/core/test/TestTimeSlot.cpp
+++ b/libs/core/test/TestTimeSlot.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/TimeSlot.hpp"
 
 using namespace std;
@@ -25,7 +26,7 @@ BOOST_AUTO_TEST_SUITE(U_Core)
 BOOST_AUTO_TEST_SUITE(T_TimeSlot)
 
 BOOST_AUTO_TEST_CASE(test_time_slot) {
-    cout << "ACore:: ...test_time_slot\n";
+    ECF_NAME_THIS_TEST();
 
     // test timeslot operator
     {

--- a/libs/core/test/TestVersion.cpp
+++ b/libs/core/test/TestVersion.cpp
@@ -70,8 +70,9 @@ BOOST_AUTO_TEST_CASE(test_version_against_cmake) {
                               << version_cmake_file);
     BOOST_REQUIRE_MESSAGE(
         Version::raw() == cmake_version,
-        "\n  Expected " << cmake_version << " but found " << Version::raw()
-                        << ", Please regenerate file $WK/ACore/src/ecflow_version.h by calling 'sh -x $WK/cmake.sh'");
+        "\n  Expected "
+            << cmake_version << " but found " << Version::raw()
+            << ", Please regenerate file $WK/libs/core/src/ecflow_version.h by calling 'sh -x $WK/cmake.sh'");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/core/test/TestVersion.cpp
+++ b/libs/core/test/TestVersion.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/Str.hpp"
 #include "ecflow/core/Version.hpp"
@@ -28,11 +29,11 @@ BOOST_AUTO_TEST_SUITE(T_Version)
 BOOST_AUTO_TEST_CASE(test_version) {
     std::string desc = Version::description();
     BOOST_CHECK_MESSAGE(!desc.empty(), "Expected version");
-    cout << "ACore:: ...test_version:" << desc << endl;
+    ECF_NAME_THIS_TEST(<< ", found version: " << desc);
 }
 
 BOOST_AUTO_TEST_CASE(test_version_against_cmake) {
-    cout << "ACore:: ...test_version_against_cmake" << endl;
+    ECF_NAME_THIS_TEST();
 
     // Open the file CMakeList.txt
     std::string version_cmake_file = File::root_source_dir() + "/CMakeLists.txt";

--- a/libs/core/test/TestVersion.cpp
+++ b/libs/core/test/TestVersion.cpp
@@ -8,8 +8,8 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <iostream>
 #include <string>
+#include <vector>
 
 #include <boost/test/unit_test.hpp>
 
@@ -18,7 +18,6 @@
 #include "ecflow/core/Str.hpp"
 #include "ecflow/core/Version.hpp"
 
-using namespace std;
 using namespace ecf;
 using namespace boost;
 

--- a/libs/core/test/TestVersioning.cpp
+++ b/libs/core/test/TestVersioning.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Filesystem.hpp"
 #include "ecflow/core/Serialization.hpp"
 
@@ -27,7 +28,8 @@ BOOST_AUTO_TEST_SUITE(T_Versioning)
 // Note: we simulate different release of class X, by using name spaces
 //       This is possible since the name space is not written.
 BOOST_AUTO_TEST_CASE(test_versioning) {
-    cout << "ACore:: ...test_versioning\n";
+    ECF_NAME_THIS_TEST();
+
     {
         // write out version 0; This will be reloaded with different version of X
         const version0::X t = version0::X(10);

--- a/libs/core/test/TestVersioning.cpp
+++ b/libs/core/test/TestVersioning.cpp
@@ -16,7 +16,6 @@
 #include "ecflow/core/Filesystem.hpp"
 #include "ecflow/core/Serialization.hpp"
 
-using namespace std;
 using namespace boost;
 
 BOOST_AUTO_TEST_SUITE(U_Core)

--- a/libs/core/test/TestWhiteListFile.cpp
+++ b/libs/core/test/TestWhiteListFile.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/WhiteListFile.hpp"
 
@@ -74,7 +75,7 @@ void test_white_list_files(const std::string& directory, bool pass) {
 }
 
 BOOST_AUTO_TEST_CASE(test_parsing_for_good_white_list_files) {
-    cout << "ACore:: ...test_parsing_for_good_white_list_files\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/core/test/data/goodWhiteListFiles", "libs/core");
 
@@ -83,7 +84,7 @@ BOOST_AUTO_TEST_CASE(test_parsing_for_good_white_list_files) {
 }
 
 BOOST_AUTO_TEST_CASE(test_parsing_for_bad_white_list_files) {
-    cout << "ACore:: ...test_parsing_for_bad_white_list_files\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/core/test/data/badWhiteListFiles", "libs/core");
 
@@ -92,7 +93,7 @@ BOOST_AUTO_TEST_CASE(test_parsing_for_bad_white_list_files) {
 }
 
 BOOST_AUTO_TEST_CASE(test_white_list_default) {
-    cout << "ACore:: ...test_white_list_default\n";
+    ECF_NAME_THIS_TEST();
 
     WhiteListFile theFile;
 
@@ -116,7 +117,7 @@ BOOST_AUTO_TEST_CASE(test_white_list_default) {
 }
 
 BOOST_AUTO_TEST_CASE(test_white_list_empty_file) {
-    cout << "ACore:: ...test_white_list_empty_file\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/core/test/data/goodWhiteListFiles/empty.lists", "libs/core");
 
@@ -144,7 +145,7 @@ BOOST_AUTO_TEST_CASE(test_white_list_empty_file) {
 }
 
 BOOST_AUTO_TEST_CASE(test_white_list) {
-    cout << "ACore:: ...test_white_list\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/core/test/data/goodWhiteListFiles/good1.lists", "libs/core");
 
@@ -267,7 +268,7 @@ BOOST_AUTO_TEST_CASE(test_white_list) {
 }
 
 BOOST_AUTO_TEST_CASE(test_white_list_all_users_have_read_access) {
-    cout << "ACore:: ...test_white_list_all_users_have_read_access\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/core/test/data/goodWhiteListFiles/all_read_access.lists", "libs/core");
 
@@ -329,7 +330,7 @@ BOOST_AUTO_TEST_CASE(test_white_list_all_users_have_read_access) {
 }
 
 BOOST_AUTO_TEST_CASE(test_white_list_all_users_have_write_access) {
-    cout << "ACore:: ...test_white_list_all_users_have_write_access\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/core/test/data/goodWhiteListFiles/all_write_access.lists", "libs/core");
 
@@ -376,7 +377,7 @@ BOOST_AUTO_TEST_CASE(test_white_list_all_users_have_write_access) {
 }
 
 BOOST_AUTO_TEST_CASE(test_white_list_all_path_users_have_write_access) {
-    cout << "ACore:: ...test_white_list_all_path_users_have_write_access\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path =
         File::test_data("libs/core/test/data/goodWhiteListFiles/all_path_write_access.lists", "libs/core");
@@ -412,7 +413,7 @@ BOOST_AUTO_TEST_CASE(test_white_list_all_path_users_have_write_access) {
 }
 
 BOOST_AUTO_TEST_CASE(test_white_list_all_path_users_have_read_access) {
-    cout << "ACore:: ...test_white_list_all_path_users_have_read_access\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path =
         File::test_data("libs/core/test/data/goodWhiteListFiles/all_path_read_access.lists", "libs/core");
@@ -448,7 +449,7 @@ BOOST_AUTO_TEST_CASE(test_white_list_all_path_users_have_read_access) {
 }
 
 BOOST_AUTO_TEST_CASE(test_white_list_path_access_list) {
-    cout << "ACore:: ...test_white_list_path_access_list\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/core/test/data/goodWhiteListFiles/path_access.lists", "libs/core");
 

--- a/libs/core/test/TestWhiteListFile.cpp
+++ b/libs/core/test/TestWhiteListFile.cpp
@@ -8,7 +8,8 @@
  * nor does it submit to any jurisdiction.
  */
 
-#include <iostream>
+#include <string>
+#include <vector>
 
 #include <boost/test/unit_test.hpp>
 
@@ -16,7 +17,6 @@
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/WhiteListFile.hpp"
 
-using namespace std;
 using namespace ecf;
 
 // #define DEBUG_ME 1
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(test_white_list_default) {
                           "expected 0 users with write access but found " << theFile.write_access_size());
 
     // test random user
-    vector<string> paths;
+    std::vector<std::string> paths;
     paths.emplace_back("/a");
     paths.emplace_back("/b");
     paths.emplace_back("/c");
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(test_white_list_empty_file) {
                           "expected 0 users with write access but found " << theFile.write_access_size());
 
     // test random user
-    vector<string> paths;
+    std::vector<std::string> paths;
     paths.emplace_back("/a");
     paths.emplace_back("/b");
     paths.emplace_back("/c");
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(test_white_list) {
                                        << " users with write access but found " << theFile.write_access_size());
 
     // Users who have read access, to all including paths
-    vector<string> paths;
+    std::vector<std::string> paths;
     paths.emplace_back("/a");
     paths.emplace_back("/b");
     paths.emplace_back("/c");
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(test_white_list) {
     }
 
     // Users who have restricted read/write access to certain paths only.
-    vector<string> read_paths;
+    std::vector<std::string> read_paths;
     read_paths.emplace_back("/suite/read");
     read_paths.emplace_back("/suite/read/f1");
     read_paths.emplace_back("/suite/read/f1/t1");
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(test_white_list) {
                                 << *i << " with path '/suite/read_me' to NOT have read access to path /suite/read");
     }
 
-    vector<string> write_paths;
+    std::vector<std::string> write_paths;
     write_paths.emplace_back("/suite/write");
     write_paths.emplace_back("/suite/write/f1");
     write_paths.emplace_back("/suite/write/f1/t1");
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(test_white_list_all_users_have_read_access) {
                                        << " users with write access but found " << theFile.write_access_size());
 
     // Any user should have read access
-    vector<string> paths;
+    std::vector<std::string> paths;
     paths.emplace_back("/a");
     paths.emplace_back("/b");
     paths.emplace_back("/c");
@@ -355,7 +355,7 @@ BOOST_AUTO_TEST_CASE(test_white_list_all_users_have_write_access) {
     BOOST_REQUIRE_MESSAGE(theFile.write_access_size() == 0, " expected 0  but found " << theFile.read_access_size());
 
     // Any user should have read access
-    vector<string> paths;
+    std::vector<std::string> paths;
     paths.emplace_back("/a");
     paths.emplace_back("/b");
     paths.emplace_back("/c");
@@ -393,11 +393,11 @@ BOOST_AUTO_TEST_CASE(test_white_list_all_path_users_have_write_access) {
     BOOST_REQUIRE_MESSAGE(theFile.read_access_size() == 0, " expected 0  but found " << theFile.read_access_size());
     BOOST_REQUIRE_MESSAGE(theFile.write_access_size() == 0, " expected 0  but found " << theFile.write_access_size());
 
-    vector<string> paths;
+    std::vector<std::string> paths;
     paths.emplace_back("/a");
     paths.emplace_back("/b");
     paths.emplace_back("/c");
-    vector<string> paths1;
+    std::vector<std::string> paths1;
     paths1.emplace_back("/a");
     paths1.emplace_back("/b");
     // Any user should have read/write access
@@ -430,11 +430,11 @@ BOOST_AUTO_TEST_CASE(test_white_list_all_path_users_have_read_access) {
     BOOST_REQUIRE_MESSAGE(theFile.write_access_size() == 0, " expected 0  but found " << theFile.write_access_size());
 
     // When no write access specified all user have write access
-    vector<string> paths;
+    std::vector<std::string> paths;
     paths.emplace_back("/a");
     paths.emplace_back("/b");
     paths.emplace_back("/c");
-    vector<string> paths1;
+    std::vector<std::string> paths1;
     paths1.emplace_back("/a");
     paths1.emplace_back("/b");
     // Any user should have read/write access
@@ -496,11 +496,11 @@ BOOST_AUTO_TEST_CASE(test_white_list_path_access_list) {
                           " expected 7  but found " << theFile.write_access_size() << theFile.dump_valid_users());
 
     // When no write access specified all user have write access
-    vector<string> paths;
+    std::vector<std::string> paths;
     paths.emplace_back("/a");
     paths.emplace_back("/b");
     paths.emplace_back("/c");
-    vector<string> partial_paths;
+    std::vector<std::string> partial_paths;
     partial_paths.emplace_back("/a");
     partial_paths.emplace_back("/b");
 
@@ -584,7 +584,7 @@ BOOST_AUTO_TEST_CASE(test_white_list_path_access_list) {
     // test * user, * means all users
     //*  /x /y   # all user have read/write access  suites /x /y
     //-* /w /z   # all user have read access to suite /w /z
-    vector<string> single_pathx;
+    std::vector<std::string> single_pathx;
     single_pathx.emplace_back("/x");
     BOOST_REQUIRE_MESSAGE(theFile.verify_read_access("xxxx"),
                           "Expected *ALL* user to have read access" << theFile.dump_valid_users());
@@ -593,14 +593,14 @@ BOOST_AUTO_TEST_CASE(test_white_list_path_access_list) {
     BOOST_REQUIRE_MESSAGE(theFile.verify_write_access("xxxx", single_pathx),
                           "Expected *ALL* user to have read/write access to /x" << theFile.dump_valid_users());
 
-    vector<string> single_pathw;
+    std::vector<std::string> single_pathw;
     single_pathw.emplace_back("/w");
     BOOST_REQUIRE_MESSAGE(theFile.verify_read_access("xxxx", single_pathw),
                           "Expected *ALL* user to have read access to /w" << theFile.dump_valid_users());
     BOOST_REQUIRE_MESSAGE(!theFile.verify_write_access("xxxx", single_pathw),
                           "Expected failure for write access to /w" << theFile.dump_valid_users());
 
-    vector<string> multiple_pathsxy;
+    std::vector<std::string> multiple_pathsxy;
     multiple_pathsxy.emplace_back("/x");
     multiple_pathsxy.emplace_back("/y");
     BOOST_REQUIRE_MESSAGE(theFile.verify_read_access("xxxx", multiple_pathsxy),
@@ -612,7 +612,7 @@ BOOST_AUTO_TEST_CASE(test_white_list_path_access_list) {
 
     // single path failure
     //   user1 /a,/b,/c  # user1 has read write access to suite /a /b /c
-    vector<string> single_path_failure;
+    std::vector<std::string> single_path_failure;
     single_path_failure.emplace_back("/fail");
     BOOST_REQUIRE_MESSAGE(!theFile.verify_read_access("user1", "/fail"),
                           "Expected user to not have read access to /fail" << theFile.dump_valid_users());
@@ -625,7 +625,7 @@ BOOST_AUTO_TEST_CASE(test_white_list_path_access_list) {
 
     // multi path failure
     //   user1 /a,/b,/c  # user1 has read write access to suite /a /b /c
-    vector<string> multiple_paths_failure;
+    std::vector<std::string> multiple_paths_failure;
     multiple_paths_failure.emplace_back("/a");
     multiple_paths_failure.emplace_back("/b");
     multiple_paths_failure.emplace_back("/fail");
@@ -670,7 +670,7 @@ BOOST_AUTO_TEST_CASE(test_white_list_path_access_list) {
     BOOST_REQUIRE_MESSAGE(theFile.verify_read_access("user1"),
                           "Expected user1 to not have read access, EVEN if no paths specified, --news has no paths\n"
                               << theFile.dump_valid_users());
-    BOOST_REQUIRE_MESSAGE(!theFile.verify_read_access("user1", vector<string>()),
+    BOOST_REQUIRE_MESSAGE(!theFile.verify_read_access("user1", std::vector<std::string>()),
                           "Expected user to not have read access if no paths specified\n"
                               << theFile.dump_valid_users());
     BOOST_REQUIRE_MESSAGE(!theFile.verify_read_access("user1", ""),
@@ -682,7 +682,7 @@ BOOST_AUTO_TEST_CASE(test_white_list_path_access_list) {
     BOOST_REQUIRE_MESSAGE(!theFile.verify_write_access("user1", ""),
                           "Expected user to not have read/write if no paths specified\n"
                               << theFile.dump_valid_users());
-    BOOST_REQUIRE_MESSAGE(!theFile.verify_write_access("user1", vector<string>()),
+    BOOST_REQUIRE_MESSAGE(!theFile.verify_write_access("user1", std::vector<std::string>()),
                           "Expected user to not have read/write if no paths specified\n"
                               << theFile.dump_valid_users());
 }

--- a/libs/node/CMakeLists.txt
+++ b/libs/node/CMakeLists.txt
@@ -106,6 +106,7 @@ ecbuild_add_test(
   LIBS
     ecflow_all
     Boost::boost # Boost header-only libraries must be available (namely unit_test_framework)
+    test_support
   TEST_DEPENDS
     u_node
 )
@@ -130,6 +131,7 @@ if (ENABLE_ALL_TESTS)
     LIBS
       ecflow_all
       Boost::boost # Boost header-only libraries must be available (namely unit_test_framework)
+      test_support
     TEST_DEPENDS
       u_anattr
   )
@@ -161,6 +163,7 @@ if (ENABLE_ALL_TESTS)
       ecflow_all
       Boost::boost # Boost header-only libraries must be available (namely unit_test_framework)
       Boost::timer
+      test_support
   )
   target_clangformat(p_parser
     CONDITION ENABLE_TESTS

--- a/libs/node/src/ecflow/node/Defs.cpp
+++ b/libs/node/src/ecflow/node/Defs.cpp
@@ -1329,7 +1329,7 @@ node_ptr Defs::replaceChild(const std::string& path,
 
         // preserve begun status. Note: we should't call begin() on the client side. As the suites will not have been
         // begun. This can cause assert, because begin time attributes assumes that calendar has been initialised. This
-        // is not the case for client ASSERT failure: !c.suiteTime().is_special() at ../ACore/src/TimeSeries.cpp:526
+        // is not the case for client ASSERT failure: !c.suiteTime().is_special() at ../core/src/TimeSeries.cpp:526
         // init has not been called on calendar. TimeSeries::duration ECFLOW-1612
         if (begin_node)
             client_node_to_add->begin();
@@ -1405,7 +1405,7 @@ node_ptr Defs::replaceChild(const std::string& path,
 
     // preserve begun status. Note: we should't call begin() on the client side. As the suites will not have been begun.
     // This can cause assert, because begin time attributes assumes that calendar has been initialised. This is not the
-    // case for client ASSERT failure: !c.suiteTime().is_special() at ../ACore/src/TimeSeries.cpp:526 init has not been
+    // case for client ASSERT failure: !c.suiteTime().is_special() at ../core/src/TimeSeries.cpp:526 init has not been
     // called on calendar. TimeSeries::duration ECFLOW-1612
     if (begin_node)
         client_node_to_add->begin();
@@ -1480,7 +1480,7 @@ void Defs::restore(const std::string& the_fileName) {
         return;
 
     /// *************************************************************************
-    /// The reason why Parser code moved to ANode directory. Avoid cyclic loop
+    /// The reason why Parser code moved to Node directory. Avoid cyclic loop
     /// *************************************************************************
     std::string errorMsg, warningMsg;
     if (!restore(the_fileName, errorMsg, warningMsg)) {
@@ -1506,7 +1506,7 @@ bool Defs::restore(const std::string& the_fileName, std::string& errorMsg, std::
 
 void Defs::restore_from_string(const std::string& str) {
     /// *************************************************************************
-    /// The reason why Parser code moved to ANode directory. Avoid cyclic loop
+    /// The reason why Parser code moved to Node directory. Avoid cyclic loop
     /// *************************************************************************
     std::string errorMsg, warningMsg;
     if (!restore_from_string(str, errorMsg, warningMsg)) {

--- a/libs/node/src/ecflow/node/Limit.hpp
+++ b/libs/node/src/ecflow/node/Limit.hpp
@@ -12,7 +12,7 @@
 #define ecflow_node_Limit_HPP
 
 ///
-/// \note Limit was placed in the ANode category because inlimit can reference
+/// \note Limit was placed in the Node category because inlimit can reference
 /// Limit on *ANOTHER* suite. This presents a problem with incremental sync,
 /// since that requires access to a parent/suite, to mark the suite as changed.
 ///

--- a/libs/node/src/ecflow/node/Node.cpp
+++ b/libs/node/src/ecflow/node/Node.cpp
@@ -1770,7 +1770,7 @@ void Node::print(std::string& os) const {
 
     if (PrintStyle::getStyle() == PrintStyle::STATE) {
         // Distinguish normal variable from generated, by adding a #
-        // This also allows it to be read in again and compared in the AParser/tests
+        // This also allows it to be read in again and compared in the libs/node/test/parser
         std::vector<Variable> gvec;
         gen_variables(gvec);
         for (const Variable& v : gvec) {

--- a/libs/node/test/TestAdd.cpp
+++ b/libs/node/test/TestAdd.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
 #include "ecflow/node/Suite.hpp"
@@ -26,7 +27,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_Add)
 
 BOOST_AUTO_TEST_CASE(test_add) {
-    cout << "ANode:: ...test_add\n";
+    ECF_NAME_THIS_TEST();
 
     defs_ptr defs = Defs::create();
     task_ptr t1   = Task::create("t1");
@@ -49,7 +50,7 @@ BOOST_AUTO_TEST_CASE(test_add) {
 }
 
 BOOST_AUTO_TEST_CASE(test_add_error) {
-    cout << "ANode:: ...test_add_error\n";
+    ECF_NAME_THIS_TEST();
 
     defs_ptr defs = Defs::create();
     suite_ptr s1  = defs->add_suite("s1");
@@ -62,7 +63,7 @@ BOOST_AUTO_TEST_CASE(test_add_error) {
 }
 
 BOOST_AUTO_TEST_CASE(test_add_delete_time) {
-    cout << "ANode:: ...test_add_delete_time\n"; // ECFLOW-1260
+    ECF_NAME_THIS_TEST(); // ECFLOW-1260
 
     // Make sure that if we delete any time based attributes
     Defs defs;

--- a/libs/node/test/TestAlias.cpp
+++ b/libs/node/test/TestAlias.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/Str.hpp"
 #include "ecflow/node/Alias.hpp"
@@ -28,8 +29,9 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_Alias)
 
 BOOST_AUTO_TEST_CASE(test_alias_create) {
-    cout << "ANode:: ...test_alias_create\n";
-    std::string ecf_home = File::test_data("ANode/test/data/alias", "ANode");
+    ECF_NAME_THIS_TEST();
+
+    std::string ecf_home = File::test_data("libs/node/test/data/alias", "libs/node");
 
     task_ptr t;
     Defs theDefs;

--- a/libs/node/test/TestAssignmentOperator.cpp
+++ b/libs/node/test/TestAssignmentOperator.cpp
@@ -13,6 +13,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "MyDefsFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/core/Ecf.hpp"
 
 using namespace std;
@@ -23,7 +24,8 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_AssignmentOperator)
 
 BOOST_AUTO_TEST_CASE(test_defs_assignment_operator) {
-    cout << "ANode:: ...test_defs_assignment_operator\n";
+    ECF_NAME_THIS_TEST();
+
     MyDefsFixture theDefsFixture;
 
     Defs defs;
@@ -45,7 +47,8 @@ BOOST_AUTO_TEST_CASE(test_defs_assignment_operator) {
 }
 
 BOOST_AUTO_TEST_CASE(test_suite_assignment_operator) {
-    cout << "ANode:: ...test_suite_assignment_operator\n";
+    ECF_NAME_THIS_TEST();
+
     Suite empty("empty");
 
     Suite s1("s1");
@@ -105,7 +108,8 @@ BOOST_AUTO_TEST_CASE(test_suite_assignment_operator) {
 }
 
 BOOST_AUTO_TEST_CASE(test_task_assignment_operator) {
-    cout << "ANode:: ...test_task_assignment_operator\n";
+    ECF_NAME_THIS_TEST();
+
     Task empty("empty");
 
     Task s1("s1");

--- a/libs/node/test/TestChangeMgrSingleton.cpp
+++ b/libs/node/test/TestChangeMgrSingleton.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/node/AbstractObserver.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
@@ -62,7 +63,8 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_ChangeMgrSingleton)
 
 BOOST_AUTO_TEST_CASE(test_change_mgr_singleton) {
-    cout << "ANode:: ...test_change_mgr_singleton\n";
+    ECF_NAME_THIS_TEST();
+
     {
         defs_ptr theDefs = Defs::create();
 

--- a/libs/node/test/TestClientSuiteMgr.cpp
+++ b/libs/node/test/TestClientSuiteMgr.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/node/ClientSuiteMgr.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
@@ -26,7 +27,8 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_ClientSuiteMgr)
 
 BOOST_AUTO_TEST_CASE(test_client_suite_mgr_remove_user) {
-    cout << "ANode:: ...test_client_suite_mgr_remove_user\n";
+    ECF_NAME_THIS_TEST();
+
     Defs theDefs;
     {
         suite_ptr suite = theDefs.add_suite("test_client_suite_mgr_remove_user");
@@ -78,7 +80,8 @@ BOOST_AUTO_TEST_CASE(test_client_suite_mgr_remove_user) {
 }
 
 BOOST_AUTO_TEST_CASE(test_client_suite_mgr_remove_handle) {
-    cout << "ANode:: ...test_client_suite_mgr_remove_handle\n";
+    ECF_NAME_THIS_TEST();
+
     Defs theDefs;
     {
         suite_ptr suite = theDefs.add_suite("test_client_suite_mgr_remove_handle");

--- a/libs/node/test/TestCopyConstructor.cpp
+++ b/libs/node/test/TestCopyConstructor.cpp
@@ -13,6 +13,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "MyDefsFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/core/Ecf.hpp"
 
 using namespace std;
@@ -23,7 +24,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_CopyConstructor)
 
 BOOST_AUTO_TEST_CASE(test_copy_constructors) {
-    cout << "ANode:: ...test_copy_constructors\n";
+    ECF_NAME_THIS_TEST();
     MyDefsFixture theDefsFixture;
 
     DebugEquality debug_equality; // only as affect in DEBUG build
@@ -32,7 +33,7 @@ BOOST_AUTO_TEST_CASE(test_copy_constructors) {
 }
 
 BOOST_AUTO_TEST_CASE(test_default_constructors) {
-    cout << "ANode:: ...test_default_constructors \n";
+    ECF_NAME_THIS_TEST();
 
     Task t;
     BOOST_CHECK_MESSAGE(t.check_defaults(), "constructor test for defaults failed");

--- a/libs/node/test/TestDefStatus.cpp
+++ b/libs/node/test/TestDefStatus.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
 #include "ecflow/node/Suite.hpp"
@@ -25,7 +26,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_DefsStatus)
 
 BOOST_AUTO_TEST_CASE(test_defstatus) {
-    cout << "ANode:: ...test_defstatus\n";
+    ECF_NAME_THIS_TEST();
 
     // Create a defs file corresponding to:
     // suite suite1
@@ -120,7 +121,7 @@ BOOST_AUTO_TEST_CASE(test_defstatus) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ECFLOW_139) {
-    cout << "ANode:: ...test_ECFLOW_139\n";
+    ECF_NAME_THIS_TEST();
 
     // Create a defs file corresponding to:
     // suite suite1

--- a/libs/node/test/TestDefs.cpp
+++ b/libs/node/test/TestDefs.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Converter.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
@@ -25,7 +26,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_Defs)
 
 BOOST_AUTO_TEST_CASE(test_defs_absorb) {
-    cout << "ANode:: ...test_defs_absorb\n";
+    ECF_NAME_THIS_TEST();
 
     // Create a defs file corresponding to:
     // suite suite1
@@ -59,7 +60,7 @@ BOOST_AUTO_TEST_CASE(test_defs_absorb) {
 }
 
 BOOST_AUTO_TEST_CASE(test_defs_absorb_server_user_variables) {
-    cout << "ANode:: ...test_defs_absorb_server_user_variables\n";
+    ECF_NAME_THIS_TEST();
 
     Defs theDefs;
     Defs otherDefs;
@@ -80,7 +81,7 @@ BOOST_AUTO_TEST_CASE(test_defs_absorb_server_user_variables) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ECFLOW_1684) {
-    cout << "ANode:: ...test_ECFLOW_1684\n";
+    ECF_NAME_THIS_TEST();
 
     Defs defs;
     defs.add_edit_history("/", "request");

--- a/libs/node/test/TestEcfFile.cpp
+++ b/libs/node/test/TestEcfFile.cpp
@@ -14,6 +14,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Ecf.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/Pid.hpp"
@@ -34,7 +35,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_EcfFile)
 
 BOOST_AUTO_TEST_CASE(test_ecf_file_with_bad_ECF_MICRO) {
-    cout << "ANode:: ...test_ecf_file_with_bad_ECF_MICRO\n";
+    ECF_NAME_THIS_TEST();
 
     // Create the defs file corresponding to the text below
     // suite suite
@@ -62,17 +63,17 @@ BOOST_AUTO_TEST_CASE(test_ecf_file_with_bad_ECF_MICRO) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecf_simple_include_file) {
+    ECF_NAME_THIS_TEST();
+
     // The specific files are specified in ECF_INCLUDE and common files
     // are specified in ECF_HOME. This test will ensure that if the file common.h
     // is not found in ECF_INCLUDE we then look at ECF_HOME
-    cout << "ANode:: ...test_ecf_simple_include_file";
 
     // This test FAIL's randomly on the cray in BATCH mode, but passes in interactive mode.
     if (getenv("ECFLOW_CRAY_BATCH")) {
         cout << " **** SKIPPING test, until HPC team can  fix File::createMissingDirectories.(like mkdir -p)  *****\n";
         return;
     }
-    cout << "\n";
 
     // Create the defs file corresponding to the text below
     // suite suite
@@ -149,13 +150,13 @@ BOOST_AUTO_TEST_CASE(test_ecf_simple_include_file) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ECFLOW_495) {
+    ECF_NAME_THIS_TEST();
+
     // This tests for a regression where, *NOT* all the include file were processed.
-    cout << "ANode:: ...test_ECFLOW_495";
     if (getenv("ECFLOW_CRAY_BATCH")) {
         cout << " **** SKIPPING test, until HPC team can fix File::createMissingDirectories.(like mkdir -p)  *****\n";
         return;
     }
-    cout << "\n";
 
     // Create the defs file corresponding to the text below
     // suite suite
@@ -223,12 +224,12 @@ BOOST_AUTO_TEST_CASE(test_ECFLOW_495) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ECF_SCRIPT_CMD_ECFLOW_427) {
-    cout << "ANode:: ...test_ECF_SCRIPT_CMD_ECFLOW_427";
+    ECF_NAME_THIS_TEST();
+
     if (getenv("ECFLOW_CRAY_BATCH")) {
         cout << " **** SKIPPING test, until HPC team can  fix File::createMissingDirectories.(like mkdir -p)  *****\n";
         return;
     }
-    cout << "\n";
 
     // Create the defs file corresponding to the text below
     // suite suite
@@ -365,17 +366,17 @@ BOOST_AUTO_TEST_CASE(test_ECF_SCRIPT_CMD_ECFLOW_427) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecf_include_file) {
+    ECF_NAME_THIS_TEST();
+
     // The specific files are specified in ECF_INCLUDE and common files
     // are specified in ECF_HOME. This test will ensure that if the file common.h
     // is not found in ECF_INCLUDE we then look at ECF_HOME
-    cout << "ANode:: ...test_ecf_include_file";
 
     // This test FAIL's randomly on the cray in BATCH mode, but passes in interactive mode.
     if (getenv("ECFLOW_CRAY_BATCH")) {
         cout << " **** SKIPPING test, until HPC team can  fix File::createMissingDirectories.(like mkdir -p)  *****\n";
         return;
     }
-    cout << "\n";
 
     // SET ECF_HOME
     std::string ecf_home = File::test_data("libs/node/test/data", "libs/node");
@@ -450,15 +451,15 @@ BOOST_AUTO_TEST_CASE(test_ecf_include_file) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecf_include_multi_paths_ECFLOW_261) {
+    ECF_NAME_THIS_TEST();
+
     // The specific files are specified in ECF_INCLUDE with multiple paths
-    cout << "ANode:: ...test_ecf_include_multi_paths_ECFLOW_261";
 
     // This test FAIL's randomly on the cray in BATCH mode, but passes in interactive mode.
     if (getenv("ECFLOW_CRAY_BATCH")) {
         cout << " **** SKIPPING test, until HPC team can  fix File::createMissingDirectories.(like mkdir -p)  *****\n";
         return;
     }
-    cout << "\n";
 
     // SET ECF_HOME
     std::string ecf_home = File::test_data("libs/node/test/data", "libs/node");
@@ -491,7 +492,7 @@ BOOST_AUTO_TEST_CASE(test_ecf_include_multi_paths_ECFLOW_261) {
 
     // generate the ecf file;
     string header   = "%include <head.h>\n\n";
-    string body     = "%include <fred.h>\n\n"; // this is only defined in ANode/test/data/includes2
+    string body     = "%include <fred.h>\n\n"; // this is only defined in libs/node/test/data/includes2
     string tail     = "%include <tail.h>\n# ===================================";
     string ecf_file = header;
     ecf_file += body;
@@ -532,16 +533,16 @@ BOOST_AUTO_TEST_CASE(test_ecf_include_multi_paths_ECFLOW_261) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecf_include_ECFLOW_274) {
+    ECF_NAME_THIS_TEST();
+
     // Test .ecf scripts with includes like %include "../bill.h"
     // In this case we expect to find bill.h in the same directory as the script
-    cout << "ANode:: ...test_ecf_include_ECFLOW_274";
 
     // This test FAIL's randomly on the cray in BATCH mode, but passes in interactive mode.
     if (getenv("ECFLOW_CRAY_BATCH")) {
         cout << " **** SKIPPING test, until HPC team can  fix File::createMissingDirectories.(like mkdir -p)  *****\n";
         return;
     }
-    cout << "\n";
 
     // SET ECF_HOME
     std::string ecf_home = File::test_data("libs/node/test/data", "libs/node");
@@ -625,18 +626,18 @@ BOOST_AUTO_TEST_CASE(test_ecf_include_ECFLOW_274) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecf_simple_used_variables) {
+    ECF_NAME_THIS_TEST();
+
     // Test that used variables are as expected
     // This should PRUNE the generated variables from the used variables list
     // Additionally it should NOT affect variables like ESUITE but should ignore generated variable SUITE
-    // See File: ANode/test/data/includes/used_variables.h
-    cout << "ANode:: ...test_ecf_simple_used_variables";
+    // See File: libs/node/test/data/includes/used_variables.h
 
     // This test FAIL's randomly on the cray in BATCH mode, but passes in interactive mode.
     if (getenv("ECFLOW_CRAY_BATCH")) {
         cout << " **** SKIPPING test, until HPC team can  fix File::createMissingDirectories.(like mkdir -p)  *****\n";
         return;
     }
-    cout << "\n";
 
     // Create the defs file corresponding to the text below
     // suite suite
@@ -694,21 +695,21 @@ BOOST_AUTO_TEST_CASE(test_ecf_simple_used_variables) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecf_simple_used_variables_with_comments) {
+    ECF_NAME_THIS_TEST();
+
     // Test that used variables are as expected
     // This should PRUNE the generated variables from the used variables list
     // Additionally it should NOT affect variables like ETASK but should ignore generated variable TASK
-    // See File: ANode/test/data/includes/used_variables_with_comments.h
+    // See File: libs/node/test/data/includes/used_variables_with_comments.h
     //
     // This WILL test that when we have user comment and manuals, we can still extract user variables
     // Those variable defined within comments and manuals that are not defined should be ignored
-    cout << "ANode:: ...test_ecf_simple_used_variables_with_comments";
 
     // This test FAIL's randomly on the cray in BATCH mode, but passes in interactive mode.
     if (getenv("ECFLOW_CRAY_BATCH")) {
         cout << " **** SKIPPING test, until HPC team can  fix File::createMissingDirectories.(like mkdir -p)  *****\n";
         return;
     }
-    cout << "\n";
 
     // SET ECF_HOME
     std::string ecf_home = File::test_data("libs/node/test/data", "libs/node");
@@ -769,17 +770,17 @@ BOOST_AUTO_TEST_CASE(test_ecf_simple_used_variables_with_comments) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecf_simple_used_variables_errors) {
+    ECF_NAME_THIS_TEST();
+
     // Test that used variables are as expected
     // This is similar to test_ecf_simple_used_variables_with_comments
     // BUT we DO NOT define variable FRED, hence we expect failure
-    cout << "ANode:: ...test_ecf_simple_used_variables_errors";
 
     // This test FAIL's randomly on the cray in BATCH mode, but passes in interactive mode.
     if (getenv("ECFLOW_CRAY_BATCH")) {
         cout << " **** SKIPPING test, until HPC team can  fix File::createMissingDirectories.(like mkdir -p)  *****\n";
         return;
     }
-    cout << "\n";
 
     // SET ECF_HOME
     std::string ecf_home = File::test_data("libs/node/test/data", "libs/node");
@@ -834,14 +835,13 @@ BOOST_AUTO_TEST_CASE(test_ecf_simple_used_variables_errors) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecf_file) {
-    cout << "ANode:: ...test_ecf_file";
+    ECF_NAME_THIS_TEST();
 
     // This test FAIL's randomly on the cray in BATCH mode, but passes in interactive mode.
     if (getenv("ECFLOW_CRAY_BATCH")) {
         cout << " **** SKIPPING test, until HPC team can  fix File::createMissingDirectories.(like mkdir -p)  *****\n";
         return;
     }
-    cout << "\n";
 
     // SET ECF_HOME
     std::string ecf_home = File::test_data("libs/node/test/data", "libs/node");
@@ -1030,14 +1030,13 @@ BOOST_AUTO_TEST_CASE(test_ecf_file) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecf_file_includenoop) {
-    cout << "ANode:: ...test_ecf_file_includenopp";
+    ECF_NAME_THIS_TEST();
 
     // This test FAIL's randomly on the cray in BATCH mode, but passes in interactive mode.
     if (getenv("ECFLOW_CRAY_BATCH")) {
         cout << " **** SKIPPING test, until HPC team can  fix File::createMissingDirectories.(like mkdir -p)  *****\n";
         return;
     }
-    cout << "\n";
 
     // This test is used to check that %includenopp are expanded only.
     // There should be NO variable substitution, or removal of comments/manual
@@ -1124,14 +1123,13 @@ BOOST_AUTO_TEST_CASE(test_ecf_file_includenoop) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecf_file_override_ECF_JOB) {
-    cout << "ANode:: ...test_ecf_file_override_ECF_JOB";
+    ECF_NAME_THIS_TEST();
 
     // This test FAIL's randomly on the cray in BATCH mode, but passes in interactive mode.
     if (getenv("ECFLOW_CRAY_BATCH")) {
         cout << " **** SKIPPING test, until HPC team can  fix File::createMissingDirectories.(like mkdir -p)  *****\n";
         return;
     }
-    cout << "\n";
 
     // This test is used to check that when user has added a variable ECF_JOB
     // to specify the location of the job file, we use that, in preference
@@ -1207,8 +1205,9 @@ BOOST_AUTO_TEST_CASE(test_ecf_file_override_ECF_JOB) {
 }
 
 BOOST_AUTO_TEST_CASE(test_manual_files) {
+    ECF_NAME_THIS_TEST();
+
     // The specific files are specified in ECF_INCLUDE and common files are specified in ECF_HOME.
-    cout << "ANode:: ...test_manual_files\n";
 
     // SET ECF_HOME
     std::string ecf_home = File::test_data("libs/node/test/data/SMSHOME", "libs/node");
@@ -1296,13 +1295,14 @@ BOOST_AUTO_TEST_CASE(test_manual_files) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ECFLOW_672) {
+    ECF_NAME_THIS_TEST();
+
     // test for recursive includes that are not recursive
-    cout << "ANode:: ...test_ECFLOW_672";
+
     if (getenv("ECFLOW_CRAY_BATCH")) {
         cout << " **** SKIPPING test, until HPC team can fix File::createMissingDirectories.(like mkdir -p)  *****\n";
         return;
     }
-    cout << "\n";
 
     // Create the defs file corresponding to the text below
     // suite ECFLOW_672
@@ -1352,13 +1352,11 @@ static void basic_test_template(const std::string& test_name,
                                 const std::string& expected_job_file_contents,
                                 const std::string& ecf_micro = "",
                                 bool expect_success          = true) {
-    cout << "ANode:: ..." << test_name;
     // This test FAIL's randomly on the cray in BATCH mode, but passes in interactive mode.
     if (getenv("ECFLOW_CRAY_BATCH")) {
         cout << " **** SKIPPING test, until HPC team can  fix File::createMissingDirectories.(like mkdir -p)  *****\n";
         return;
     }
-    cout << "\n";
 
     // Create the defs file corresponding to the text below
     // suite suite
@@ -1444,6 +1442,8 @@ static void basic_test_template(const std::string& test_name,
 }
 
 BOOST_AUTO_TEST_CASE(test_includeonce) {
+    ECF_NAME_THIS_TEST();
+
     // simplest test of include once, no hierarchy
     // generate the ecf file;
     string ecf_file = "%includeonce <simple_head.h>\n";
@@ -1459,6 +1459,8 @@ BOOST_AUTO_TEST_CASE(test_includeonce) {
 }
 
 BOOST_AUTO_TEST_CASE(test_includeonce_hierarchical) {
+    ECF_NAME_THIS_TEST();
+
     // Test the pre-processing is done depth first, ( < 4.1.1 it was done breadth first)
     // generate the ecf file;
     string ecf_file = "%includeonce <AA.h>\n";
@@ -1471,6 +1473,8 @@ BOOST_AUTO_TEST_CASE(test_includeonce_hierarchical) {
 }
 
 BOOST_AUTO_TEST_CASE(test_include_with_variables) {
+    ECF_NAME_THIS_TEST();
+
     // Test includes with variables %include <%head%.h> ECFLOW-765
 
     string ecf_file;
@@ -1484,6 +1488,8 @@ BOOST_AUTO_TEST_CASE(test_include_with_variables) {
 }
 
 BOOST_AUTO_TEST_CASE(test_include_with_variable_alternative) {
+    ECF_NAME_THIS_TEST();
+
     string ecf_file;
     ecf_file += "%include %FRED:<simple_head.h>%\n";
     ecf_file += "#body\n";
@@ -1495,6 +1501,8 @@ BOOST_AUTO_TEST_CASE(test_include_with_variable_alternative) {
 }
 
 BOOST_AUTO_TEST_CASE(test_include_with_variables_change_micro) {
+    ECF_NAME_THIS_TEST();
+
     string ecf_file;
     ecf_file += "%ecfmicro &\n"; // ecf_micro in script OVERRIDES ECF_MICRO variable, but *only* in script
     ecf_file += "&include <&simple&_head.h>\n";
@@ -1508,6 +1516,8 @@ BOOST_AUTO_TEST_CASE(test_include_with_variables_change_micro) {
 }
 
 BOOST_AUTO_TEST_CASE(test_script_override_ecf_micro) {
+    ECF_NAME_THIS_TEST();
+
     string ecf_file;             // ecf_micro in script OVERRIDES ECF_MICRO variable, but *only* in script
     ecf_file += "$simple$\n";    // ECF_MICRO is set to $
     ecf_file += "$ecfmicro &\n"; // ecfmicro change from $ -> &
@@ -1522,6 +1532,8 @@ BOOST_AUTO_TEST_CASE(test_script_override_ecf_micro) {
 }
 
 BOOST_AUTO_TEST_CASE(test_mistyped_ecf_micro) {
+    ECF_NAME_THIS_TEST();
+
     // same test as above, but we have mistyped ecf_micro. Make sure we don't ignore this.
     string ecf_file;
     ecf_file += "$simple$\n";
@@ -1537,6 +1549,8 @@ BOOST_AUTO_TEST_CASE(test_mistyped_ecf_micro) {
 }
 
 BOOST_AUTO_TEST_CASE(test_include_with_variables_mismatched_micros) {
+    ECF_NAME_THIS_TEST();
+
     // generate the ecf file, where include file has missmatched ecf_micro
     string ecf_file;
     ecf_file += "%include <%simple%_head%.h>\n";
@@ -1553,6 +1567,8 @@ BOOST_AUTO_TEST_CASE(test_include_with_variables_mismatched_micros) {
 }
 
 BOOST_AUTO_TEST_CASE(test_include_with_variable_not_defined) {
+    ECF_NAME_THIS_TEST();
+
     string ecf_file;
     ecf_file += "%include %simple_head.h%\n";
     ecf_file += "#body\n";
@@ -1568,6 +1584,8 @@ BOOST_AUTO_TEST_CASE(test_include_with_variable_not_defined) {
 }
 
 BOOST_AUTO_TEST_CASE(test_nopp_preserves_contents) {
+    ECF_NAME_THIS_TEST();
+
     string ecf_file;
     ecf_file += "%include <simple_head.h>\n";
     ecf_file += "#body\n";
@@ -1588,6 +1606,8 @@ BOOST_AUTO_TEST_CASE(test_nopp_preserves_contents) {
 }
 
 BOOST_AUTO_TEST_CASE(test_nopp_preserves_contents2) {
+    ECF_NAME_THIS_TEST();
+
     string ecf_file;
     ecf_file += "%include <simple_head.h>\n";
     ecf_file += "#body\n";
@@ -1602,6 +1622,8 @@ BOOST_AUTO_TEST_CASE(test_nopp_preserves_contents2) {
 }
 
 BOOST_AUTO_TEST_CASE(test_comment_and_manual_removal) {
+    ECF_NAME_THIS_TEST();
+
     string ecf_file;
     ecf_file += "%include <simple_head.h>\n";
     ecf_file += "#body\n";
@@ -1619,6 +1641,8 @@ BOOST_AUTO_TEST_CASE(test_comment_and_manual_removal) {
 }
 
 BOOST_AUTO_TEST_CASE(test_unterminated_manual) {
+    ECF_NAME_THIS_TEST();
+
     string ecf_file;
     ecf_file += "%include <simple_head.h>\n";
     ecf_file += "#body\n";
@@ -1634,6 +1658,8 @@ BOOST_AUTO_TEST_CASE(test_unterminated_manual) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecf_micro_with_comments_ECFLOW_1686) {
+    ECF_NAME_THIS_TEST();
+
     string ecf_file;
     ecf_file += "%include <simple_head.h>\n";
     ecf_file += "var=%XXXX:2 # fred%\n";
@@ -1647,6 +1673,8 @@ BOOST_AUTO_TEST_CASE(test_ecf_micro_with_comments_ECFLOW_1686) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecf_file_resolve_single_ecf_include_with_dollar) {
+    ECF_NAME_THIS_TEST();
+
     Defs d;
     suite_ptr s = d.add_suite("suite");                      // suite suite
     s->add_variable("CORE", "/path/to/core");                //   edit CORE /path/to/core
@@ -1662,6 +1690,8 @@ BOOST_AUTO_TEST_CASE(test_ecf_file_resolve_single_ecf_include_with_dollar) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecf_file_resolve_single_ecf_include) {
+    ECF_NAME_THIS_TEST();
+
     Defs d;
     suite_ptr s = d.add_suite("suite");                       // suite suite
     s->add_variable("CORE", "/path/to/core");                 //   edit CORE /path/to/core
@@ -1677,6 +1707,8 @@ BOOST_AUTO_TEST_CASE(test_ecf_file_resolve_single_ecf_include) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecf_file_resolve_multiple_ecf_include) {
+    ECF_NAME_THIS_TEST();
+
     Defs d;
     suite_ptr s = d.add_suite("suite");                                   // suite suite
     s->add_variable("CORE", "/path/to/core");                             //   edit CORE /path/to/core

--- a/libs/node/test/TestEcfFileLocator.cpp
+++ b/libs/node/test/TestEcfFileLocator.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/Pid.hpp"
 #include "ecflow/core/Str.hpp"
@@ -83,7 +84,8 @@ void create_ecf_file(const std::string& ecf_file_location) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecf_file_search) {
-    cout << "ANode:: ...test_ecf_file_search\n";
+    ECF_NAME_THIS_TEST();
+
     // Do test which fails first, i.e does not find the ecf file, then add variable ECF_FILES_LOOKUP(PRUNE_LEAF)
     // The test should then succeed
     // Note: Setting ECF_FILES_LOOKUP(PRUNE_LEAF) or ECF_FILES_LOOKUP(PRUNE_ROOT)/default affects the lookup for
@@ -238,7 +240,7 @@ BOOST_AUTO_TEST_CASE(test_ecf_file_search) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecf_file_locator) {
-    cout << "ANode:: ...test_ecf_file_locator\n";
+    ECF_NAME_THIS_TEST();
 
     // SET ECF_HOME
     std::string smshome = File::test_data("libs/node/test/data/SMSHOME", "libs/node");
@@ -356,7 +358,7 @@ BOOST_AUTO_TEST_CASE(test_ecf_file_locator) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecf_file_locator_using_ECF_FILES) {
-    cout << "ANode:: ...test_ecf_file_locator_using_ECF_FILES\n";
+    ECF_NAME_THIS_TEST();
 
     // This test will check we can locate the ecf files in ECF_FILES directory
 
@@ -369,8 +371,8 @@ BOOST_AUTO_TEST_CASE(test_ecf_file_locator_using_ECF_FILES) {
     // Create a defs file corresponding to:
     // # Test the sms file can be found via ECF_SCRIPT
     // #
-    // edit ECF_HOME    ANode/test/data
-    // edit ECF_FILES   ANode/test/data/SMSHOME/suite/family
+    // edit ECF_HOME    libs/node/test/test/data
+    // edit ECF_FILES   libs/node/test/data/SMSHOME/suite/family
     // suite suite
     // edit ECF_INCLUDE $ECF_HOME/includes
     // edit SLEEPTIME 10
@@ -421,7 +423,7 @@ BOOST_AUTO_TEST_CASE(test_ecf_file_locator_using_ECF_FILES) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ecf_file_locator_using_ECF_FILES_variable_substitution) {
-    cout << "ANode:: ...test_ecf_file_locator_using_ECF_FILES_variable_substitution\n";
+    ECF_NAME_THIS_TEST();
 
     // ECFLOW-788
     // This test will check we can locate the ecf files in ECF_FILES directory
@@ -436,8 +438,8 @@ BOOST_AUTO_TEST_CASE(test_ecf_file_locator_using_ECF_FILES_variable_substitution
     // Create a defs file corresponding to:
     // # Test the sms file can be found via ECF_SCRIPT
     // #
-    // edit ECF_HOME    ANode/test/data
-    // edit ECF_FILES   ANode/test/data/SMSHOME/suite/%FAMILY%   # test we variable substitute
+    // edit ECF_HOME    libs/node/test/data
+    // edit ECF_FILES   libs/node/test/data/SMSHOME/suite/%FAMILY%   # test we variable substitute
     // suite suite
     // edit ECF_INCLUDE $ECF_HOME/includes
     // edit SLEEPTIME 10

--- a/libs/node/test/TestEnviromentSubstitution.cpp
+++ b/libs/node/test/TestEnviromentSubstitution.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Str.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Suite.hpp"
@@ -25,7 +26,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_EnvironmentSubstitution)
 
 BOOST_AUTO_TEST_CASE(test_environment_substitution) {
-    std::cout << "ANode:: ...test_environment_substitution\n";
+    ECF_NAME_THIS_TEST();
 
     Defs defs;
     Suite* s = nullptr;

--- a/libs/node/test/TestExprParser.cpp
+++ b/libs/node/test/TestExprParser.cpp
@@ -14,6 +14,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Converter.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/ExprAst.hpp"
@@ -31,7 +32,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_ExprParser)
 
 BOOST_AUTO_TEST_CASE(test_expression_parser_basic) {
-    std::cout << "ANode:: ...test_expression_parser_basic\n";
+    ECF_NAME_THIS_TEST();
 
     using namespace std::string_literals;
 
@@ -113,7 +114,7 @@ BOOST_AUTO_TEST_CASE(test_expression_parser_basic) {
 }
 
 BOOST_AUTO_TEST_CASE(test_expression_parser_basic_with_braces) {
-    std::cout << "ANode:: ...test_expression_parser_basic_with_braces\n";
+    ECF_NAME_THIS_TEST();
 
     using namespace std::string_literals;
 
@@ -162,7 +163,7 @@ BOOST_AUTO_TEST_CASE(test_expression_parser_basic_with_braces) {
 }
 
 BOOST_AUTO_TEST_CASE(test_parser_good_expressions) {
-    std::cout << "ANode:: ...test_parser_good_expressions\n";
+    ECF_NAME_THIS_TEST();
 
     // The map key  = trigger expression,
     // value.first  = type of the expected root abstract syntax tree
@@ -482,7 +483,7 @@ BOOST_AUTO_TEST_CASE(test_parser_good_expressions) {
 }
 
 BOOST_AUTO_TEST_CASE(test_trigger_functions) {
-    std::cout << "ANode:: ...test_trigger_functions\n";
+    ECF_NAME_THIS_TEST();
 
     // The map key  = trigger expression,
     // value.first  = type of the expected root abstract syntax tree
@@ -552,7 +553,7 @@ BOOST_AUTO_TEST_CASE(test_trigger_functions) {
 }
 
 BOOST_AUTO_TEST_CASE(test_date_to_julian_with_repeat_YMD) {
-    std::cout << "ANode:: ...test_date_to_julian_with_repeat_YMD\n";
+    ECF_NAME_THIS_TEST();
 
     Defs theDefs;
     suite_ptr suite = theDefs.add_suite("s1");
@@ -580,7 +581,8 @@ BOOST_AUTO_TEST_CASE(test_date_to_julian_with_repeat_YMD) {
 }
 
 BOOST_AUTO_TEST_CASE(test_trigger_functions_with_boost_date) {
-    std::cout << "ANode:: ...test_trigger_functions_with_boost_date\n";
+    ECF_NAME_THIS_TEST();
+
     // The map key  = trigger expression,
     // value.first  = type of the expected root abstract syntax tree
     // value.second = result of expected evaluation
@@ -648,7 +650,7 @@ BOOST_AUTO_TEST_CASE(test_trigger_functions_with_boost_date) {
 }
 
 BOOST_AUTO_TEST_CASE(test_trigger_expression_divide_by_zero) {
-    std::cout << "ANode:: ...test_trigger_expression_divide_by_zero\n";
+    ECF_NAME_THIS_TEST();
 
     // The map key  = trigger expression,
     // value.first  = type of the expected root abstract syntax tree
@@ -688,7 +690,7 @@ BOOST_AUTO_TEST_CASE(test_trigger_expression_divide_by_zero) {
 }
 
 BOOST_AUTO_TEST_CASE(test_parser_bad_expressions) {
-    std::cout << "ANode:: ...test_parser_bad_expressions\n";
+    ECF_NAME_THIS_TEST();
 
     std::vector expressions = {"/s/f/t<flag>restored"s,
                                "a <= complete"s,

--- a/libs/node/test/TestExprRepeatDateArithmetic.cpp
+++ b/libs/node/test/TestExprRepeatDateArithmetic.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/ExprAst.hpp"
 #include "ecflow/node/Suite.hpp"
@@ -23,7 +24,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_ExprRepeatDateArithmetic)
 
 BOOST_AUTO_TEST_CASE(test_repeat_data_arithmetic) {
-    cout << "ANode:: ...test_repeat_data_arithmetic\n";
+    ECF_NAME_THIS_TEST();
 
     Defs theDefs;
     task_ptr t2, t1;
@@ -56,7 +57,7 @@ BOOST_AUTO_TEST_CASE(test_repeat_data_arithmetic) {
 }
 
 BOOST_AUTO_TEST_CASE(test_repeat_data_arithmetic_add_to_end_of_month) {
-    cout << "ANode:: ...test_repeat_data_arithmetic_add_to_end_of_month\n";
+    ECF_NAME_THIS_TEST();
 
     Defs theDefs;
     task_ptr t2, t1;
@@ -136,7 +137,7 @@ BOOST_AUTO_TEST_CASE(test_repeat_data_arithmetic_add_to_end_of_month) {
 }
 
 BOOST_AUTO_TEST_CASE(test_repeat_data_arithmetic_take_from_end_of_month) {
-    cout << "ANode:: ...test_repeat_data_arithmetic_take_from_end_of_month\n";
+    ECF_NAME_THIS_TEST();
 
     Defs theDefs;
     task_ptr t2, t1;

--- a/libs/node/test/TestExprRepeatDateListArithmetic.cpp
+++ b/libs/node/test/TestExprRepeatDateListArithmetic.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/ExprAst.hpp"
 #include "ecflow/node/Suite.hpp"
@@ -23,7 +24,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_ExprRepeatDateListArithmetic)
 
 BOOST_AUTO_TEST_CASE(test_repeat_date_list_arithmetic) {
-    cout << "ANode:: ... test_repeat_date_list_arithmetic\n";
+    ECF_NAME_THIS_TEST();
 
     Defs theDefs;
     task_ptr t2, t1;
@@ -56,7 +57,7 @@ BOOST_AUTO_TEST_CASE(test_repeat_date_list_arithmetic) {
 }
 
 BOOST_AUTO_TEST_CASE(test_repeat_date_list_arithmetic_add_to_end_of_month) {
-    cout << "ANode:: ...test_repeat_date_list_arithmetic_add_to_end_of_month \n";
+    ECF_NAME_THIS_TEST();
 
     Defs theDefs;
     task_ptr t2, t1;
@@ -136,7 +137,7 @@ BOOST_AUTO_TEST_CASE(test_repeat_date_list_arithmetic_add_to_end_of_month) {
 }
 
 BOOST_AUTO_TEST_CASE(test_repeat_date_list_arithmetic_take_from_end_of_month) {
-    cout << "ANode:: ... test_repeat_date_list_arithmetic_take_from_end_of_month\n";
+    ECF_NAME_THIS_TEST();
 
     Defs theDefs;
     task_ptr t2, t1;

--- a/libs/node/test/TestFindAbsNodePath.cpp
+++ b/libs/node/test/TestFindAbsNodePath.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Converter.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
@@ -26,7 +27,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_FindAbsNodePath)
 
 BOOST_AUTO_TEST_CASE(test_find_abs_node_path) {
-    cout << "ANode:: ...test_find_abs_node_path\n";
+    ECF_NAME_THIS_TEST();
 
     size_t no_of_nodes = 0;
     size_t no_of_alias = 0;

--- a/libs/node/test/TestFlag.cpp
+++ b/libs/node/test/TestFlag.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/node/Flag.hpp"
 
 using namespace std;
@@ -22,7 +23,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_Flag)
 
 BOOST_AUTO_TEST_CASE(test_node_flags) {
-    cout << "ANode:: ...test_node_flags\n";
+    ECF_NAME_THIS_TEST();
 
     Flag flag;
     std::string expected_flags =
@@ -64,7 +65,7 @@ BOOST_AUTO_TEST_CASE(test_node_flags) {
 }
 
 BOOST_AUTO_TEST_CASE(test_node_flags_parsing) {
-    cout << "ANode:: ...test_node_flags_parsing\n";
+    ECF_NAME_THIS_TEST();
 
     /// Set the flags
     Flag flag;

--- a/libs/node/test/TestHistoryParser.cpp
+++ b/libs/node/test/TestHistoryParser.cpp
@@ -14,6 +14,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/node/Defs.hpp"
 
 using namespace std;
@@ -31,7 +32,7 @@ static std::string dump(const std::vector<std::string>& vec) {
 }
 
 BOOST_AUTO_TEST_CASE(test_defs_history_parser) {
-    cout << "ANode:: ...test_defs_history_parser\n";
+    ECF_NAME_THIS_TEST();
 
     {
         string str1("MSG:[12:03:55 21.8.2013] --shutdown=yes :map");

--- a/libs/node/test/TestInLimit.cpp
+++ b/libs/node/test/TestInLimit.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "TestSerialisation.hpp"
 #include "ecflow/node/InLimit.hpp"
 #include "ecflow/node/Task.hpp"
@@ -25,7 +26,8 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_InLimit)
 
 BOOST_AUTO_TEST_CASE(test_inlimit_basics) {
-    cout << "ANode:: ...test_inlimit_basics \n";
+    ECF_NAME_THIS_TEST();
+
     {
         InLimit empty;
         InLimit empty2;
@@ -78,7 +80,7 @@ BOOST_AUTO_TEST_CASE(test_inlimit_basics) {
 }
 
 BOOST_AUTO_TEST_CASE(test_inlimit_duplicates) {
-    cout << "ANode:: ...test_inlimit_duplicates \n";
+    ECF_NAME_THIS_TEST();
 
     InLimit inlim("fred", "/path/to/node", 1, true);
 
@@ -96,7 +98,8 @@ BOOST_AUTO_TEST_CASE(test_inlimit_duplicates) {
 // Globals used throughout the test
 static std::string fileName = "test_InLimit_serialisation.txt";
 BOOST_AUTO_TEST_CASE(test_InLimit_serialisation) {
-    cout << "ANode:: ...test_InLimit_serialisation\n";
+    ECF_NAME_THIS_TEST();
+
     {
         // save and restore the default constructor
         doSaveAndRestore<InLimit>(fileName);

--- a/libs/node/test/TestJobCreator.cpp
+++ b/libs/node/test/TestJobCreator.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/Str.hpp"
 #include "ecflow/node/Defs.hpp"
@@ -30,7 +31,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_JobCreator)
 
 BOOST_AUTO_TEST_CASE(test_job_creator) {
-    cout << "ANode:: ...test_job_creator\n";
+    ECF_NAME_THIS_TEST();
 
     // SET SMSHOME
     std::string ecf_home = File::test_data("libs/node/test/data/SMSHOME", "libs/node");

--- a/libs/node/test/TestJobProfiler.cpp
+++ b/libs/node/test/TestJobProfiler.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/Log.hpp"
 #include "ecflow/core/Str.hpp"
@@ -30,7 +31,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_JobProfiler)
 
 BOOST_AUTO_TEST_CASE(test_job_profiler) {
-    cout << "ANode:: ...test_job_profiler\n";
+    ECF_NAME_THIS_TEST();
 
     // delete the log file if it exists.
     std::string log_path = File::test_data("libs/node/test/logfile.txt", "libs/node");

--- a/libs/node/test/TestLimit.cpp
+++ b/libs/node/test/TestLimit.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "TestSerialisation.hpp"
 #include "ecflow/core/Converter.hpp"
 #include "ecflow/core/Ecf.hpp"
@@ -25,7 +26,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_Limit)
 
 BOOST_AUTO_TEST_CASE(test_limit_basics) {
-    cout << "ANode:: ...test_limit_basics \n";
+    ECF_NAME_THIS_TEST();
 
     {
         Limit empty;
@@ -89,7 +90,7 @@ BOOST_AUTO_TEST_CASE(test_limit_basics) {
 }
 
 BOOST_AUTO_TEST_CASE(test_limit_increment) {
-    cout << "ANode:: ...test_limit_increment\n";
+    ECF_NAME_THIS_TEST();
 
     Limit limit("name", 10);    // Limit of 10
     limit.increment(1, "path"); // consume 1 token
@@ -105,7 +106,7 @@ BOOST_AUTO_TEST_CASE(test_limit_increment) {
 }
 
 BOOST_AUTO_TEST_CASE(test_limit_increment_2) {
-    cout << "ANode:: ...test_limit_increment_2\n";
+    ECF_NAME_THIS_TEST();
 
     Limit limit("name", 10); // Limit of 10
     for (int i = 0; i < 20; i++) {
@@ -118,7 +119,7 @@ BOOST_AUTO_TEST_CASE(test_limit_increment_2) {
 }
 
 BOOST_AUTO_TEST_CASE(test_limit_decrement) {
-    cout << "ANode:: ...test_limit_decrement\n";
+    ECF_NAME_THIS_TEST();
 
     Ecf::set_server(true); // needed to test state_change_numbers
 
@@ -171,7 +172,7 @@ BOOST_AUTO_TEST_CASE(test_limit_decrement) {
 }
 
 BOOST_AUTO_TEST_CASE(test_limit_set_value) {
-    cout << "ANode:: ...test_limit_set_value\n";
+    ECF_NAME_THIS_TEST();
 
     Limit limit("name", 10);     // Limit of 10
     limit.increment(1, "path");  // consume 1 token
@@ -194,13 +195,14 @@ BOOST_AUTO_TEST_CASE(test_limit_set_value) {
 // Globals used throughout the test
 static std::string fileName = "testLimit.txt";
 BOOST_AUTO_TEST_CASE(test_LimitDefaultConstructor_serialisation) {
-    cout << "ANode:: ...test_LimitDefaultConstructor_serialisation \n";
+    ECF_NAME_THIS_TEST();
 
     doSaveAndRestore<Limit>(fileName);
 }
 
 BOOST_AUTO_TEST_CASE(test_Limit_serialisation) {
-    cout << "ANode:: ...test_Limit_serialisation\n";
+    ECF_NAME_THIS_TEST();
+
     Limit saved1("limitName", 100);
     doSaveAndRestore(fileName, saved1);
 

--- a/libs/node/test/TestMigration.cpp
+++ b/libs/node/test/TestMigration.cpp
@@ -11,6 +11,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "MyDefsFixture.hpp"
+#include "TestNaming.hpp"
 #include "TestSerialisation.hpp"
 #include "ecflow/core/Ecf.hpp"
 #include "ecflow/core/File.hpp"
@@ -31,7 +32,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_Migration)
 
 BOOST_AUTO_TEST_CASE(test_default_constructor_persistence) {
-    cout << "ANode:: ...test_default_constructor_persistence\n";
+    ECF_NAME_THIS_TEST();
 
     std::string file_name = File::test_data("libs/node/test/data/migration/", "libs/node");
 
@@ -62,7 +63,7 @@ BOOST_AUTO_TEST_CASE(test_default_constructor_persistence) {
 }
 
 BOOST_AUTO_TEST_CASE(test_compare_cereal_and_defs_checkpt_file) {
-    cout << "ANode:: ...test_compare_cereal_and_defs_checkpt_file\n";
+    ECF_NAME_THIS_TEST();
 
     std::string file_name = File::test_data("libs/node/test/data/migration/", "libs/node");
 

--- a/libs/node/test/TestMissNextTimeSlot.cpp
+++ b/libs/node/test/TestMissNextTimeSlot.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Suite.hpp"
 #include "ecflow/node/Task.hpp"
@@ -22,7 +23,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_MissNextTimeSlot)
 
 BOOST_AUTO_TEST_CASE(test_miss_next_time_slot) {
-    cout << "ANode:: ...test_miss_next_time_slot\n";
+    ECF_NAME_THIS_TEST();
 
     // Start TIME at 9:30
     // This test is custom. When the user interactively forces a node to the complete state,

--- a/libs/node/test/TestMovePeer.cpp
+++ b/libs/node/test/TestMovePeer.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
 #include "ecflow/node/Suite.hpp"
@@ -23,7 +24,8 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_MovePeer)
 
 BOOST_AUTO_TEST_CASE(test_move_peer) {
-    cout << "ANode:: ...test_move_peer\n";
+    ECF_NAME_THIS_TEST();
+
     Defs defs;
     {
         std::vector<string> vec{"3", "2", "1"};

--- a/libs/node/test/TestNodeBeginRequeue.cpp
+++ b/libs/node/test/TestNodeBeginRequeue.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
 #include "ecflow/node/Suite.hpp"
@@ -23,7 +24,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_NodeBeginRequeue)
 
 BOOST_AUTO_TEST_CASE(test_node_begin_requeue_hybrid) {
-    cout << "ANode:: ...test_node_begin_reque_hybrid\n";
+    ECF_NAME_THIS_TEST();
 
     // Create a suite with a *HYBRID* clock, and tasks with day,date and cron time attributes
     defs_ptr the_defs = Defs::create();

--- a/libs/node/test/TestNodeState.cpp
+++ b/libs/node/test/TestNodeState.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
 #include "ecflow/node/Suite.hpp"
@@ -25,7 +26,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_NodeState)
 
 BOOST_AUTO_TEST_CASE(test_state_hierarchy) {
-    cout << "ANode:: ...test_state_hierarchy\n";
+    ECF_NAME_THIS_TEST();
 
     // Create a defs file corresponding to:
     // suite s1

--- a/libs/node/test/TestOrder.cpp
+++ b/libs/node/test/TestOrder.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/CalendarUpdateParams.hpp"
 #include "ecflow/core/Str.hpp"
 #include "ecflow/node/Alias.hpp"
@@ -36,7 +37,8 @@ static void test_invariants(Defs& the_defs, int line) {
 }
 
 BOOST_AUTO_TEST_CASE(test_order) {
-    cout << "ANode:: ...test_order\n";
+    ECF_NAME_THIS_TEST();
+
     std::vector<std::string> vec;
     vec.reserve(5);
     vec.emplace_back("a");
@@ -333,7 +335,8 @@ BOOST_AUTO_TEST_CASE(test_order) {
 }
 
 BOOST_AUTO_TEST_CASE(test_alias_order) {
-    cout << "ANode:: ...test_alias_order\n";
+    ECF_NAME_THIS_TEST();
+
     task_ptr task;
     Defs theDefs;
     {
@@ -402,7 +405,8 @@ BOOST_AUTO_TEST_CASE(test_alias_order) {
 }
 
 BOOST_AUTO_TEST_CASE(test_order_by_runtime) {
-    cout << "ANode:: ...test_order_by_runtime\n";
+    ECF_NAME_THIS_TEST();
+
     Defs defs;
     {
         std::vector<string> vec{"3", "2", "1"};

--- a/libs/node/test/TestPersistence.cpp
+++ b/libs/node/test/TestPersistence.cpp
@@ -11,6 +11,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "MyDefsFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/core/Filesystem.hpp"
 #include "ecflow/node/Defs.hpp"
 
@@ -49,13 +50,14 @@ static void testPersistence(const Defs& fixtureDefs) {
 }
 
 BOOST_AUTO_TEST_CASE(test_node_tree_persistence_text) {
-    cout << left << setw(54) << "ANode:: ...test_node_tree_persistence_text";
+    ECF_NAME_THIS_TEST();
+
     BOOST_CHECK_MESSAGE(true, ""); // stop boost complaining about no assertions
     testPersistence(fixtureDefsFile());
 }
 
 BOOST_AUTO_TEST_CASE(test_node_defs_persistence) {
-    cout << "ANode:: ...test_node_defs_persistence\n";
+    ECF_NAME_THIS_TEST();
 
     const Defs& defs = fixtureDefsFile();
     std::vector<node_ptr> all_nodes;

--- a/libs/node/test/TestPreProcessing.cpp
+++ b/libs/node/test/TestPreProcessing.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Ecf.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/Str.hpp"
@@ -188,7 +189,7 @@ void test_sms_preprocessing(const std::string& directory, bool pass) {
 }
 
 BOOST_AUTO_TEST_CASE(test_good_sms) {
-    cout << "ANode:: ...test_good_ecf\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/node/test/data/SMSHOME2/good", "libs/node");
 
@@ -197,7 +198,7 @@ BOOST_AUTO_TEST_CASE(test_good_sms) {
 }
 
 BOOST_AUTO_TEST_CASE(test_bad_sms) {
-    cout << "ANode:: ...test_bad_ecf\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/node/test/data/SMSHOME2/bad", "libs/node");
 

--- a/libs/node/test/TestRepeatWithTimeDependencies.cpp
+++ b/libs/node/test/TestRepeatWithTimeDependencies.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/CalendarUpdateParams.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
@@ -30,7 +31,8 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_RepeatWithTimeDependencies)
 
 BOOST_AUTO_TEST_CASE(test_repeat_day_time_combination_in_hierarchy) {
-    cout << "ANode:: ...test_repeat_day_time_combination_in_hierarchy \n";
+    ECF_NAME_THIS_TEST();
+
     // Create the suite, starting on a sunday
     // suite s1
     //  family f
@@ -116,7 +118,8 @@ BOOST_AUTO_TEST_CASE(test_repeat_day_time_combination_in_hierarchy) {
 }
 
 BOOST_AUTO_TEST_CASE(test_repeat_time_day_combination_in_hierarchy) {
-    cout << "ANode:: ...test_repeat_time_day_combination_in_hierarchy \n";
+    ECF_NAME_THIS_TEST();
+
     // Create the suite, starting on a sunday
     // suite s1
     //  family f
@@ -184,7 +187,8 @@ BOOST_AUTO_TEST_CASE(test_repeat_time_day_combination_in_hierarchy) {
 }
 
 BOOST_AUTO_TEST_CASE(test_repeat_with_impossible_day_combination_in_hierarchy) {
-    cout << "ANode:: ...test_repeat_with_impossible_day_combination_in_hierarchy\n";
+    ECF_NAME_THIS_TEST();
+
     // Create the suite, starting on a sunday
     //   suite s1
     //     clock real 04.08.2019            # Sunday

--- a/libs/node/test/TestReplace.cpp
+++ b/libs/node/test/TestReplace.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Ecf.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/Str.hpp"
@@ -68,7 +69,8 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_Replace)
 
 BOOST_AUTO_TEST_CASE(test_replace_add_task) {
-    cout << "ANode:: ...test_replace_add_task\n";
+    ECF_NAME_THIS_TEST();
+
     defs_ptr clientDef = Defs::create();
     {
         suite_ptr suite = Suite::create("suite1");
@@ -105,7 +107,8 @@ BOOST_AUTO_TEST_CASE(test_replace_add_task) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_add_suite) {
-    cout << "ANode:: ...test_replace_add_suite\n";
+    ECF_NAME_THIS_TEST();
+
     // In this test the server defs is *EMPTY* hence we should copy/move over the whole suite
     // provided the a/ Path to node exists in the client def, b/ create nodes as needed is TRUE
     Defs expectedDefs;
@@ -180,7 +183,8 @@ BOOST_AUTO_TEST_CASE(test_replace_add_suite) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_child) {
-    cout << "ANode:: ...test_replace_child\n";
+    ECF_NAME_THIS_TEST();
+
     defs_ptr clientDef = Defs::create();
     {
         suite_ptr suite = Suite::create("suite1");
@@ -209,7 +213,8 @@ BOOST_AUTO_TEST_CASE(test_replace_child) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_add_preserves_states) {
-    cout << "ANode:: ...test_replace_add_preserves_states\n";
+    ECF_NAME_THIS_TEST();
+
     defs_ptr clientDef = Defs::create();
     {
         suite_ptr suite = clientDef->add_suite("suite1");
@@ -264,7 +269,8 @@ BOOST_AUTO_TEST_CASE(test_replace_add_preserves_states) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_preserves_suspend) {
-    cout << "ANode:: ...test_replace_preserves_suspend\n"; // ECFLOW-1520
+    ECF_NAME_THIS_TEST(); // ECFLOW-1520
+
     defs_ptr clientDef = Defs::create();
     {
         suite_ptr suite = clientDef->add_suite("suite1");
@@ -324,7 +330,8 @@ BOOST_AUTO_TEST_CASE(test_replace_preserves_suspend) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_preserves_suspend2) {
-    cout << "ANode:: ...test_replace_preserves_suspend2\n"; // ECFLOW-1520
+    ECF_NAME_THIS_TEST(); // ECFLOW-1520
+
     defs_ptr clientDef = Defs::create();
     {
         suite_ptr suite = clientDef->add_suite("suite1");
@@ -373,7 +380,8 @@ BOOST_AUTO_TEST_CASE(test_replace_preserves_suspend2) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_preserves_sibling_states) {
-    cout << "ANode:: ...test_replace_preserves_sibling_states\n";
+    ECF_NAME_THIS_TEST();
+
     defs_ptr clientDef = Defs::create();
     {
         suite_ptr suite = Suite::create("suite1");
@@ -409,7 +417,8 @@ BOOST_AUTO_TEST_CASE(test_replace_preserves_sibling_states) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_preserves_begun_status) {
-    cout << "ANode:: ...test_replace_preserves_begun_status\n";
+    ECF_NAME_THIS_TEST();
+
     defs_ptr clientDef = Defs::create();
     {
         suite_ptr suite = clientDef->add_suite("suite1");
@@ -445,10 +454,12 @@ BOOST_AUTO_TEST_CASE(test_replace_preserves_begun_status) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_preserves_begun_where_client_not_begun) {
-    cout << "ANode:: ...test_replace_preserves_begun_where_client_not_begun\n"; // ECFLOW-1612
+    ECF_NAME_THIS_TEST(); // ECFLOW-1612
+
     // In this test we will end up calling begin on the time attribute.
     // However we had called begin on the client defs side, where the calendar/suite had not been begun
     // Thus causing an assert failure. The fix is to call begin on the server side, after the replace.
+
     defs_ptr clientDef = Defs::create();
     {
         suite_ptr suite = Suite::create("suite1");
@@ -489,7 +500,8 @@ BOOST_AUTO_TEST_CASE(test_replace_preserves_begun_where_client_not_begun) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_add_node) {
-    cout << "ANode:: ...test_replace_add_node\n";
+    ECF_NAME_THIS_TEST();
+
     defs_ptr clientDef = Defs::create();
     {
         suite_ptr suite = Suite::create("suite1");
@@ -529,7 +541,8 @@ BOOST_AUTO_TEST_CASE(test_replace_add_node) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_add_hierarchy) {
-    cout << "ANode:: ...test_replace_add_hierarchy\n";
+    ECF_NAME_THIS_TEST();
+
     defs_ptr clientDef = Defs::create();
     {
         suite_ptr suite = Suite::create("suite1");
@@ -578,9 +591,11 @@ BOOST_AUTO_TEST_CASE(test_replace_add_hierarchy) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_order_preserved_for_suite) {
-    cout << "ANode:: ...test_replace_order_preserved_for_suite\n";
+    ECF_NAME_THIS_TEST();
+
     // Test that when we replace a suite, its order is preserved,
     // See  ECFLOW-23 - When replacing a node the order is changed.
+
     defs_ptr clientDef = Defs::create();
     {
         clientDef->add_suite("s1");
@@ -628,9 +643,11 @@ BOOST_AUTO_TEST_CASE(test_replace_order_preserved_for_suite) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_order_preserved_for_family) {
-    cout << "ANode:: ...test_replace_order_preserved_for_family\n";
+    ECF_NAME_THIS_TEST();
+
     // Test that when we replace a family, its order is preserved,
     // See  ECFLOW-23 - When replacing a node the order is changed.
+
     defs_ptr clientDef = Defs::create();
     {
         suite_ptr suite = clientDef->add_suite("suite1");
@@ -682,9 +699,11 @@ BOOST_AUTO_TEST_CASE(test_replace_order_preserved_for_family) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_order_preserved_for_task) {
-    cout << "ANode:: ...test_replace_order_preserved_for_task\n";
+    ECF_NAME_THIS_TEST();
+
     // Test that when we replace a family, its order is preserved,
     // See  ECFLOW-23 - When replacing a node the order is changed.
+
     defs_ptr clientDef = Defs::create();
     {
         suite_ptr suite = clientDef->add_suite("suite1");
@@ -742,7 +761,8 @@ BOOST_AUTO_TEST_CASE(test_replace_order_preserved_for_task) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_child_errors) {
-    cout << "ANode:: ...test_replace_child_errors\n";
+    ECF_NAME_THIS_TEST();
+
     defs_ptr clientDef = Defs::create();
     {
         suite_ptr suite = Suite::create("suite1");
@@ -763,7 +783,8 @@ BOOST_AUTO_TEST_CASE(test_replace_child_errors) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_child_errors_2) {
-    cout << "ANode:: ...test_replace_child_errors_2\n";
+    ECF_NAME_THIS_TEST();
+
     defs_ptr clientDef = Defs::create();
     {
         suite_ptr suite = Suite::create("suite1");
@@ -802,8 +823,10 @@ BOOST_AUTO_TEST_CASE(test_replace_child_errors_2) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_child_errors_3) {
+    ECF_NAME_THIS_TEST();
+
     // test force option
-    cout << "ANode:: ...test_replace_child_errors_3\n";
+
     defs_ptr clientDef = Defs::create();
     {
         suite_ptr suite = Suite::create("suite1");
@@ -844,7 +867,8 @@ BOOST_AUTO_TEST_CASE(test_replace_child_errors_3) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_add_task_with_bad_trigger) {
-    cout << "ANode:: ...test_replace_add_task_with_bad_trigger\n";
+    ECF_NAME_THIS_TEST();
+
     defs_ptr clientDef = Defs::create();
     {
         suite_ptr suite = clientDef->add_suite("suite1");
@@ -877,7 +901,7 @@ BOOST_AUTO_TEST_CASE(test_replace_add_task_with_bad_trigger) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_add_suite_with_bad_triggers) {
-    cout << "ANode:: ...test_replace_add_suite_with_bad_triggers\n";
+    ECF_NAME_THIS_TEST();
 
     // The whole suite should get *MOVED* from clientDef to the *EMPTY* server def. i.e add
     defs_ptr clientDef = Defs::create();
@@ -913,7 +937,7 @@ BOOST_AUTO_TEST_CASE(test_replace_add_suite_with_bad_triggers) {
 }
 
 BOOST_AUTO_TEST_CASE(test_replace_task_ECFLOW_1135) {
-    cout << "ANode:: ...test_replace_task_ECFLOW_1135\n";
+    ECF_NAME_THIS_TEST();
 
     // The whole suite should get *MOVED* from clientDef to the *EMPTY* server def. i.e add
     defs_ptr clientDef = Defs::create();
@@ -950,7 +974,7 @@ BOOST_AUTO_TEST_CASE(test_replace_task_ECFLOW_1135) {
 }
 
 BOOST_AUTO_TEST_CASE(test_trigger_references_during_replace) {
-    cout << "ANode:: ...test_trigger_references_during_replace\n"; // ECFLOW-1319
+    ECF_NAME_THIS_TEST(); // ECFLOW-1319
 
     // This is used to check that the trigger references in AST, are invalidated after replace.
 

--- a/libs/node/test/TestSetState.cpp
+++ b/libs/node/test/TestSetState.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
 #include "ecflow/node/Jobs.hpp"
@@ -41,7 +42,8 @@ static void test_state(node_ptr n, NState::State expected) {
 }
 
 BOOST_AUTO_TEST_CASE(test_set_state) {
-    cout << "ANode:: ...test_set_state\n";
+    ECF_NAME_THIS_TEST();
+
     std::vector<NState::State> stateVec = NState::states();
 
     // 	cout << "Defs setState\n";
@@ -95,7 +97,7 @@ BOOST_AUTO_TEST_CASE(test_set_state) {
 
 BOOST_AUTO_TEST_CASE(test_set_aborted) {
     // see ECFLOW-344
-    cout << "ANode:: ...test_set_aborted\n";
+    ECF_NAME_THIS_TEST();
 
     Defs defs;
     suite_ptr suite = defs.add_suite("s1");

--- a/libs/node/test/TestSingleExprParse.cpp
+++ b/libs/node/test/TestSingleExprParse.cpp
@@ -18,9 +18,11 @@
 #include <boost/date_time/posix_time/time_formatters.hpp> // requires boost date and time lib, for to_simple_string
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/node/ExprAst.hpp"
 #include "ecflow/node/ExprDuplicate.hpp"
 #include "ecflow/node/ExprParser.hpp"
+
 using namespace std;
 using namespace boost::gregorian;
 using namespace boost::posix_time;
@@ -33,7 +35,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_SingleExprParse)
 
 BOOST_AUTO_TEST_CASE(test_single_expression) {
-    std::cout << "ANode:: ...test_single_expression\n";
+    ECF_NAME_THIS_TEST();
 
     // Duplicate AST are held in a static map. Delete them, to avoid ASAN complaining
     ExprDuplicate reclaim_cloned_ast_memory;
@@ -91,7 +93,7 @@ BOOST_AUTO_TEST_CASE(test_single_expression) {
 
 // BOOST_AUTO_TEST_CASE( test_expression_read_from_file )
 //{
-//    std::cout <<  "ANode:: ...test_expression_read_from_file\n";
+//    ECF_NAME_THIS_TEST();
 //
 //    std::string filename = "${ECF_TEST_DEFS_DIR}/triggers.list";
 //    std::ifstream the_file(filename.c_str(),std::ios_base::in);

--- a/libs/node/test/TestSpecificIssues.cpp
+++ b/libs/node/test/TestSpecificIssues.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/CalendarUpdateParams.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
@@ -28,7 +29,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_SpecificIssues)
 
 BOOST_AUTO_TEST_CASE(test_ECFLOW_195) {
-    cout << "ANode:: ...test_ECFLOW_195 re-queue on task should retain label value\n";
+    ECF_NAME_THIS_TEST();
 
     defs_ptr defs = Defs::create();
     suite_ptr s1  = defs->add_suite("s1");
@@ -109,7 +110,7 @@ BOOST_AUTO_TEST_CASE(test_ECFLOW_195) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ECFLOW_247) {
-    cout << "ANode:: ...test_ECFLOW_247  \n";
+    ECF_NAME_THIS_TEST();
 
     defs_ptr defs = Defs::create();
     suite_ptr s1  = defs->add_suite("s1");
@@ -184,8 +185,9 @@ BOOST_AUTO_TEST_CASE(test_ECFLOW_247) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ECFLOW_417_real_clock) {
+    ECF_NAME_THIS_TEST();
+
     // Make sure reque resets calendar according to the clock attribute *FOR* a real clock
-    cout << "ANode:: ...test_ECFLOW_417_real_clock  \n";
 
     defs_ptr defs = Defs::create();
     suite_ptr s1  = defs->add_suite("s1");
@@ -229,9 +231,10 @@ BOOST_AUTO_TEST_CASE(test_ECFLOW_417_real_clock) {
 }
 
 BOOST_AUTO_TEST_CASE(test_ECFLOW_417_hybrid_clock) {
+    ECF_NAME_THIS_TEST();
+
     // ECFLOW-417
     // For a suite with a hybrid clock *AND* repeat day. requue should update calendar date, by the repeat day interval
-    cout << "ANode:: ...test_ECFLOW_417_hybrid_clock  \n";
 
     defs_ptr defs = Defs::create();
     suite_ptr s1  = defs->add_suite("s1");

--- a/libs/node/test/TestSystem.cpp
+++ b/libs/node/test/TestSystem.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Filesystem.hpp"
 #include "ecflow/node/Signal.hpp"
 #include "ecflow/node/System.hpp"
@@ -24,7 +25,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_System)
 
 BOOST_AUTO_TEST_CASE(test_system) {
-    cout << "ANode:: ...test_system \n";
+    ECF_NAME_THIS_TEST();
 
     std::string file = "test_system.log";
     std::string cmd  = "echo sat siri akal dunyia > " + file;

--- a/libs/node/test/TestTaskScriptGenerator.cpp
+++ b/libs/node/test/TestTaskScriptGenerator.cpp
@@ -14,6 +14,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "MyDefsFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/core/Ecf.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/Str.hpp"
@@ -32,7 +33,8 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_TaskScriptGenerator)
 
 BOOST_AUTO_TEST_CASE(test_reset_after_job_generation_checking) {
-    cout << "ANode:: ...test_reset_after_job_generation_checking\n";
+    ECF_NAME_THIS_TEST();
+
     {
         Defs defs   = Defs();
         suite_ptr s = defs.add_suite("s");
@@ -68,7 +70,7 @@ BOOST_AUTO_TEST_CASE(test_reset_after_job_generation_checking) {
 }
 
 BOOST_AUTO_TEST_CASE(test_task_script_generator) {
-    cout << "ANode:: ...test_task_script_generator\n";
+    ECF_NAME_THIS_TEST();
 
     // SET ECF_HOME
     std::string ecf_home = File::test_data("libs/node/test/data/TaskScriptGenerator", "libs/node");
@@ -154,7 +156,7 @@ BOOST_AUTO_TEST_CASE(test_task_script_generator) {
 }
 
 BOOST_AUTO_TEST_CASE(test_task_script_generator_with_dummy_tasks) {
-    cout << "ANode:: ...test_task_script_generator_with_dummy_tasks\n";
+    ECF_NAME_THIS_TEST();
 
     // SET ECF_HOME
     std::string ecf_home = File::test_data("libs/node/test/data/TaskScriptGenerator", "libs/node");

--- a/libs/node/test/TestTimeDependencies.cpp
+++ b/libs/node/test/TestTimeDependencies.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/CalendarUpdateParams.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
@@ -30,10 +31,11 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_TimeDependencies)
 
 // See ECFLOW-337
-// See ECFLOW-833. Also See Note: ACore/doc/TimeDependencies.ddoc
+// See ECFLOW-833. Also See Note: libs/core/doc/TimeDependencies.ddoc
 
 BOOST_AUTO_TEST_CASE(test_day_time_combination) {
-    cout << "ANode:: ...test_day_time_combination\n";
+    ECF_NAME_THIS_TEST();
+
     // Create the suite, starting on a sunday
     // suite s1
     //  clock real 7.6.2015  # sunday
@@ -82,7 +84,8 @@ BOOST_AUTO_TEST_CASE(test_day_time_combination) {
 }
 
 BOOST_AUTO_TEST_CASE(test_date_time_combination) {
-    cout << "ANode:: ...test_date_time_combination\n";
+    ECF_NAME_THIS_TEST();
+
     // Create the suite, starting on a sunday
     // suite s1
     //  clock real 7.6.2015  # sunday
@@ -130,7 +133,8 @@ BOOST_AUTO_TEST_CASE(test_date_time_combination) {
 }
 
 BOOST_AUTO_TEST_CASE(test_day_time_combination_in_hierarchy) {
-    cout << "ANode:: ...test_day_time_combination_in_hierarchy\n";
+    ECF_NAME_THIS_TEST();
+
     // Create the suite, starting on a sunday
     // suite s1
     //  clock real 7.6.2015 # sunday
@@ -188,7 +192,8 @@ BOOST_AUTO_TEST_CASE(test_day_time_combination_in_hierarchy) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_day_combination_in_hierarchy) {
-    cout << "ANode:: ...test_time_day_combination_in_hierarchy\n";
+    ECF_NAME_THIS_TEST();
+
     // Create the suite, starting on a sunday
     // suite s1
     //  clock real 7.6.2015 # sunday
@@ -245,7 +250,7 @@ BOOST_AUTO_TEST_CASE(test_time_day_combination_in_hierarchy) {
 }
 
 BOOST_AUTO_TEST_CASE(test_date_time_combination_in_hierarchy) {
-    cout << "ANode:: ...test_date_time_combination_in_hierarchy\n";
+    ECF_NAME_THIS_TEST();
 
     // Create the suite, starting on a sunday
     // suite s1
@@ -305,7 +310,8 @@ BOOST_AUTO_TEST_CASE(test_date_time_combination_in_hierarchy) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_date_combination_in_hierarchy) {
-    cout << "ANode:: ...test_time_date_combination_in_hierarchy \n";
+    ECF_NAME_THIS_TEST();
+
     // Create the suite, starting on a sunday
     // suite s1
     //  clock real 7.6.2015 # sunday
@@ -372,7 +378,8 @@ BOOST_AUTO_TEST_CASE(test_time_date_combination_in_hierarchy) {
 }
 
 BOOST_AUTO_TEST_CASE(test_impossible_day_combination) {
-    cout << "ANode:: ...test_impossible_day_combination\n";
+    ECF_NAME_THIS_TEST();
+
     // Create the suite, starting on a sunday
     // suite s1
     //  clock real 4.8.2019 # sunday
@@ -424,7 +431,7 @@ BOOST_AUTO_TEST_CASE(test_impossible_day_combination) {
 }
 
 BOOST_AUTO_TEST_CASE(test_impossible_date_combination) {
-    cout << "ANode:: ...test_impossible_date_combination\n";
+    ECF_NAME_THIS_TEST();
 
     // Create the suite, starting on a sunday
     // suite s1

--- a/libs/node/test/TestVariableGeneration.cpp
+++ b/libs/node/test/TestVariableGeneration.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Cal.hpp"
 #include "ecflow/core/Converter.hpp"
 #include "ecflow/core/Str.hpp"
@@ -39,7 +40,7 @@ static void findParentVariableValue(task_ptr t, const std::string& name, const s
 }
 
 BOOST_AUTO_TEST_CASE(test_generated_variables) {
-    std::cout << "ANode:: ...test_generated_variables\n";
+    ECF_NAME_THIS_TEST();
 
     task_ptr t;
 

--- a/libs/node/test/TestVariableInheritance.cpp
+++ b/libs/node/test/TestVariableInheritance.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
 #include "ecflow/node/Suite.hpp"
@@ -33,7 +34,7 @@ static void findParentVariableValue(task_ptr t, const std::string& name, const s
 }
 
 BOOST_AUTO_TEST_CASE(test_variable_inheritance) {
-    std::cout << "ANode:: ...test_variable_inheritance\n";
+    ECF_NAME_THIS_TEST();
 
     // See page 31, section 5.1 variable inheritance, of SMS users guide
     task_ptr t;

--- a/libs/node/test/TestVariableSubstitution.cpp
+++ b/libs/node/test/TestVariableSubstitution.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Ecf.hpp"
 #include "ecflow/core/Str.hpp"
 #include "ecflow/core/Version.hpp"
@@ -29,7 +30,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_VariableSubstitution)
 
 BOOST_AUTO_TEST_CASE(test_variable_substitution) {
-    std::cout << "ANode:: ...test_variable_substitution\n";
+    ECF_NAME_THIS_TEST();
 
     Defs defs;
     suite_ptr s = defs.add_suite("suite");
@@ -162,7 +163,7 @@ BOOST_AUTO_TEST_CASE(test_variable_substitution) {
 }
 
 BOOST_AUTO_TEST_CASE(test_variable_substitution_double_micro) {
-    std::cout << "ANode:: ...test_variable_substitution_double_micro\n";
+    ECF_NAME_THIS_TEST();
 
     Defs defs;
     suite_ptr s = defs.add_suite("suite");
@@ -205,7 +206,7 @@ BOOST_AUTO_TEST_CASE(test_variable_substitution_double_micro) {
 }
 
 BOOST_AUTO_TEST_CASE(test_user_variable_substitution) {
-    std::cout << "ANode:: ...test_user_variable_substitution\n";
+    ECF_NAME_THIS_TEST();
 
     Defs defs;
     suite_ptr s = defs.add_suite("suite");
@@ -346,7 +347,7 @@ BOOST_AUTO_TEST_CASE(test_user_variable_substitution) {
 }
 
 BOOST_AUTO_TEST_CASE(test_user_variable_substitution_1) {
-    std::cout << "ANode:: ...test_user_variable_substitution_1\n";
+    ECF_NAME_THIS_TEST();
 
     Defs defs;
     suite_ptr s = defs.add_suite("suite");
@@ -408,7 +409,7 @@ static std::vector<std::string> required_server_variables() {
 }
 
 BOOST_AUTO_TEST_CASE(test_server_variable_substitution) {
-    std::cout << "ANode:: ...test_server_variable_substitution\n";
+    ECF_NAME_THIS_TEST();
 
     Defs defs;
     suite_ptr s = defs.add_suite("suite");
@@ -442,9 +443,10 @@ BOOST_AUTO_TEST_CASE(test_server_variable_substitution) {
 }
 
 BOOST_AUTO_TEST_CASE(test_generated_variable_substitution) {
+    ECF_NAME_THIS_TEST();
+
     // test that if ECF_OUT is defined using %, then we perform variable substitution
     // test that if ECF_JOBOUT or ECF_JOB are specified, they take priority over the generated variables
-    std::cout << "ANode:: ...test_generated_variable_substitution\n";
 
     Defs defs;
     suite_ptr s = defs.add_suite("suite");

--- a/libs/node/test/TestVariableSubstitutionDefs.cpp
+++ b/libs/node/test/TestVariableSubstitutionDefs.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/Ecf.hpp"
 #include "ecflow/core/Version.hpp"
 #include "ecflow/node/Defs.hpp"
@@ -25,7 +26,7 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_VariableSubstitutionDefs)
 
 BOOST_AUTO_TEST_CASE(test_defs_variable_substitution) {
-    std::cout << "ANode:: ...test_defs_variable_substitution\n";
+    ECF_NAME_THIS_TEST();
 
     Defs defs;
     {
@@ -148,7 +149,7 @@ BOOST_AUTO_TEST_CASE(test_defs_variable_substitution) {
 }
 
 BOOST_AUTO_TEST_CASE(test_defs_variable_substitution_double_micro) {
-    std::cout << "ANode:: ...test_defs_variable_substitution_double_micro\n";
+    ECF_NAME_THIS_TEST();
 
     Defs defs;
 

--- a/libs/node/test/TestZombies.cpp
+++ b/libs/node/test/TestZombies.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/attribute/ZombieAttr.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
@@ -27,7 +28,8 @@ BOOST_AUTO_TEST_SUITE(U_Node)
 BOOST_AUTO_TEST_SUITE(T_Zombies)
 
 BOOST_AUTO_TEST_CASE(test_zombies) {
-    cout << "ANode:: ...test_zombies\n";
+    ECF_NAME_THIS_TEST();
+
     Defs theDefs;
     suite_ptr s = theDefs.add_suite("s");
     task_ptr t  = s->add_family("f")->add_task("t");

--- a/libs/node/test/data/SMSHOME2/good/ecf_micro_2.ecf
+++ b/libs/node/test/data/SMSHOME2/good/ecf_micro_2.ecf
@@ -1,6 +1,6 @@
 
 %ecfmicro ^
-exe_time=`date +%s -r ACore/bin/^COMPILER_TEST_PATH:gcc^/u_acore`
+exe_time=`date +%s -r libs/core/bin/^COMPILER_TEST_PATH:gcc^/u_acore`
 ^ecfmicro %
 
 %manual

--- a/libs/node/test/parser/TestAutoAddExterns.cpp
+++ b/libs/node/test/parser/TestAutoAddExterns.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/node/Defs.hpp"
 
@@ -26,9 +27,8 @@ BOOST_AUTO_TEST_SUITE(T_AutoAddExterns)
 // Test that automatic add of externs
 BOOST_AUTO_TEST_CASE(test_auto_add_externs) {
     std::string path = File::test_data("libs/node/test/parser/data/single_defs/test_auto_add_extern.def", "parser");
-
     size_t mega_file_size = fs::file_size(path);
-    cout << "AParser:: ...test_auto_add_externs " << path << " file_size(" << mega_file_size << ")\n";
+    ECF_NAME_THIS_TEST(<< ", using file: " << path << " of size(" << mega_file_size << " MB)");
 
     Defs defs;
     std::string errorMsg, warningMsg;

--- a/libs/node/test/parser/TestAvisoAttr.cpp
+++ b/libs/node/test/parser/TestAvisoAttr.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/node/AvisoAttr.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
@@ -24,7 +25,7 @@ BOOST_AUTO_TEST_SUITE(U_Parser)
 BOOST_AUTO_TEST_SUITE(T_AvisoAttr)
 
 BOOST_AUTO_TEST_CASE(can_parse_aviso_attribute_on_task_with_default_parameters) {
-    std::cout << "..." << boost::unit_test::framework::current_test_unit().full_name() << std::endl;
+    ECF_NAME_THIS_TEST();
 
     using namespace ecf;
 
@@ -65,7 +66,7 @@ BOOST_AUTO_TEST_CASE(can_parse_aviso_attribute_on_task_with_default_parameters) 
 }
 
 BOOST_AUTO_TEST_CASE(can_parse_aviso_attribute_on_task_with_all_parameters) {
-    std::cout << "..." << boost::unit_test::framework::current_test_unit().full_name() << std::endl;
+    ECF_NAME_THIS_TEST();
 
     using namespace ecf;
 

--- a/libs/node/test/parser/TestDefsStructurePersistAndReload.cpp
+++ b/libs/node/test/parser/TestDefsStructurePersistAndReload.cpp
@@ -15,6 +15,7 @@
 
 #include "MyDefsFixture.hpp"
 #include "PersistHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/core/PrintStyle.hpp"
 
 using namespace std;
@@ -31,7 +32,7 @@ BOOST_AUTO_TEST_SUITE(T_DefsStructurePersisteAndReload)
 // Specifically written to test the parser.
 // Note: Aliases are *NOT* written in the defs file BUT are when in MIGRATE
 BOOST_AUTO_TEST_CASE(test_defs_structure_persistence_and_reload) {
-    cout << "AParser:: ...test_defs_structure_persistence_and_reload\n";
+    ECF_NAME_THIS_TEST();
 
     MyDefsFixture theDefsFixture;
     PersistHelper helper;
@@ -49,7 +50,7 @@ BOOST_AUTO_TEST_CASE(test_defs_structure_persistence_and_reload) {
 }
 
 BOOST_AUTO_TEST_CASE(test_defs_checkpt_persistence_and_reload) {
-    cout << "AParser:: ...test_defs_checkpt_persistence_and_reload\n";
+    ECF_NAME_THIS_TEST();
 
     MyDefsFixture theDefsFixture;
     PersistHelper helper;
@@ -76,7 +77,7 @@ void test_find_task_using_path(NodeContainer* f, const Defs& defs) {
 }
 
 BOOST_AUTO_TEST_CASE(test_find_task_using_paths) {
-    cout << "AParser:: ...test_find_task_using_paths\n";
+    ECF_NAME_THIS_TEST();
 
     MyDefsFixture theDefsFixture;
 

--- a/libs/node/test/parser/TestMementoPersistAndReload.cpp
+++ b/libs/node/test/parser/TestMementoPersistAndReload.cpp
@@ -14,6 +14,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "PersistHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Memento.hpp"
 
@@ -42,9 +43,10 @@ BOOST_AUTO_TEST_SUITE(U_Parser)
 BOOST_AUTO_TEST_SUITE(T_MementoPersistAndReload)
 
 BOOST_AUTO_TEST_CASE(test_memento_persist_and_reload) {
+    ECF_NAME_THIS_TEST();
+
     std::vector<ecf::Aspect::Type> aspects;
     bool aspect_only = false;
-    cout << "AParser:: ...test_memento_persist_and_reload\n";
     {
         Defs defs;
         suite_ptr suite = defs.add_suite("s1");

--- a/libs/node/test/parser/TestMigration.cpp
+++ b/libs/node/test/parser/TestMigration.cpp
@@ -15,6 +15,7 @@
 
 #include "MyDefsFixture.hpp"
 #include "PersistHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/core/Converter.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
@@ -48,7 +49,8 @@ BOOST_AUTO_TEST_SUITE(U_Parser)
 BOOST_AUTO_TEST_SUITE(T_Migration)
 
 BOOST_AUTO_TEST_CASE(test_state_parser) {
-    cout << "AParser:: ...test_state_parser\n";
+    ECF_NAME_THIS_TEST();
+
     // **** The persistence will NOT write the defaults, hence we need to change the states
     // **** to test the persistence
     PersistHelper helper;
@@ -139,7 +141,8 @@ BOOST_AUTO_TEST_CASE(test_state_parser) {
 }
 
 BOOST_AUTO_TEST_CASE(test_state_node_attributes) {
-    cout << "AParser:: ...test_state_node_attributes\n";
+    ECF_NAME_THIS_TEST();
+
     PersistHelper helper;
     {
         Defs defs;
@@ -338,7 +341,8 @@ BOOST_AUTO_TEST_CASE(test_state_node_attributes) {
 }
 
 BOOST_AUTO_TEST_CASE(test_state_time_attributes) {
-    cout << "AParser:: ...test_state_time_attributes\n";
+    ECF_NAME_THIS_TEST();
+
     PersistHelper helper;
     {
         Defs defs;
@@ -463,7 +467,8 @@ BOOST_AUTO_TEST_CASE(test_state_time_attributes) {
 }
 
 BOOST_AUTO_TEST_CASE(test_state_edit_history) {
-    cout << "AParser:: ...test_state_edit_history\n";
+    ECF_NAME_THIS_TEST();
+
     PersistHelper helper(true /* compare edit History */);
     Defs defs;
     suite_ptr suite = defs.add_suite("s1");
@@ -491,7 +496,8 @@ static std::string dump_edit_history(const std::unordered_map<std::string, std::
 }
 
 BOOST_AUTO_TEST_CASE(test_state_edit_history_pruning) {
-    cout << "AParser:: ...test_state_edit_history_pruning\n";
+    ECF_NAME_THIS_TEST();
+
     Defs defs;
     suite_ptr suite = defs.add_suite("s1");
     defs.add_edit_history(suite->absNodePath(), "MSG:[07:36:05 10.3.2016] --requeue force /s1  :maj");
@@ -527,7 +533,7 @@ BOOST_AUTO_TEST_CASE(test_state_edit_history_pruning) {
 }
 
 BOOST_AUTO_TEST_CASE(test_state_edit_history_pruning2) {
-    cout << "AParser:: ...test_state_edit_history_pruning2\n";
+    ECF_NAME_THIS_TEST();
 
     // Create edit history for today, this should not be affected by pruning
     date todays_date_in_utc = day_clock::universal_day();
@@ -570,7 +576,8 @@ BOOST_AUTO_TEST_CASE(test_state_edit_history_pruning2) {
 }
 
 BOOST_AUTO_TEST_CASE(test_server_state) {
-    cout << "AParser:: ...test_server_state\n";
+    ECF_NAME_THIS_TEST();
+
     PersistHelper helper(true /* compare edit History */);
     {
         Defs defs;
@@ -607,7 +614,8 @@ BOOST_AUTO_TEST_CASE(test_server_state) {
 }
 
 BOOST_AUTO_TEST_CASE(test_state_fixture_defs) {
-    cout << "AParser:: ...test_state_fixture_defs\n";
+    ECF_NAME_THIS_TEST();
+
     PersistHelper helper;
     MyDefsFixture theDefsFixture;
     BOOST_REQUIRE_MESSAGE(helper.test_state_persist_and_reload_with_checkpt(theDefsFixture.defsfile_),

--- a/libs/node/test/parser/TestMirrorAttr.cpp
+++ b/libs/node/test/parser/TestMirrorAttr.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
 #include "ecflow/node/MirrorAttr.hpp"
@@ -24,7 +25,7 @@ BOOST_AUTO_TEST_SUITE(U_Parser)
 BOOST_AUTO_TEST_SUITE(T_MirrorAttr)
 
 BOOST_AUTO_TEST_CASE(can_parse_mirror_attribute_on_task_with_default_parameters) {
-    std::cout << "..." << boost::unit_test::framework::current_test_unit().full_name() << std::endl;
+    ECF_NAME_THIS_TEST();
 
     using namespace ecf;
 
@@ -65,7 +66,7 @@ BOOST_AUTO_TEST_CASE(can_parse_mirror_attribute_on_task_with_default_parameters)
 }
 
 BOOST_AUTO_TEST_CASE(can_parse_mirror_attribute_on_task_with_all_attributes) {
-    std::cout << "..." << boost::unit_test::framework::current_test_unit().full_name() << std::endl;
+    ECF_NAME_THIS_TEST();
 
     using namespace ecf;
 

--- a/libs/node/test/parser/TestParser.cpp
+++ b/libs/node/test/parser/TestParser.cpp
@@ -14,6 +14,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "PersistHelper.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/core/Ecf.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/node/Defs.hpp"
@@ -143,7 +144,7 @@ void test_defs(const std::string& directory, bool pass) {
 }
 
 BOOST_AUTO_TEST_CASE(test_parsing_for_good_defs) {
-    cout << "AParser:: ...test_parsing_for_good_defs\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/node/test/parser/data/good_defs", "parser");
 
@@ -152,7 +153,7 @@ BOOST_AUTO_TEST_CASE(test_parsing_for_good_defs) {
 }
 
 BOOST_AUTO_TEST_CASE(test_parsing_for_bad_defs) {
-    cout << "AParser:: ...test_parsing_for_bad_defs\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/node/test/parser/data/bad_defs", "parser");
 
@@ -161,7 +162,7 @@ BOOST_AUTO_TEST_CASE(test_parsing_for_bad_defs) {
 }
 
 BOOST_AUTO_TEST_CASE(test_parsing_for_good_defs_state) {
-    cout << "AParser:: ...test_parsing_for_good_defs_state\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/node/test/parser/data/good_defs_state", "parser");
 
@@ -220,7 +221,7 @@ void test_node_defs(const std::string& directory, bool pass) {
 }
 
 BOOST_AUTO_TEST_CASE(test_parsing_node) {
-    cout << "AParser:: ...test_parsing_node\n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/node/test/parser/data/good_node_defs", "parser");
 

--- a/libs/node/test/parser/TestSingleDefsFile.cpp
+++ b/libs/node/test/parser/TestSingleDefsFile.cpp
@@ -18,6 +18,7 @@
 
 #include "PersistHelper.hpp"
 #include "TemporaryFile.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/Log.hpp"
 #include "ecflow/core/PrintStyle.hpp"
@@ -72,10 +73,9 @@ double get_seconds(const boost::timer::nanosecond_type& elapsed) {
 
 BOOST_AUTO_TEST_CASE(test_single_defs) {
     boost::timer::auto_cpu_timer auto_cpu_timer;
-
     std::string path      = File::test_data("libs/node/test/parser/data/single_defs/mega.def", "parser");
     size_t mega_file_size = fs::file_size(path);
-    cout << "AParser:: ...test_single_defs " << path << " file_size(" << mega_file_size << ")\n";
+    ECF_NAME_THIS_TEST(<< ", using file: " << path << " of size(" << mega_file_size << "MB)");
 
     // Time parse/resolve dependencies: This will need to be #defined depending on the platform
     // Change for file_iterator to plain string halved the time taken to load operation suite

--- a/libs/node/test/parser/TestVariableParsing.cpp
+++ b/libs/node/test/parser/TestVariableParsing.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/File.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Suite.hpp"
@@ -25,8 +26,7 @@ BOOST_AUTO_TEST_SUITE(U_Parser)
 BOOST_AUTO_TEST_SUITE(T_VariableParsing)
 
 BOOST_AUTO_TEST_CASE(test_single_defs) {
-
-    cout << "AParser:: ...test_variable  \n";
+    ECF_NAME_THIS_TEST();
 
     std::string path = File::test_data("libs/node/test/parser/data/good_defs/edit/edit.def", "parser");
 

--- a/libs/pyext/migrate/py_u_TestMigrate.py
+++ b/libs/pyext/migrate/py_u_TestMigrate.py
@@ -29,7 +29,7 @@ def get_root_source_dir():
             if os.path.exists(file):
                 # determine path by looking into this file:
                 for line in open(file):
-                    ## Source directory: /tmp/ma0/workspace/ecflow/ACore
+                    ## Source directory: /tmp/ma0/workspace/ecflow/libs/core
                     if line.find("Source directory"):
                         tokens = line.split()
                         if len(tokens) == 4:

--- a/libs/pyext/samples/TestBench.py
+++ b/libs/pyext/samples/TestBench.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
             This programs assumes that ecflow module is accessible
 
             example:
-                python libs/pyext/samples/TestBench.py --port=3141 --verbose=True ANode/parser/test/data/good_defs/trigger/late.def
+                python libs/pyext/samples/TestBench.py --port=3141 --verbose=True libs/node/parser/test/data/good_defs/trigger/late.def
             """    
             
     print("####################################################################")

--- a/libs/pyext/samples/TestJobGenPerf.py
+++ b/libs/pyext/samples/TestJobGenPerf.py
@@ -18,7 +18,7 @@
 #   ECF_ variables, we need to remove them and inject our own.
 #
 #   This test was created aid the performance testing of job generation
-#   It is tied to ANode/parser/test/TestJobGenPerf.cpp
+#   It is tied to libs/node/parser/test/TestJobGenPerf.cpp
 # =============================================================================
 import ecflow
 import os       # for getenv

--- a/libs/rest/CMakeLists.txt
+++ b/libs/rest/CMakeLists.txt
@@ -134,6 +134,7 @@ if (ENABLE_HTTP AND ENABLE_SERVER)
         ecflow_all
         Boost::boost # Boost header-only libraries must be available (namely unit_test_framework)
         $<$<BOOL:${OPENSSL_FOUND}>:OpenSSL::SSL>
+        test_support
       DEPENDS
         ecflow_server # the server is launched to support tests
         ecflow_http

--- a/libs/rest/src/ecflow/http/HttpServer.cpp
+++ b/libs/rest/src/ecflow/http/HttpServer.cpp
@@ -199,7 +199,7 @@ void apply_listeners(httplib::Server& http_server) {
 
     http_server.set_logger([&format](const httplib::Request& req, const httplib::Response& res) {
         const std::string str = format(req, res);
-        // using std::cout crashes with many threads calling
+        // using iostream-based output crashes with many threads calling
         if (opts.verbose) {
             printf("%s\n", str.c_str());
         }

--- a/libs/rest/test/Certificate.hpp
+++ b/libs/rest/test/Certificate.hpp
@@ -23,6 +23,8 @@
 #include <openssl/rsa.h>
 #include <openssl/x509.h>
 
+#include "TestNaming.hpp"
+
 class Certificate {
 public:
     Certificate() = delete;
@@ -37,13 +39,10 @@ private:
 };
 
 inline Certificate::Certificate(const std::string& path) : path_(path) {
-    // std::cout << "Generating RSA key..." << std::endl;
-
+    // Generating RSA key...
     EVP_PKEY* pkey = generate_key();
 
-    /* Generate the certificate. */
-    // std::cout << "Generating x509 certificate..." << std::endl;
-
+    // Generating x509 certificate...
     X509* x509 = generate_x509(pkey);
     if (!x509) {
         EVP_PKEY_free(pkey);
@@ -51,25 +50,23 @@ inline Certificate::Certificate(const std::string& path) : path_(path) {
         ;
     }
 
-    /* Write the private key and certificate out to disk. */
-    // std::cout << "Writing key and certificate to disk..." << std::endl;
-
+    // Writing key and certificate to disk...
     write_to_disk(pkey, x509);
 }
 
 inline Certificate::~Certificate() {
     if (remove((path_ + "/server.crt").c_str()) != 0) {
-        std::cerr << "Failed to remove file server.crt" << std::endl;
+        ECF_TEST_ERR(<< "Failed to remove file server.crt");
     }
     else {
-        std::cout << "Removed file " << (path_ + "/server.crt") << std::endl;
+        ECF_TEST_ERR(<< "Removed file " << (path_ + "/server.crt"));
     }
 
     if (remove((path_ + "/server.key").c_str()) != 0) {
-        std::cerr << "Failed to remove file server.key" << std::endl;
+        ECF_TEST_ERR(<< "Failed to remove file server.key");
     }
     else {
-        std::cout << "Removed file " << (path_ + "/server.key") << std::endl;
+        ECF_TEST_ERR(<< "Removed file " << (path_ + "/server.key"));
     }
 }
 

--- a/libs/rest/test/TestApiV1.cpp
+++ b/libs/rest/test/TestApiV1.cpp
@@ -18,6 +18,7 @@
 
 #include "Certificate.hpp"
 #include "InvokeServer.hpp"
+#include "TestNaming.hpp"
 #include "TokenFile.hpp"
 #include "ecflow/http/HttpServer.hpp"
 #include "ecflow/http/HttpServerException.hpp"
@@ -268,7 +269,7 @@ bool check_for_element(const std::string& path,
 }
 
 BOOST_AUTO_TEST_CASE(test_server) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     wait_until([] { return check_for_element("/v1/server/status?filter=status", "", "", "RUNNING"); });
 
@@ -290,7 +291,7 @@ BOOST_AUTO_TEST_CASE(test_server) {
 }
 
 BOOST_AUTO_TEST_CASE(test_suite) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     // remove test-suite if it exists; disregard any problems with the call
     request("delete", "/v1/suites/test/definition", "", API_KEY);
@@ -355,7 +356,7 @@ BOOST_AUTO_TEST_CASE(test_suite) {
 }
 
 BOOST_AUTO_TEST_CASE(test_node_basic_tree) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     // (0) Clean up -- in case there is any left-over from passed/failed tests
     request("delete", "/v1/suites/basic_suite/definition", "", API_KEY);
@@ -403,7 +404,7 @@ BOOST_AUTO_TEST_CASE(test_node_basic_tree) {
 }
 
 BOOST_AUTO_TEST_CASE(test_node_full_tree) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     // (0) Clean up -- in case there is any left-over from passed/failed tests
     request("delete", "/v1/suites/full_suite/definition", "", API_KEY);
@@ -476,7 +477,7 @@ BOOST_AUTO_TEST_CASE(test_node_full_tree) {
 }
 
 BOOST_AUTO_TEST_CASE(test_token_authentication) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     handle_response(
         request("post", "/v1/server/attributes", R"({"type":"variable","name":"xfoo","value":"xbar"})", API_KEY),
@@ -516,6 +517,8 @@ BOOST_AUTO_TEST_CASE(test_token_authentication) {
 }
 
 BOOST_AUTO_TEST_CASE(test_family_add, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_suite")) {
+    ECF_NAME_THIS_TEST();
+
     handle_response(
         request("put", "/v1/suites/test/definition", R"({"definition": "family dynamic\nendfamily"})", API_KEY));
     wait_until([] { return check_for_path("/v1/suites/test/dynamic/definition"); });
@@ -524,7 +527,7 @@ BOOST_AUTO_TEST_CASE(test_family_add, *boost::unit_test::depends_on("S_Http/T_Ap
 // STATUS
 
 BOOST_AUTO_TEST_CASE(test_status, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_family_add")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     const std::map<std::string, std::string> statuses{
         {"abort", "aborted"}, {"complete", "complete"}, {"requeue", "queued"}, {"suspend", "suspended"}};
@@ -552,7 +555,7 @@ BOOST_AUTO_TEST_CASE(test_status, *boost::unit_test::depends_on("S_Http/T_ApiV1/
 // VARIABLE
 
 BOOST_AUTO_TEST_CASE(test_variable, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_family_add")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     handle_response(
         request(
@@ -577,7 +580,7 @@ BOOST_AUTO_TEST_CASE(test_variable, *boost::unit_test::depends_on("S_Http/T_ApiV
 // METER
 
 BOOST_AUTO_TEST_CASE(test_meter, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_family_add")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     handle_response(request("post",
                             "/v1/suites/test/dynamic/attributes",
@@ -603,7 +606,7 @@ BOOST_AUTO_TEST_CASE(test_meter, *boost::unit_test::depends_on("S_Http/T_ApiV1/t
 // LIMIT
 
 BOOST_AUTO_TEST_CASE(test_limit, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_family_add")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     handle_response(
         request("post", "/v1/suites/test/dynamic/attributes", R"({"type":"limit","name":"foo","value":"0"})", API_KEY),
@@ -627,7 +630,7 @@ BOOST_AUTO_TEST_CASE(test_limit, *boost::unit_test::depends_on("S_Http/T_ApiV1/t
 // EVENT
 
 BOOST_AUTO_TEST_CASE(test_event, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_family_add")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     handle_response(
         request(
@@ -652,7 +655,7 @@ BOOST_AUTO_TEST_CASE(test_event, *boost::unit_test::depends_on("S_Http/T_ApiV1/t
 // LABEL
 
 BOOST_AUTO_TEST_CASE(test_label, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_family_add")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     handle_response(
         request(
@@ -677,7 +680,7 @@ BOOST_AUTO_TEST_CASE(test_label, *boost::unit_test::depends_on("S_Http/T_ApiV1/t
 // TIME
 
 BOOST_AUTO_TEST_CASE(test_time, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_family_add")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     handle_response(
         request("post", "/v1/suites/test/dynamic/attributes", R"({"type":"time","value":"+00:20"})", API_KEY),
@@ -703,7 +706,7 @@ BOOST_AUTO_TEST_CASE(test_time, *boost::unit_test::depends_on("S_Http/T_ApiV1/te
 // DAY
 
 BOOST_AUTO_TEST_CASE(test_day, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_family_add")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     handle_response(
         request("post", "/v1/suites/test/dynamic/attributes", R"({"type":"day","value":"monday"})", API_KEY),
@@ -729,7 +732,7 @@ BOOST_AUTO_TEST_CASE(test_day, *boost::unit_test::depends_on("S_Http/T_ApiV1/tes
 // DATE
 
 BOOST_AUTO_TEST_CASE(test_date, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_family_add")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     handle_response(
         request("post", "/v1/suites/test/dynamic/attributes", R"({"type":"date","value":"1.*.*"})", API_KEY),
@@ -755,7 +758,7 @@ BOOST_AUTO_TEST_CASE(test_date, *boost::unit_test::depends_on("S_Http/T_ApiV1/te
 // TODAY
 
 BOOST_AUTO_TEST_CASE(test_today, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_family_add")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     handle_response(
         request("post", "/v1/suites/test/dynamic/attributes", R"({"type":"today","value":"03:00"})", API_KEY),
@@ -784,7 +787,7 @@ BOOST_AUTO_TEST_CASE(test_today, *boost::unit_test::depends_on("S_Http/T_ApiV1/t
 // CRON
 
 BOOST_AUTO_TEST_CASE(test_cron, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_family_add")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     handle_response(
         request("post", "/v1/suites/test/dynamic/attributes", R"({"type":"cron","value":"-w 0,1 10:00"})", API_KEY),
@@ -811,7 +814,7 @@ BOOST_AUTO_TEST_CASE(test_cron, *boost::unit_test::depends_on("S_Http/T_ApiV1/te
 // LATE
 
 BOOST_AUTO_TEST_CASE(test_late, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_family_add")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     handle_response(request("post",
                             "/v1/suites/test/dynamic/attributes",
@@ -841,7 +844,7 @@ BOOST_AUTO_TEST_CASE(test_late, *boost::unit_test::depends_on("S_Http/T_ApiV1/te
 // COMPLETE
 
 BOOST_AUTO_TEST_CASE(test_complete, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_family_add")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     handle_response(request("post",
                             "/v1/suites/test/dynamic/attributes",
@@ -873,7 +876,7 @@ BOOST_AUTO_TEST_CASE(test_complete, *boost::unit_test::depends_on("S_Http/T_ApiV
 // AUTOCANCEL
 
 BOOST_AUTO_TEST_CASE(test_autocancel, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_family_add")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     handle_response(
         request("post", "/v1/suites/test/dynamic/attributes", R"({"type":"autocancel","value":"+01:00"})", API_KEY),
@@ -897,7 +900,7 @@ BOOST_AUTO_TEST_CASE(test_autocancel, *boost::unit_test::depends_on("S_Http/T_Ap
 // AUTOARCHIVE
 
 BOOST_AUTO_TEST_CASE(test_autoarchive, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_family_add")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     handle_response(
         request("post", "/v1/suites/test/dynamic/attributes", R"({"type":"autoarchive","value":"+01:00"})", API_KEY),
@@ -921,7 +924,7 @@ BOOST_AUTO_TEST_CASE(test_autoarchive, *boost::unit_test::depends_on("S_Http/T_A
 // AUTORESTORE
 
 BOOST_AUTO_TEST_CASE(test_autorestore, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_family_add")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     handle_response(
         request("post", "/v1/suites/test/dynamic/attributes", R"({"type":"autorestore","value":"/test/a"})", API_KEY),
@@ -947,21 +950,23 @@ BOOST_AUTO_TEST_CASE(test_autorestore, *boost::unit_test::depends_on("S_Http/T_A
 // OUTPUT
 
 BOOST_AUTO_TEST_CASE(test_output, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_family_add")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
+
     handle_response(request("get", "/v1/suites/test/a/a/output"), HttpStatusCode::client_error_not_found);
 }
 
 // SCRIPT
 
 BOOST_AUTO_TEST_CASE(test_script, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_family_add")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
+
     handle_response(request("get", "/v1/suites/test/a/a/script"), HttpStatusCode::client_error_not_found);
 }
 
 // DELETE FAMILY
 
 BOOST_AUTO_TEST_CASE(test_suite_family_delete, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_autorestore")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     handle_response(request("delete", "/v1/suites/test/dynamic/definition", "", API_KEY),
                     HttpStatusCode::success_no_content);
@@ -973,7 +978,7 @@ BOOST_AUTO_TEST_CASE(test_suite_family_delete, *boost::unit_test::depends_on("S_
 }
 
 BOOST_AUTO_TEST_CASE(test_statistics, *boost::unit_test::depends_on("S_Http/T_ApiV1/test_server")) {
-    std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
+    ECF_NAME_THIS_TEST();
 
     auto response = handle_response(request("get", "/v1/statistics"));
     auto j        = ojson::parse(response.body);

--- a/libs/rest/test/TestApiV1.cpp
+++ b/libs/rest/test/TestApiV1.cpp
@@ -231,40 +231,33 @@ bool check_for_element(const std::string& path,
         }
         else if (j.is_array() == false) {
             j = ojson::array({j});
-            std::cout << "json is " << j << std::endl;
+            ECF_TEST_DBG(<< "json is " << j);
         }
 
         for (const auto& x : j) {
-            // std::cout << x << std::endl;
             if (attr_name.empty() == false) {
                 // { "name": "foo", "value": "bar"}
-                // std::cout << "expecting: " << attr_name << "=" << value << " got: " << x["name"].get<std::string>()
-                // << "=" << json_type_to_string(x[key_name]) << std::endl;
-                if (attr_name == x["name"] && value == ecf::http::json_type_to_string(x[key_name]))
+                if (attr_name == x["name"] && value == ecf::http::json_type_to_string(x[key_name])) {
                     return true;
+                }
             }
             else if (key_name.empty() == false) {
                 // { "foo" : "bar" }
-                // std::cout << "expecting: " << key_name << "='" << value << " got: " << key_name << "='" <<
-                // json_type_to_string(x[key_name]) << "'" << std::endl;
-
-                if (ecf::http::json_type_to_string(x[key_name]) == value)
+                if (ecf::http::json_type_to_string(x[key_name]) == value) {
                     return true;
+                }
             }
             else {
                 // "bar"
-                // std::cout << "expecting: '" << value << "' got: '" << json_type_to_string(x) << "'" << std::endl;
-
-                if (value == ecf::http::json_type_to_string(x))
+                if (value == ecf::http::json_type_to_string(x)) {
                     return true;
+                }
             }
         }
     }
     catch (const std::exception& e) {
         BOOST_TEST_MESSAGE(e.what());
     }
-    // BOOST_TEST_MESSAGE("Attribute " << attr_name << " --> " << key_name << "=" << value << " at path " << path << "
-    // not found");
     return false;
 }
 

--- a/libs/rest/test/TokenFile.hpp
+++ b/libs/rest/test/TokenFile.hpp
@@ -14,6 +14,7 @@
 #include <ostream>
 #include <string>
 
+#include "TestNaming.hpp"
 #include "nlohmann/json.hpp"
 
 class TokenFile {
@@ -57,7 +58,7 @@ inline TokenFile::TokenFile(const std::string& tokenfile) : tokenfile_(tokenfile
 
 inline TokenFile::~TokenFile() {
     if (remove(tokenfile_.c_str()) != 0) {
-        std::cerr << "Failed to remove token file " << tokenfile_ << std::endl;
+        ECF_TEST_ERR(<< "Failed to remove token file " << tokenfile_);
     }
     else {
         BOOST_TEST_MESSAGE("Removed token file " << tokenfile_);

--- a/libs/server/CMakeLists.txt
+++ b/libs/server/CMakeLists.txt
@@ -47,7 +47,7 @@ SET_TARGET_PROPERTIES(ecflow_server
 # which point to directories outside the build tree to the install RPATH
 #SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
 
-                          
+
 # ================================================================================                         
 # TEST
 ecbuild_add_test(
@@ -67,6 +67,7 @@ ecbuild_add_test(
     Boost::boost # Boost header-only libraries must be available (namely unit_test_framework)
     $<$<BOOL:${OPENSSL_FOUND}>:OpenSSL::SSL>
     Threads::Threads
+    test_support
   TEST_DEPENDS
     u_base
 )
@@ -90,6 +91,7 @@ ecbuild_add_test(
     Boost::boost # Boost header-only libraries must be available (namely unit_test_framework)
     $<$<BOOL:${OPENSSL_FOUND}>:OpenSSL::SSL>
     Threads::Threads
+    test_support
   TEST_DEPENDS
     u_base
 )

--- a/libs/server/test/TestCheckPtSaver.cpp
+++ b/libs/server/test/TestCheckPtSaver.cpp
@@ -13,12 +13,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/server/CheckPtSaver.hpp"
-
-// TODO: Move the following trace_*_function to a common test module/library
-static void trace_test() {
-    std::cout << "..." << boost::unit_test::framework::current_test_case().full_name() << "\n";
-}
 
 /**
  * A self cleaning test file, useful to automate test data storage/cleanup, with automatic generation of file names.
@@ -72,7 +68,7 @@ BOOST_AUTO_TEST_SUITE(U_Server)
 BOOST_AUTO_TEST_SUITE(T_CheckPtSaver)
 
 BOOST_AUTO_TEST_CASE(test_checkpt_store_successful_case0) {
-    trace_test();
+    ECF_NAME_THIS_TEST();
 
     // Case 0: neither current and backup exist
 
@@ -86,7 +82,7 @@ BOOST_AUTO_TEST_CASE(test_checkpt_store_successful_case0) {
 }
 
 BOOST_AUTO_TEST_CASE(test_checkpt_store_successful_case1) {
-    trace_test();
+    ECF_NAME_THIS_TEST();
 
     // Case 1: current and backup both exist and are non-empty
 
@@ -100,7 +96,7 @@ BOOST_AUTO_TEST_CASE(test_checkpt_store_successful_case1) {
 }
 
 BOOST_AUTO_TEST_CASE(test_checkpt_store_successful_case2) {
-    trace_test();
+    ECF_NAME_THIS_TEST();
 
     // Case 2: current and backup both exist, and current is empty
 
@@ -114,7 +110,7 @@ BOOST_AUTO_TEST_CASE(test_checkpt_store_successful_case2) {
 }
 
 BOOST_AUTO_TEST_CASE(test_checkpt_store_successful_case3) {
-    trace_test();
+    ECF_NAME_THIS_TEST();
 
     // Case 3: current exists, but no backup is available
 

--- a/libs/server/test/TestPeriodicScheduler.cpp
+++ b/libs/server/test/TestPeriodicScheduler.cpp
@@ -15,6 +15,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/server/PeriodicScheduler.hpp"
 
 std::ostream& operator<<(std::ostream& os, const std::chrono::system_clock::time_point& tp) {
@@ -42,8 +43,8 @@ struct Collector
     using instants_t = std::vector<instant_t>;
 
     void operator()(instant_t now, instant_t last, instant_t next, bool is_boundary = true) {
-        std::cout << "Call at " << now << ", with is_boundary? " << (is_boundary ? "true" : "false") << ". Last call was at " << last
-                  << ". Next call at " << next << "." << std::endl;
+        std::cout << "Call at " << now << ", with is_boundary? " << (is_boundary ? "true" : "false")
+                  << ". Last call was at " << last << ". Next call at " << next << "." << std::endl;
 
         // Activity must be called at minute boundary!
         if (is_boundary && !instants.empty()) {
@@ -61,11 +62,12 @@ struct LongLasting
     using instant_t = ecf::PeriodicScheduler<LongLasting>::instant_t;
 
     template <typename DURATION>
-    explicit LongLasting(const DURATION& duration) : how_long_{std::chrono::duration_cast<std::chrono::milliseconds>(duration)} {}
+    explicit LongLasting(const DURATION& duration)
+        : how_long_{std::chrono::duration_cast<std::chrono::milliseconds>(duration)} {}
 
     void operator()(instant_t now, instant_t last, instant_t next, bool is_boundary = true) {
-        std::cout << "Call at " << now << ", with is_boundary? " << (is_boundary ? "true" : "false") << ". Last call was at " << last
-                  << ". Next call at " << next << "." << std::endl;
+        std::cout << "Call at " << now << ", with is_boundary? " << (is_boundary ? "true" : "false")
+                  << ". Last call was at " << last << ". Next call at " << next << "." << std::endl;
 
         std::this_thread::sleep_for(how_long_);
     }
@@ -74,6 +76,8 @@ struct LongLasting
 };
 
 BOOST_AUTO_TEST_CASE(test_periodic_scheduler_over_one_minute) {
+    ECF_NAME_THIS_TEST();
+
     // Setup time collector
     Collector collector;
     boost::asio::io_context io;
@@ -82,7 +86,8 @@ BOOST_AUTO_TEST_CASE(test_periodic_scheduler_over_one_minute) {
 
     // Arrange time collector termination
     ecf::Timer teardown(io);
-    teardown.set([&scheduler](const boost::system::error_code& error) { scheduler.terminate(); }, std::chrono::seconds(62));
+    teardown.set([&scheduler](const boost::system::error_code& error) { scheduler.terminate(); },
+                 std::chrono::seconds(62));
 
     // Run services
     io.run();
@@ -91,6 +96,8 @@ BOOST_AUTO_TEST_CASE(test_periodic_scheduler_over_one_minute) {
 }
 
 BOOST_AUTO_TEST_CASE(test_periodic_scheduler_with_long_lasting_activity) {
+    ECF_NAME_THIS_TEST();
+
     // Setup time collector
     LongLasting activity{std::chrono::milliseconds(2499)};
     boost::asio::io_context io;
@@ -99,7 +106,8 @@ BOOST_AUTO_TEST_CASE(test_periodic_scheduler_with_long_lasting_activity) {
 
     // Arrange time collector termination
     ecf::Timer teardown(io);
-    teardown.set([&scheduler](const boost::system::error_code& error) { scheduler.terminate(); }, std::chrono::seconds(60));
+    teardown.set([&scheduler](const boost::system::error_code& error) { scheduler.terminate(); },
+                 std::chrono::seconds(60));
 
     // Run services
     io.run();

--- a/libs/server/test/TestServer.cpp
+++ b/libs/server/test/TestServer.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/EcfPortLock.hpp"
 #include "ecflow/core/Host.hpp"
 #include "ecflow/core/Log.hpp"
@@ -149,7 +150,7 @@ void test_the_server(const std::string& port) {
 }
 
 BOOST_AUTO_TEST_CASE(test_server) {
-    cout << "Server:: ...test_server\n";
+    ECF_NAME_THIS_TEST();
 
     // Create a unique port number, allowing debug and release,gnu,clang,intel to run at the same time
     // Hence the lock file is not always sufficient.

--- a/libs/server/test/TestServerEnvironment.cpp
+++ b/libs/server/test/TestServerEnvironment.cpp
@@ -14,6 +14,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "ecflow/core/CheckPt.hpp"
 #include "ecflow/core/Converter.hpp"
 #include "ecflow/core/Ecf.hpp"
@@ -32,7 +33,7 @@ BOOST_AUTO_TEST_SUITE(U_Server)
 BOOST_AUTO_TEST_SUITE(T_ServerEnvironment)
 
 BOOST_AUTO_TEST_CASE(test_server_environment_ecfinterval) {
-    cout << "Server:: ...test_server_environment_ecfinterval\n";
+    ECF_NAME_THIS_TEST();
 
     // ecflow server interval is valid for range [1-60]
     std::string port = Str::DEFAULT_PORT_NUMBER();
@@ -61,7 +62,7 @@ BOOST_AUTO_TEST_CASE(test_server_environment_ecfinterval) {
 }
 
 BOOST_AUTO_TEST_CASE(test_server_environment_port) {
-    cout << "Server:: ...test_server_environment_port\n";
+    ECF_NAME_THIS_TEST();
 
     // The port numbers are divided into three ranges.\n";
     //  o the Well Known Ports, (require root permission)      0 -1023\n";
@@ -103,8 +104,9 @@ BOOST_AUTO_TEST_CASE(test_server_environment_port) {
 }
 
 BOOST_AUTO_TEST_CASE(test_server_environment_log_file) {
+    ECF_NAME_THIS_TEST();
+
     // Regression test log file creation
-    cout << "Server:: ...test_server_environment_log_file\n";
 
     int argc     = 2;
     char* argv[] = {const_cast<char*>("ServerEnvironment"), const_cast<char*>("--port=3144")};
@@ -138,8 +140,9 @@ BOOST_AUTO_TEST_CASE(test_server_environment_log_file) {
 }
 
 BOOST_AUTO_TEST_CASE(test_server_config_file) {
+    ECF_NAME_THIS_TEST();
+
     // Regression test to make sure the server environment variable don't get removed
-    cout << "Server:: ...test_server_config_file\n";
 
     int argc     = 1;
     char* argv[] = {const_cast<char*>("ServerEnvironment")};
@@ -280,8 +283,9 @@ BOOST_AUTO_TEST_CASE(test_server_config_file) {
 }
 
 BOOST_AUTO_TEST_CASE(test_server_environment_variables) {
+    ECF_NAME_THIS_TEST();
+
     // Regression test to make sure the server environment variable don't get removed
-    cout << "Server:: ...test_server_environment_variables\n";
 
     int argc     = 2;
     char* argv[] = {const_cast<char*>("ServerEnvironment"), const_cast<char*>("--port=3144")};
@@ -326,7 +330,8 @@ BOOST_AUTO_TEST_CASE(test_server_environment_variables) {
 }
 
 BOOST_AUTO_TEST_CASE(test_server_profile_threshold_environment_variable) {
-    cout << "Server:: ...test_server_profile_threshold_environment_variable\n";
+    ECF_NAME_THIS_TEST();
+
     int argc     = 1;
     char* argv[] = {const_cast<char*>("ServerEnvironment")};
     {

--- a/libs/test/CMakeLists.txt
+++ b/libs/test/CMakeLists.txt
@@ -81,6 +81,7 @@ if (ENABLE_ALL_TESTS)
     LIBS
       libharness
       $<$<BOOL:${OPENSSL_FOUND}>:OpenSSL::SSL>
+      test_support
     TEST_DEPENDS
       s_client
   )
@@ -98,6 +99,7 @@ if (ENABLE_ALL_TESTS)
     LIBS
       libharness
       $<$<BOOL:${OPENSSL_FOUND}>:OpenSSL::SSL>
+      test_support
     TEST_DEPENDS
       s_test
   )

--- a/libs/test/TestAbortCmd.cpp
+++ b/libs/test/TestAbortCmd.cpp
@@ -16,6 +16,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/DurationTimer.hpp"
 #include "ecflow/node/Defs.hpp"
@@ -35,8 +36,9 @@ BOOST_AUTO_TEST_SUITE(T_AbortCmd)
 // is defined. Then providing its value is less the the task's try number
 // we should do an immediate job submission.
 BOOST_AUTO_TEST_CASE(test_abort_cmd) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_abort_cmd " << flush;
     TestClean clean_at_start_and_end;
 
     // Create the defs file corresponding to the text below

--- a/libs/test/TestAlias.cpp
+++ b/libs/test/TestAlias.cpp
@@ -16,6 +16,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/base/cts/user/CFileCmd.hpp"
 #include "ecflow/core/AssertTimer.hpp"
@@ -63,8 +64,9 @@ void wait_for_alias_to_complete(const std::string& alias_path) {
 }
 
 BOOST_AUTO_TEST_CASE(test_alias) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_alias " << flush;
     TestClean clean_at_start_and_end;
 
     // Create the defs file corresponding to the text below

--- a/libs/test/TestClkSync.cpp
+++ b/libs/test/TestClkSync.cpp
@@ -17,6 +17,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/DurationTimer.hpp"
 #include "ecflow/core/PrintStyle.hpp"
@@ -35,6 +36,8 @@ BOOST_AUTO_TEST_SUITE(S_Test)
 BOOST_AUTO_TEST_SUITE(T_ClkSync)
 
 BOOST_AUTO_TEST_CASE(test_clk_sync) {
+    ECF_NAME_THIS_TEST();
+
     // This test is used to test sync'ing of the suite calendars
     // The default clock type is *real*. We will create a suite with a hybrid clock attribute
     // For the suite calendar, we do not persist the clock type(hybrid/real), since this can be
@@ -47,7 +50,6 @@ BOOST_AUTO_TEST_CASE(test_clk_sync) {
     // This is done in ServerTestHarness via invariant checking.
 
     DurationTimer timer;
-    cout << "Test:: ...test_clk_sync " << flush;
     TestClean clean_at_start_and_end;
 
     // Create the defs file corresponding to the text below
@@ -80,8 +82,9 @@ BOOST_AUTO_TEST_CASE(test_clk_sync) {
 }
 
 BOOST_AUTO_TEST_CASE(test_suite_calendar_sync) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_suite_calendar_sync " << flush;
     TestClean clean_at_start_and_end;
 
     // When using ECF_SSL sync is to slow.

--- a/libs/test/TestComplete.cpp
+++ b/libs/test/TestComplete.cpp
@@ -15,6 +15,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "ServerTestHarness.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/DurationTimer.hpp"
 #include "ecflow/node/Defs.hpp"
@@ -45,8 +46,9 @@ BOOST_AUTO_TEST_SUITE(T_Complete)
 //      hierarchically
 // **************************************************************************
 BOOST_AUTO_TEST_CASE(test_complete) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_complete " << flush;
     TestClean clean_at_start_and_end;
 
     // Create the defs file corresponding to the text below
@@ -100,8 +102,9 @@ BOOST_AUTO_TEST_CASE(test_complete) {
 }
 
 BOOST_AUTO_TEST_CASE(test_complete_does_not_hold) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_complete_does_not_hold " << flush;
 
     /// This test shows that a complete expression should not hold a node
     /// A complete should complete a node, and not hold it
@@ -135,8 +138,9 @@ BOOST_AUTO_TEST_CASE(test_complete_does_not_hold) {
 }
 
 BOOST_AUTO_TEST_CASE(test_complete_with_empty_family) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_complete_with_empty_family " << flush;
 
     // Test a family with a complete expression and that has no children
 

--- a/libs/test/TestCron.cpp
+++ b/libs/test/TestCron.cpp
@@ -17,6 +17,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/AssertTimer.hpp"
 #include "ecflow/core/DurationTimer.hpp"
@@ -69,8 +70,9 @@ static void wait_for_cron(int max_time_to_wait, const std::string& path) {
 }
 
 BOOST_AUTO_TEST_CASE(test_cron_time_series) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_cron_time_series " << flush;
     TestClean clean_at_start_and_end;
 
     // SLOW SYSTEMS

--- a/libs/test/TestCtsWaitCmd.cpp
+++ b/libs/test/TestCtsWaitCmd.cpp
@@ -16,6 +16,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/AssertTimer.hpp"
 #include "ecflow/core/DurationTimer.hpp"
@@ -100,8 +101,9 @@ static bool wait_for_state(std::vector<std::pair<std::string, NState::State>>& p
 // In this case the job associated with task 'wait' should block until the expression evaluates
 // to true, which should be after the completion of all other tasks
 BOOST_AUTO_TEST_CASE(test_wait_cmd) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_wait_cmd " << flush;
     TestClean clean_at_start_and_end;
 
     Defs theDefs;
@@ -130,8 +132,9 @@ BOOST_AUTO_TEST_CASE(test_wait_cmd) {
 }
 
 BOOST_AUTO_TEST_CASE(test_wait_cmd_parse_fail) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_wait_cmd_parse_fail " << flush;
 
     // This time we add a wait expression that
     // should fail to parse, and we should return an error
@@ -175,8 +178,9 @@ BOOST_AUTO_TEST_CASE(test_wait_cmd_parse_fail) {
 }
 
 BOOST_AUTO_TEST_CASE(test_wait_cmd_non_existant_paths) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_wait_cmd_non_existant_paths " << flush;
 
     // This time we add a wait expression that should fail
     // because the paths referenced in the expression don't exist

--- a/libs/test/TestDayDate.cpp
+++ b/libs/test/TestDayDate.cpp
@@ -16,6 +16,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "ServerTestHarness.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/DurationTimer.hpp"
 #include "ecflow/node/Defs.hpp"
@@ -33,9 +34,10 @@ BOOST_AUTO_TEST_SUITE(S_Test)
 BOOST_AUTO_TEST_SUITE(T_DayDate)
 
 BOOST_AUTO_TEST_CASE(test_day_at_midnight) {
+    ECF_NAME_THIS_TEST();
+
     // See ECFLOW-337 versus ECFLOW-1550
     DurationTimer timer;
-    cout << "Test:: ...test_day_at_midnight " << flush;
     TestClean clean_at_start_and_end;
 
     // SLOW SYSTEMS
@@ -88,9 +90,10 @@ BOOST_AUTO_TEST_CASE(test_day_at_midnight) {
 }
 
 BOOST_AUTO_TEST_CASE(test_date_at_midnight) {
+    ECF_NAME_THIS_TEST();
+
     // See ECFLOW-337 versus ECFLOW-1550
     DurationTimer timer;
-    cout << "Test:: ...test_date_at_midnight " << flush;
     TestClean clean_at_start_and_end;
 
     // # Note: we have to use relative paths, since these tests are relocatable

--- a/libs/test/TestEcfNoScriptCmd.cpp
+++ b/libs/test/TestEcfNoScriptCmd.cpp
@@ -15,6 +15,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "ServerTestHarness.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/DurationTimer.hpp"
 #include "ecflow/node/Defs.hpp"
@@ -30,6 +31,8 @@ BOOST_AUTO_TEST_SUITE(S_Test)
 BOOST_AUTO_TEST_SUITE(T_EcfNoScriptCmd)
 
 BOOST_AUTO_TEST_CASE(test_ecf_no_script) {
+    ECF_NAME_THIS_TEST();
+
     // This test is used to case where we ONLY want to execute ECF_JOB_CMD WITHOUT processing .ecf script.
     // For this ECF_NO_SCRIPT must be set to any value.
     // The ECF_JOB_CMD must then encompass ecflow_client --init/complete and the environment settings
@@ -37,7 +40,6 @@ BOOST_AUTO_TEST_CASE(test_ecf_no_script) {
     // Although ServerTestHarness creates the .ecf file, they are ignored when ECF_NO_SCRIPT is specified.
 
     DurationTimer timer;
-    cout << "Test:: ...test_ecf_no_script " << flush;
     TestClean clean_at_start_and_end;
 
     // Create the defs file corresponding to the text below

--- a/libs/test/TestEcfScriptCmd.cpp
+++ b/libs/test/TestEcfScriptCmd.cpp
@@ -16,6 +16,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/DurationTimer.hpp"
 #include "ecflow/core/File.hpp"
@@ -32,8 +33,9 @@ BOOST_AUTO_TEST_SUITE(S_Test)
 BOOST_AUTO_TEST_SUITE(T_EcfScriptCmd)
 
 BOOST_AUTO_TEST_CASE(test_ECF_SCRIPT_CMD) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_ECF_SCRIPT_CMD " << flush;
     TestClean clean_at_start_and_end;
 
     // Create the defs file corresponding to the text below

--- a/libs/test/TestEvents.cpp
+++ b/libs/test/TestEvents.cpp
@@ -16,6 +16,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/DurationTimer.hpp"
 #include "ecflow/node/Defs.hpp"
@@ -36,8 +37,9 @@ BOOST_AUTO_TEST_SUITE(T_Events)
 // This test does not have any time dependencies in the def file.
 
 BOOST_AUTO_TEST_CASE(test_event_and_query) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_event_and_query " << flush;
     TestClean clean_at_start_and_end;
 
     // Create the defs file corresponding to the text below

--- a/libs/test/TestFileCmd.cpp
+++ b/libs/test/TestFileCmd.cpp
@@ -14,6 +14,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/base/cts/user/CFileCmd.hpp"
 #include "ecflow/core/Converter.hpp"
@@ -37,8 +38,9 @@ BOOST_AUTO_TEST_SUITE(S_Test)
 BOOST_AUTO_TEST_SUITE(T_FileCmd)
 
 BOOST_AUTO_TEST_CASE(test_file_cmd) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_file_cmd " << flush;
     TestClean clean_at_start_and_end;
 
     // Create the defs file corresponding to the text below

--- a/libs/test/TestHandle.cpp
+++ b/libs/test/TestHandle.cpp
@@ -16,6 +16,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/base/cts/ClientToServerCmd.hpp"
 #include "ecflow/core/AssertTimer.hpp"
@@ -42,8 +43,9 @@ BOOST_AUTO_TEST_SUITE(S_Test)
 BOOST_AUTO_TEST_SUITE(T_Handle)
 
 BOOST_AUTO_TEST_CASE(test_handle) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_handle " << flush;
     TestClean clean_at_start_and_end;
 
     Defs theDefs;
@@ -195,8 +197,9 @@ BOOST_AUTO_TEST_CASE(test_handle) {
 }
 
 BOOST_AUTO_TEST_CASE(test_handle_sync) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_handle_sync " << flush;
     TestClean clean_at_start_and_end;
 
     Defs theDefs;
@@ -333,8 +336,9 @@ BOOST_AUTO_TEST_CASE(test_handle_sync) {
 }
 
 BOOST_AUTO_TEST_CASE(test_handle_add_remove_add) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_handle_add_remove_add " << flush;
     TestClean clean_at_start_and_end;
 
     defs_ptr theDefs = Defs::create();

--- a/libs/test/TestInitAddVariable.cpp
+++ b/libs/test/TestInitAddVariable.cpp
@@ -16,6 +16,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/Converter.hpp"
 #include "ecflow/core/DurationTimer.hpp"
@@ -35,6 +36,8 @@ BOOST_AUTO_TEST_SUITE(T_InitAddVariable)
 // The data is created dynamically so that we can stress test the server
 // This test does not have any time dependencies in the def file.
 BOOST_AUTO_TEST_CASE(test_init_add_variable) {
+    ECF_NAME_THIS_TEST();
+
     // Added since in 5.2.0 (only 5.2.0 server supports this behaviour)
     if (getenv("ECF_DISABLE_TEST_FOR_OLD_SERVERS")) {
         std::cout << "\n    Disable test_init_add_variable for old server , re-enable when 5.2.0 is minimum version\n";
@@ -42,7 +45,6 @@ BOOST_AUTO_TEST_CASE(test_init_add_variable) {
     }
 
     DurationTimer timer;
-    cout << "Test:: ...test_init_add_variable " << flush;
     TestClean clean_at_start_and_end;
 
     // # Note: we have to use relative paths, since these tests are relocatable

--- a/libs/test/TestKillCmd.cpp
+++ b/libs/test/TestKillCmd.cpp
@@ -14,6 +14,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/base/cts/ClientToServerCmd.hpp"
 #include "ecflow/core/AssertTimer.hpp"
@@ -45,16 +46,18 @@ static bool waitForTaskState(NState::State state, int max_time_to_wait);
 // test:: test the kill command. Create a task that runs a long time
 // The associated job is then killed. This should leave task in aborted state
 BOOST_AUTO_TEST_CASE(test_kill_cmd) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_kill_cmd " << flush;
     TestClean clean_at_start_and_end;
     BOOST_REQUIRE_MESSAGE(kill_cmd(true), " kill of task '/test_kill_cmd/family/t0' failed");
     cout << timer.duration() << "\n";
 }
 
 BOOST_AUTO_TEST_CASE(test_hierarchical_kill_cmd) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_hierarchical_kill_cmd " << flush;
     TestClean clean_at_start_and_end;
     BOOST_REQUIRE_MESSAGE(kill_cmd(false), "kill of suite '/test_kill_cmd' failed");
     cout << timer.duration() << "\n";

--- a/libs/test/TestLate.cpp
+++ b/libs/test/TestLate.cpp
@@ -16,6 +16,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/LateAttr.hpp"
 #include "ecflow/base/cts/ClientToServerCmd.hpp"
 #include "ecflow/core/Converter.hpp"
@@ -35,8 +36,9 @@ BOOST_AUTO_TEST_SUITE(S_Test)
 BOOST_AUTO_TEST_SUITE(T_Late)
 
 BOOST_AUTO_TEST_CASE(test_late) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_late " << flush;
     TestClean clean_at_start_and_end;
 
     /// This test will sleep longer than the job submission interval
@@ -82,9 +84,10 @@ BOOST_AUTO_TEST_CASE(test_late) {
 }
 
 BOOST_AUTO_TEST_CASE(test_late_hierarchically) {
+    ECF_NAME_THIS_TEST();
+
     // ECFLOW-610
     DurationTimer timer;
-    cout << "Test:: ...test_late_hierarchically " << flush;
     TestClean clean_at_start_and_end;
 
     /// This test will sleep longer than the job submission interval

--- a/libs/test/TestLimit.cpp
+++ b/libs/test/TestLimit.cpp
@@ -15,6 +15,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "ServerTestHarness.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/Converter.hpp"
 #include "ecflow/core/DurationTimer.hpp"
@@ -38,8 +39,9 @@ BOOST_AUTO_TEST_SUITE(T_Limit)
 // The data is created dynamically so that we can stress test the server
 // This test does not have any time dependencies in the def file.
 BOOST_AUTO_TEST_CASE(test_limit) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_limit " << flush;
     TestClean clean_at_start_and_end;
 
     // Create the defs file corresponding to the text below

--- a/libs/test/TestOrderCmd.cpp
+++ b/libs/test/TestOrderCmd.cpp
@@ -16,6 +16,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/base/cts/ClientToServerCmd.hpp"
 #include "ecflow/core/AssertTimer.hpp"
@@ -151,8 +152,9 @@ void test_ordering() {
 }
 
 BOOST_AUTO_TEST_CASE(test_change_order) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_change_order " << flush;
     TestClean clean_at_start_and_end;
 
     /// NOT: We *DONT* need to run the jobs for this TEST
@@ -187,8 +189,9 @@ BOOST_AUTO_TEST_CASE(test_change_order) {
 }
 
 BOOST_AUTO_TEST_CASE(test_handle_change_order) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_handle_change_order " << flush;
     TestClean clean_at_start_and_end;
 
     std::vector<std::string> str_a_b_c;

--- a/libs/test/TestQueueCmd.cpp
+++ b/libs/test/TestQueueCmd.cpp
@@ -15,6 +15,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "ServerTestHarness.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/QueueAttr.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/DurationTimer.hpp"
@@ -35,8 +36,9 @@ BOOST_AUTO_TEST_SUITE(T_QueueCmd)
 // This test does not have any time dependencies in the def file.
 
 BOOST_AUTO_TEST_CASE(test_queue) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_queue " << flush;
     TestClean clean_at_start_and_end;
 
     // Create the defs file corresponding to the text below

--- a/libs/test/TestRepeat.cpp
+++ b/libs/test/TestRepeat.cpp
@@ -17,6 +17,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/base/WhyCmd.hpp"
 #include "ecflow/core/Converter.hpp"
@@ -41,8 +42,9 @@ BOOST_AUTO_TEST_SUITE(T_Repeat)
 // The data is created dynamically so that we can stress test the server
 // This test does not have any time dependencies in the def file.
 BOOST_AUTO_TEST_CASE(test_repeat_integer) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_repeat_integer " << flush;
     TestClean clean_at_start_and_end;
 
     // ********************************************************************************
@@ -95,8 +97,9 @@ BOOST_AUTO_TEST_CASE(test_repeat_integer) {
 }
 
 BOOST_AUTO_TEST_CASE(test_repeat_date) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_repeat_date " << flush;
     TestClean clean_at_start_and_end;
 
     // ********************************************************************************
@@ -132,8 +135,9 @@ BOOST_AUTO_TEST_CASE(test_repeat_date) {
 }
 
 BOOST_AUTO_TEST_CASE(test_repeat_date_list) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_repeat_date_list " << flush;
     TestClean clean_at_start_and_end;
 
     // ********************************************************************************
@@ -169,8 +173,9 @@ BOOST_AUTO_TEST_CASE(test_repeat_date_list) {
 }
 
 BOOST_AUTO_TEST_CASE(test_repeat_enumerator) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_repeat_enumerator " << flush;
     TestClean clean_at_start_and_end;
 
     // ********************************************************************************
@@ -211,8 +216,9 @@ BOOST_AUTO_TEST_CASE(test_repeat_enumerator) {
 }
 
 BOOST_AUTO_TEST_CASE(test_repeat_defstatus) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_repeat_defstatus " << flush;
     TestClean clean_at_start_and_end;
 
     // TEST SHOULD COMPLETE STRAIGHT AWAY SINCE WE HAVE A DEFSTATUS COMPLETE
@@ -256,12 +262,13 @@ BOOST_AUTO_TEST_CASE(test_repeat_defstatus) {
 
 // #define DEBUG_ME 1
 BOOST_AUTO_TEST_CASE(test_repeat_clears_user_edit) {
+    ECF_NAME_THIS_TEST();
+
     // Tests code:: Node::requeueOrSetMostSignificantStateUpNodeTree()
     // In *PARTICULAR* THE REQUE caused by the repeat, this ensures we clear NO_REQUE_IF_SINGLE_TIME_DEP
     // So that the effect of manual run/force complete are negated via automated re-queue caused by a REPEAT
 
     DurationTimer timer;
-    cout << "Test:: ...test_repeat_clears_user_edit " << flush;
     TestClean clean_at_start_and_end;
 
     // # Note: we have to use relative paths, since these tests are relocatable

--- a/libs/test/TestRequeueNode.cpp
+++ b/libs/test/TestRequeueNode.cpp
@@ -16,6 +16,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/Converter.hpp"
 #include "ecflow/core/DurationTimer.hpp"
@@ -33,8 +34,9 @@ BOOST_AUTO_TEST_SUITE(S_Test)
 BOOST_AUTO_TEST_SUITE(T_RequeueNode)
 
 BOOST_AUTO_TEST_CASE(test_requeue_node) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_requeue_node " << flush;
     TestClean clean_at_start_and_end;
 
     // Create the defs file corresponding to the text below

--- a/libs/test/TestServer.cpp
+++ b/libs/test/TestServer.cpp
@@ -16,6 +16,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/Converter.hpp"
 #include "ecflow/core/DurationTimer.hpp"
@@ -37,8 +38,9 @@ BOOST_AUTO_TEST_SUITE(T_Server)
 // The data is created dynamically so that we can stress test the server
 // This test does not have any time dependencies in the def file.
 BOOST_AUTO_TEST_CASE(test_server_job_submission) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_server_job_submission " << flush;
     TestClean clean_at_start_and_end;
 
     // # Note: we have to use relative paths, since these tests are relocatable
@@ -70,8 +72,9 @@ BOOST_AUTO_TEST_CASE(test_server_job_submission) {
 }
 
 BOOST_AUTO_TEST_CASE(test_restore_defs_from_check_pt) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_restore_defs_from_check_pt " << flush;
     TestClean clean_at_start_and_end;
     // **********************************************************************
     // In order for this test to work, we need to disable the automatic

--- a/libs/test/TestSingle.cpp
+++ b/libs/test/TestSingle.cpp
@@ -128,13 +128,13 @@ BOOST_AUTO_TEST_CASE(test_stress) {
 // Be sure to comment out defstatus suspended in mega.def
 // BOOST_AUTO_TEST_CASE( test_mega_def )
 //{
+//   ECF_NAME_THIS_TEST();
+//
 //   DurationTimer timer;
 //
 //   // location to mega.def and left over log file
 //   std::string log_file = File::test_data("libs/node/parser/test/data/single_defs/mega.def_log","parser");
 //   std::string path = File::test_data("libs/node/parser/test/data/single_defs/mega.def","parser");
-//
-//   cout << "Test:: ..." << path << " log file: " << log_file << flush;
 //
 //   // Remove the log file.
 //   fs::remove(log_file);
@@ -156,8 +156,9 @@ BOOST_AUTO_TEST_CASE(test_stress) {
 // This is used to test with thousands of labels
 // BOOST_AUTO_TEST_CASE( test_large_client_labels_calls )
 //{
+//   ECF_NAME_THIS_TEST();
+//
 //   DurationTimer timer;
-//   cout << "Test:: ...test_large_client_labels_calls "<< flush;
 //   TestClean clean_at_start_and_end;
 //
 //   //# Note: we have to use relative paths, since these tests are relocatable
@@ -222,9 +223,9 @@ BOOST_AUTO_TEST_CASE(test_stress) {
 ///   5000               29                     800
 ///   6000               37                     900
 // void time_for_tasks(int tasks) {
+//    ECF_NAME_THIS_TEST();
 //
 //    std::string test_name = "test_stress_" + ecf::convert_to<std::string>(tasks);
-//    cout << "Test:: ..." << test_name  << flush;
 //
 //    Defs theDefs;
 //    {

--- a/libs/test/TestSingle.cpp
+++ b/libs/test/TestSingle.cpp
@@ -131,8 +131,8 @@ BOOST_AUTO_TEST_CASE(test_stress) {
 //   DurationTimer timer;
 //
 //   // location to mega.def and left over log file
-//   std::string log_file = File::test_data("ANode/parser/test/data/single_defs/mega.def_log","parser");
-//   std::string path = File::test_data("ANode/parser/test/data/single_defs/mega.def","parser");
+//   std::string log_file = File::test_data("libs/node/parser/test/data/single_defs/mega.def_log","parser");
+//   std::string path = File::test_data("libs/node/parser/test/data/single_defs/mega.def","parser");
 //
 //   cout << "Test:: ..." << path << " log file: " << log_file << flush;
 //

--- a/libs/test/TestSpecificIssues.cpp
+++ b/libs/test/TestSpecificIssues.cpp
@@ -16,6 +16,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/DurationTimer.hpp"
 #include "ecflow/node/Defs.hpp"
@@ -30,10 +31,11 @@ BOOST_AUTO_TEST_SUITE(S_Test)
 BOOST_AUTO_TEST_SUITE(T_SpecificIssues)
 
 BOOST_AUTO_TEST_CASE(test_ECFLOW_1589) {
+    ECF_NAME_THIS_TEST();
+
     // Test ECF_JOB_CMD where task *completes* but the ECF_JOB_CMD still fails. i.e ECFLOW-1589
 
     DurationTimer timer;
-    cout << "Test:: ...test_ECFLOW_1589 " << flush;
     TestClean clean_at_start_and_end;
 
     // Create the defs file corresponding to the text below

--- a/libs/test/TestSuspend.cpp
+++ b/libs/test/TestSuspend.cpp
@@ -17,6 +17,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/AssertTimer.hpp"
 #include "ecflow/core/Converter.hpp"
@@ -78,8 +79,9 @@ static void waitForTimeDependenciesToBeFree(int max_time_to_wait) {
 // be handled. When the server/node is restarted/resumed the task should
 // be submitted straight away.(i.e providing no trigger/complete dependencies)
 BOOST_AUTO_TEST_CASE(test_shutdown) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_shutdown " << flush;
     TestClean clean_at_start_and_end;
 
     // Create the defs file corresponding to the text below
@@ -158,8 +160,9 @@ BOOST_AUTO_TEST_CASE(test_shutdown) {
 // be handled. When the server/node is restarted/resumed the task should
 // be submitted straight away.(i.e providing no trigger/complete dependencies)
 BOOST_AUTO_TEST_CASE(test_suspend_node) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_suspend_node " << flush;
     TestClean clean_at_start_and_end;
 
     // Create the defs file corresponding to the text below

--- a/libs/test/TestTime.cpp
+++ b/libs/test/TestTime.cpp
@@ -17,6 +17,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/Converter.hpp"
 #include "ecflow/core/DurationTimer.hpp"
@@ -36,8 +37,9 @@ BOOST_AUTO_TEST_SUITE(S_Test)
 BOOST_AUTO_TEST_SUITE(T_Time)
 
 BOOST_AUTO_TEST_CASE(test_single_real_time) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_single_real_time " << flush;
     TestClean clean_at_start_and_end;
 
     // Create the defs file corresponding to the text below
@@ -93,9 +95,10 @@ BOOST_AUTO_TEST_CASE(test_single_real_time) {
 }
 
 BOOST_AUTO_TEST_CASE(test_single_time_trigger) {
+    ECF_NAME_THIS_TEST();
+
     // ECFLOW-833
     DurationTimer timer;
-    cout << "Test:: ...test_single_time_trigger " << flush;
     TestClean clean_at_start_and_end;
 
     // Create the defs file corresponding to the text below
@@ -153,8 +156,9 @@ BOOST_AUTO_TEST_CASE(test_single_time_trigger) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_multiple_single_slot) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_time_multiple_single_slot " << flush;
     TestClean clean_at_start_and_end;
 
     // SLOW SYSTEMS
@@ -206,8 +210,9 @@ BOOST_AUTO_TEST_CASE(test_time_multiple_single_slot) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_relative_time_series) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_time_relative_time_series " << flush;
     TestClean clean_at_start_and_end;
 
     // SLOW SYSTEMS
@@ -252,8 +257,9 @@ BOOST_AUTO_TEST_CASE(test_time_relative_time_series) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_real_series) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_time_real_series " << flush;
     TestClean clean_at_start_and_end;
 
     // SLOW SYSTEMS
@@ -309,8 +315,9 @@ BOOST_AUTO_TEST_CASE(test_time_real_series) {
 }
 
 BOOST_AUTO_TEST_CASE(test_single_real_time_near_midnight) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_single_real_time_near_midnight " << flush;
     TestClean clean_at_start_and_end;
 
     // # Note: we have to use relative paths, since these tests are relocatable
@@ -360,8 +367,9 @@ BOOST_AUTO_TEST_CASE(test_single_real_time_near_midnight) {
 }
 
 BOOST_AUTO_TEST_CASE(test_time_real_series_near_midnight) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_time_real_series_near_midnight " << flush;
     int the_server_version = TestFixture::server_version();
     if (the_server_version == 403) {
         cout << " SKIPPING, This test does not work with 403, current server version is " << the_server_version << "\n";

--- a/libs/test/TestToday.cpp
+++ b/libs/test/TestToday.cpp
@@ -17,6 +17,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/Converter.hpp"
 #include "ecflow/core/DurationTimer.hpp"
@@ -37,8 +38,9 @@ BOOST_AUTO_TEST_SUITE(T_Today)
 // In the test case we will dynamically create all the test data.
 // The data is created dynamically so that we can stress test the server
 BOOST_AUTO_TEST_CASE(test_today_single_slot) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_today_single_slot " << flush;
     TestClean clean_at_start_and_end;
 
     // **************************************************************************
@@ -90,8 +92,9 @@ BOOST_AUTO_TEST_CASE(test_today_single_slot) {
 }
 
 BOOST_AUTO_TEST_CASE(test_today_relative_time_series) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_today_relative_time_series " << flush;
     TestClean clean_at_start_and_end;
 
     // SLOW SYSTEMS
@@ -136,8 +139,9 @@ BOOST_AUTO_TEST_CASE(test_today_relative_time_series) {
 }
 
 BOOST_AUTO_TEST_CASE(test_today_real_time_series) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_today_real_time_series " << flush;
     TestClean clean_at_start_and_end;
 
     // SLOW SYSTEMS

--- a/libs/test/TestTrigger.cpp
+++ b/libs/test/TestTrigger.cpp
@@ -15,6 +15,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "ServerTestHarness.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/attribute/VerifyAttr.hpp"
 #include "ecflow/core/Converter.hpp"
 #include "ecflow/core/DurationTimer.hpp"
@@ -36,8 +37,9 @@ BOOST_AUTO_TEST_SUITE(T_Trigger)
 // The data is created dynamically so that we can stress test the server
 // This test does not have any time dependencies in the def file.
 BOOST_AUTO_TEST_CASE(test_triggers_and_meters) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_triggers_and_meters " << flush;
     TestClean clean_at_start_and_end;
 
     // # Note: we have to use relative paths, since these tests are relocatable
@@ -84,10 +86,11 @@ BOOST_AUTO_TEST_CASE(test_triggers_and_meters) {
 }
 
 BOOST_AUTO_TEST_CASE(test_triggers_with_limits) {
+    ECF_NAME_THIS_TEST();
+
     // One family is in the limits, another is without. Bit of hack
     // But shows use of limits in triggers
     DurationTimer timer;
-    cout << "Test:: ...test_triggers_with_limits " << flush;
     TestClean clean_at_start_and_end;
 
     // # Note: we have to use relative paths, since these tests are relocatable

--- a/libs/test/TestWhyCmd.cpp
+++ b/libs/test/TestWhyCmd.cpp
@@ -15,6 +15,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ecflow/base/WhyCmd.hpp"
 #include "ecflow/base/cts/ClientToServerCmd.hpp"
 #include "ecflow/core/AssertTimer.hpp"
@@ -74,8 +75,9 @@ static unsigned int waitForWhy(const std::string& path, const std::string& why, 
 }
 
 BOOST_AUTO_TEST_CASE(test_why_day) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_why_day " << flush;
     TestClean clean_at_start_and_end;
 
     Defs theDefs;
@@ -111,8 +113,9 @@ BOOST_AUTO_TEST_CASE(test_why_day) {
 }
 
 BOOST_AUTO_TEST_CASE(test_why_date) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_why_date " << flush;
 
     Defs theDefs;
     {
@@ -146,8 +149,9 @@ BOOST_AUTO_TEST_CASE(test_why_date) {
 }
 
 BOOST_AUTO_TEST_CASE(test_why_time) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_why_time " << flush;
 
     Defs theDefs;
     {
@@ -181,8 +185,9 @@ BOOST_AUTO_TEST_CASE(test_why_time) {
 }
 
 BOOST_AUTO_TEST_CASE(test_why_today) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_why_today " << flush;
 
     Defs theDefs;
     {
@@ -225,8 +230,9 @@ BOOST_AUTO_TEST_CASE(test_why_today) {
 }
 
 BOOST_AUTO_TEST_CASE(test_why_cron) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_why_cron " << flush;
 
     Defs theDefs;
     {
@@ -283,8 +289,9 @@ BOOST_AUTO_TEST_CASE(test_why_cron) {
 }
 
 BOOST_AUTO_TEST_CASE(test_why_limit) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_why_limit " << flush;
 
     // Testing for limits requires that we have least some jobs are submitted.
     // we need to kill these jobs, at the end of test.
@@ -362,8 +369,9 @@ BOOST_AUTO_TEST_CASE(test_why_limit) {
 }
 
 BOOST_AUTO_TEST_CASE(test_why_trigger) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_why_trigger " << flush;
 
     Defs theDefs;
     {
@@ -389,8 +397,9 @@ BOOST_AUTO_TEST_CASE(test_why_trigger) {
 }
 
 BOOST_AUTO_TEST_CASE(test_why_meter) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_why_meter " << flush;
 
     Defs theDefs;
     {
@@ -417,8 +426,9 @@ BOOST_AUTO_TEST_CASE(test_why_meter) {
 }
 
 BOOST_AUTO_TEST_CASE(test_why_event) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_why_event " << flush;
 
     Defs theDefs;
     {
@@ -449,8 +459,9 @@ BOOST_AUTO_TEST_CASE(test_why_event) {
 }
 
 BOOST_AUTO_TEST_CASE(test_why_user_var) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_why_user_var " << flush;
 
     Defs theDefs;
     {
@@ -477,8 +488,9 @@ BOOST_AUTO_TEST_CASE(test_why_user_var) {
 }
 
 BOOST_AUTO_TEST_CASE(test_why_gen_var) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_why_gen_var " << flush;
 
     Defs theDefs;
     {
@@ -505,8 +517,9 @@ BOOST_AUTO_TEST_CASE(test_why_gen_var) {
 }
 
 BOOST_AUTO_TEST_CASE(test_why_repeat) {
+    ECF_NAME_THIS_TEST();
+
     DurationTimer timer;
-    cout << "Test:: ...test_why_repeat " << flush;
 
     Defs theDefs;
     {

--- a/libs/test/TestZombies.cpp
+++ b/libs/test/TestZombies.cpp
@@ -16,6 +16,7 @@
 
 #include "ServerTestHarness.hpp"
 #include "TestFixture.hpp"
+#include "TestNaming.hpp"
 #include "ZombieUtil.hpp"
 #include "ecflow/core/AssertTimer.hpp"
 #include "ecflow/core/Child.hpp"
@@ -643,16 +644,17 @@ BOOST_AUTO_TEST_CASE(enable_debug_for_ECF_TRY_NO_Greater_than_one) {
 
     if (getenv("ECF_DEBUG_ZOMBIES")) {
         ecf_debug_enabled = true;
-        cout << "Test:: ... debug_enabled" << endl;
+        ECF_NAME_THIS_TEST();
     }
 }
 
 #ifdef DO_TEST1
 BOOST_AUTO_TEST_CASE(test_path_zombie_creation) {
+    ECF_NAME_THIS_TEST();
+
     if (ecf_debug_enabled)
         std::cout << "\n\n=============================================================================\n";
     DurationTimer timer;
-    cout << "Test:: ...test_path_zombie_creation " << flush;
     if (ecf_debug_enabled)
         cout << "\n";
     TestClean clean_at_start_and_end;
@@ -694,10 +696,11 @@ BOOST_AUTO_TEST_CASE(test_path_zombie_creation) {
 
 #ifdef DO_TEST2
 BOOST_AUTO_TEST_CASE(test_user_zombies_for_delete_fob) {
+    ECF_NAME_THIS_TEST();
+
     if (ecf_debug_enabled)
         std::cout << "\n\n=============================================================================\n";
     DurationTimer timer;
-    cout << "Test:: ...test_user_zombies_for_delete_fob " << flush;
     if (ecf_debug_enabled)
         cout << "\n";
     TestClean clean_at_start_and_end;
@@ -732,10 +735,11 @@ BOOST_AUTO_TEST_CASE(test_user_zombies_for_delete_fob) {
 
 #ifdef DO_TEST3
 BOOST_AUTO_TEST_CASE(test_user_zombies_for_delete_fail) {
+    ECF_NAME_THIS_TEST();
+
     if (ecf_debug_enabled)
         std::cout << "\n\n=============================================================================\n";
     DurationTimer timer;
-    cout << "Test:: ...test_user_zombies_for_delete_fail " << flush;
     if (ecf_debug_enabled)
         cout << "\n";
     TestClean clean_at_start_and_end;
@@ -764,10 +768,11 @@ BOOST_AUTO_TEST_CASE(test_user_zombies_for_delete_fail) {
 
 #ifdef DO_TEST4
 BOOST_AUTO_TEST_CASE(test_user_zombies_for_begin) {
+    ECF_NAME_THIS_TEST();
+
     if (ecf_debug_enabled)
         std::cout << "\n\n=============================================================================\n";
     DurationTimer timer;
-    cout << "Test:: ...test_user_zombies_for_begin " << flush;
     if (ecf_debug_enabled)
         cout << "\n";
     TestClean clean_at_start_and_end;
@@ -808,11 +813,12 @@ BOOST_AUTO_TEST_CASE(test_user_zombies_for_begin) {
 
 #ifdef DO_TEST5
 BOOST_AUTO_TEST_CASE(test_zombies_attr) {
+    ECF_NAME_THIS_TEST();
+
     if (ecf_debug_enabled)
         std::cout << "\n\n=============================================================================\n";
     DurationTimer timer;
     std::string suite_name = "test_zombies_attr";
-    cout << "Test:: ..." << suite_name << " " << flush;
     if (ecf_debug_enabled)
         cout << "\n";
     TestClean clean_at_start_and_end;
@@ -848,11 +854,12 @@ BOOST_AUTO_TEST_CASE(test_zombies_attr) {
 
 #ifdef DO_TEST6
 BOOST_AUTO_TEST_CASE(test_user_zombies_for_adopt) {
+    ECF_NAME_THIS_TEST();
+
     if (ecf_debug_enabled)
         std::cout << "\n\n=============================================================================\n";
     DurationTimer timer;
     std::string suite_name = "test_user_zombies_for_adopt";
-    cout << "Test:: ..." << suite_name << " " << flush;
     if (ecf_debug_enabled)
         cout << "\n";
     TestClean clean_at_start_and_end;
@@ -892,13 +899,12 @@ BOOST_AUTO_TEST_CASE(test_user_zombies_for_adopt) {
 
 #ifdef DO_TEST7
 BOOST_AUTO_TEST_CASE(test_zombies_attr_for_adopt) {
+    std::string suite_name = "test_zombies_attr_for_adopt";
+    ECF_NAME_THIS_TEST(<< ", using suite: " << suite_name);
+
     if (ecf_debug_enabled)
         std::cout << "\n\n=============================================================================\n";
     DurationTimer timer;
-    std::string suite_name = "test_zombies_attr_for_adopt";
-    cout << "Test:: ..." << suite_name << " " << flush;
-    if (ecf_debug_enabled)
-        cout << "\n";
     TestClean clean_at_start_and_end;
 
     // This command creates user zombies up front, these may not have a pid, if task in submitted state
@@ -938,13 +944,12 @@ BOOST_AUTO_TEST_CASE(test_zombies_attr_for_adopt) {
 
 #ifdef DO_TEST8
 BOOST_AUTO_TEST_CASE(test_user_zombie_creation_via_complete) {
+    std::string suite_name = "test_zombies_attr_for_adopt";
+    ECF_NAME_THIS_TEST(<< ", using suite: " << suite_name);
+
     if (ecf_debug_enabled)
         std::cout << "\n\n=============================================================================\n";
     DurationTimer timer;
-    std::string suite_name = "test_user_zombie_creation_via_complete";
-    cout << "Test:: ..." << suite_name << " " << flush;
-    if (ecf_debug_enabled)
-        cout << "\n";
     TestClean clean_at_start_and_end;
 
     // This command creates user zombies up front, these may not have a pid, if task in submitted state
@@ -965,13 +970,12 @@ BOOST_AUTO_TEST_CASE(test_user_zombie_creation_via_complete) {
 
 #ifdef DO_TEST9
 BOOST_AUTO_TEST_CASE(test_user_zombie_creation_via_abort) {
+    std::string suite_name = "test_user_zombie_creation_via_abort";
+    ECF_NAME_THIS_TEST(<< ", using suite: " << suite_name);
+
     if (ecf_debug_enabled)
         std::cout << "\n\n=============================================================================\n";
     DurationTimer timer;
-    std::string suite_name = "test_user_zombie_creation_via_abort";
-    cout << "Test:: ..." << suite_name << " " << flush;
-    if (ecf_debug_enabled)
-        cout << "\n";
     TestClean clean_at_start_and_end;
 
     // This command creates user zombies up front, these may not have a pid, if task in submitted state
@@ -992,13 +996,12 @@ BOOST_AUTO_TEST_CASE(test_user_zombie_creation_via_abort) {
 
 #ifdef DO_TEST10
 BOOST_AUTO_TEST_CASE(test_zombie_inheritance) {
+    std::string suite_name = "test_zombie_inheritance";
+    ECF_NAME_THIS_TEST(<< ", using suite: " << suite_name);
+
     if (ecf_debug_enabled)
         std::cout << "\n\n=============================================================================\n";
     DurationTimer timer;
-    std::string suite_name = "test_zombie_inheritance";
-    cout << "Test:: ..." << suite_name << " " << flush;
-    if (ecf_debug_enabled)
-        cout << "\n";
     TestClean clean_at_start_and_end;
 
     // Add zombie attribute, make sure it inherited
@@ -1065,13 +1068,12 @@ static int wait_for_killed_zombies(int no_of_tasks, int max_time_to_wait) {
 }
 
 BOOST_AUTO_TEST_CASE(test_zombie_kill) {
+    std::string suite_name = "test_zombie_kill";
+    ECF_NAME_THIS_TEST(<< ", using suite: " << suite_name);
+
     if (ecf_debug_enabled)
         std::cout << "\n\n=============================================================================\n";
     DurationTimer timer;
-    std::string suite_name = "test_zombie_kill";
-    cout << "Test:: ..." << suite_name << " " << flush;
-    if (ecf_debug_enabled)
-        cout << "\n";
     TestClean clean_at_start_and_end;
 
     // This command creates user zombies up front, these may not have a pid, if task in submitted state
@@ -1183,13 +1185,12 @@ static void remove_all_user_zombies() {
         dump_zombies();
 }
 BOOST_AUTO_TEST_CASE(test_ecf_zombie_type_creation) {
+    std::string suite_name = "test_ecf_zombie_type_creation";
+    ECF_NAME_THIS_TEST(<< ", using suite: " << suite_name);
+
     if (ecf_debug_enabled)
         std::cout << "\n\n=============================================================================\n";
     DurationTimer timer;
-    std::string suite_name = "test_ecf_zombie_type_creation";
-    cout << "Test:: ..." << suite_name << " " << flush;
-    if (ecf_debug_enabled)
-        cout << "\n";
     TestClean clean_at_start_and_end;
 
     // some systems are really quick, where tasks are already active, when we make them zombies, then the next

--- a/libs/udp/CMakeLists.txt
+++ b/libs/udp/CMakeLists.txt
@@ -86,6 +86,7 @@ ecbuild_add_test(
     Boost::boost
     Boost::unit_test_framework
     $<$<BOOL:${OPENSSL_FOUND}>:OpenSSL::SSL>
+    test_support
   DEPENDS
     ecflow_server # the server is launched to support tests
     ${SERVER_TARGET}

--- a/libs/udp/test/TestSupport.hpp
+++ b/libs/udp/test/TestSupport.hpp
@@ -46,7 +46,7 @@ public:
         BOOST_REQUIRE_MESSAGE(port_ > 0, "port is be larger than 0");
 
         server_ = SERVER::launch(host_, port_, std::forward<Args>(args)...);
-        std::cout << "   MOCK: " << SERVER::designation << " has been started!" << std::endl;
+        ECF_TEST_DBG(<< "   MOCK: " << SERVER::designation << " has been started!");
     }
     BaseMockServer(const BaseMockServer&) = delete;
     BaseMockServer(BaseMockServer&&)      = delete;
@@ -54,7 +54,7 @@ public:
     ~BaseMockServer() {
         server_.terminate();
         SERVER::cleanup(host_, port_);
-        std::cout << "   MOCK: " << SERVER::designation << " has been terminated!" << std::endl;
+        ECF_TEST_DBG(<< "   MOCK: " << SERVER::designation << " has been terminated!");
     }
 
     const hostname_t& host() const { return host_; }
@@ -86,7 +86,7 @@ public:
                 false, "load definitions, without throwing exception (but threw: " + std::string(e.what()) + ")");
         }
 
-        std::cout << "   MOCK: reference ecFlow suite has been loaded" << std::endl;
+        ECF_TEST_DBG(<< "   MOCK: reference ecFlow suite has been loaded");
     }
 
     Meter get_meter(const std::string& path, const std::string& name) const {
@@ -106,7 +106,7 @@ public:
 
 private:
     node_ptr get_node_at(const std::string& path) const {
-        std::cout << "   Creating ecflow_client connected to " << host() << ":" << port() << std::endl;
+        ECF_TEST_DBG(<< "   Creating ecflow_client connected to " << host() << ":" << port());
         ClientInvoker client(ecf::Str::LOCALHOST(), port());
 
         // load all definitions
@@ -144,7 +144,7 @@ public:
         invoke_command += std::to_string(port);
         invoke_command += " -d &";
 
-        std::cout << "Launching ecflow_server @" << host << ":" << port << ", with: " << invoke_command << std::endl;
+        ECF_TEST_DBG(<< "Launching ecflow_server @" << host << ":" << port << ", with: " << invoke_command);
 
         bp::child child(invoke_command);
 
@@ -195,7 +195,7 @@ public:
     }
 
     void send(const std::string& request) {
-        std::cout << "   MOCK: UDP Client sending request: " << request << std::endl;
+        ECF_TEST_DBG(<< "   MOCK: UDP Client sending request: " << request);
         sendRequest(port(), request);
     }
 
@@ -221,7 +221,7 @@ private:
 
     static void sendRequest(uint16_t port, const std::string& request) {
         const std::string host = "localhost";
-        std::cout << "   Creating ecflow_udp client connected to " << host << ":" << port << std::endl;
+        ECF_TEST_DBG(<< "   Creating ecflow_udp client connected to " << host << ":" << port);
         ecf::UDPClient client(host, std::to_string(port));
         client.send(request);
 
@@ -241,7 +241,7 @@ public:
         invoke_command += std::to_string(ecflow_port);
         invoke_command += " --verbose";
 
-        std::cout << "   Launching ecflow_udp @" << host << ":" << port << ", with: " << invoke_command << std::endl;
+        ECF_TEST_DBG(<< "   Launching ecflow_udp @" << host << ":" << port << ", with: " << invoke_command);
 
         bp::child server(invoke_command);
 
@@ -270,13 +270,13 @@ struct EnableServersFixture
 private:
     static MockServer::port_t get_ecflow_server_port() {
         MockServer::port_t selected_port = 3199;
-        std::cout << "   Attempting to use port: " << selected_port << std::endl;
+        ECF_TEST_DBG(<< "   Attempting to use port: " << selected_port);
         while (!EcfPortLock::is_free(selected_port)) {
-            std::cout << "   Selected port: " << selected_port << " is not available." << std::endl;
+            ECF_TEST_DBG(<< "   Selected port: " << selected_port << " is not available.");
             ++selected_port;
-            std::cout << "   Attempting to use port: " << selected_port << std::endl;
+            ECF_TEST_DBG(<< "   Attempting to use port: " << selected_port);
         }
-        std::cout << "   Found free port: " << selected_port << "\n";
+        ECF_TEST_DBG(<< "   Found free port: " << selected_port);
         return selected_port;
     }
     static MockServer::port_t get_ecflow_udp_port() { return 3198; }

--- a/libs/udp/test/TestUDPServer.cpp
+++ b/libs/udp/test/TestUDPServer.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "TestNaming.hpp"
 #include "TestSupport.hpp"
 
 namespace ut = boost::unit_test;
@@ -19,6 +20,8 @@ BOOST_FIXTURE_TEST_SUITE(S_UDP, ecf::test::EnableServersFixture)
 BOOST_AUTO_TEST_SUITE(T_UDPServer)
 
 BOOST_AUTO_TEST_CASE(can_update_events) {
+    ECF_NAME_THIS_TEST();
+
     // Family f2
     {
         auto event = ecflow_server.get_event("/s1/f2", "event_at_f2");
@@ -61,6 +64,8 @@ BOOST_AUTO_TEST_CASE(can_update_events) {
 }
 
 BOOST_AUTO_TEST_CASE(can_update_labels) {
+    ECF_NAME_THIS_TEST();
+
     // Family f2
     {
         auto label = ecflow_server.get_label("/s1/f2", "label_at_f2");
@@ -95,6 +100,8 @@ BOOST_AUTO_TEST_CASE(can_update_labels) {
 }
 
 BOOST_AUTO_TEST_CASE(can_update_meters) {
+    ECF_NAME_THIS_TEST();
+
     // Family f2
     {
         auto meter = ecflow_server.get_meter("/s1/f2", "meter_at_f2");
@@ -129,6 +136,8 @@ BOOST_AUTO_TEST_CASE(can_update_meters) {
 }
 
 BOOST_AUTO_TEST_CASE(can_update_meter_outside_valid_range) {
+    ECF_NAME_THIS_TEST();
+
     {
         ecflow_udp.update_meter("/s1/f2/f3/t4", "meter_at_t4", 50);
         auto meter = ecflow_server.get_meter("/s1/f2/f3/t4", "meter_at_t4");
@@ -147,6 +156,8 @@ BOOST_AUTO_TEST_CASE(can_update_meter_outside_valid_range) {
 }
 
 BOOST_AUTO_TEST_CASE(can_handle_invalid_json_request) {
+    ECF_NAME_THIS_TEST();
+
     ecflow_udp.send(R"()");
     ecflow_udp.send(R"({})");
     ecflow_udp.send(R"({"method": "invalid", "data": {}})");
@@ -161,6 +172,7 @@ BOOST_AUTO_TEST_CASE(can_handle_invalid_json_request) {
 }
 
 BOOST_AUTO_TEST_CASE(can_authenticate_requests) {
+    ECF_NAME_THIS_TEST();
 
     ecflow_udp.send(R"()");
 }


### PR DESCRIPTION
- Apply consistent format to tests name (i.e. output shown at runtime)
- Reduce the number of direct uses of std::cout in test implementation