### PR TITLE
Fix build issue on conda-forge ECFLOW-1987

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -224,6 +224,20 @@ endif()
 
 
 # =========================================================================================
+# Crypt
+# =========================================================================================
+ecbuild_info( "Locating Crypt" )
+
+find_package(Crypt)
+
+ecbuild_info( "Crypt details:" )
+ecbuild_info( " * Crypt_FOUND        : ${Crypt_FOUND}" )
+ecbuild_info( " * Crypt_INCLUDE_DIRS : ${Crypt_INCLUDE_DIRS}" )
+ecbuild_info( " * Crypt_LIBRARIES    : ${Crypt_LIBRARIES}" )
+
+ecbuild_info( "Found Crypt at ${Crypt_INCLUDE_DIRS}" )
+
+# =========================================================================================
 # Dependency: Qt
 # =========================================================================================
 
@@ -362,15 +376,3 @@ else()
   ecbuild_info("Clang-Format not found")
   ecbuild_info("    WARNING: No formatting targets will be defined!")
 endif ()
-
-# =========================================================================================
-# Crypt
-# =========================================================================================
-ecbuild_info( "Locating Crypt" )
-
-find_package(Crypt)
-
-ecbuild_info( "Crypt details:" )
-ecbuild_info( " * Crypt_FOUND        : ${Crypt_FOUND}" )
-ecbuild_info( " * Crypt_INCLUDE_DIRS : ${Crypt_INCLUDE_DIRS}" )
-ecbuild_info( " * Crypt_LIBRARIES    : ${Crypt_LIBRARIES}" )


### PR DESCRIPTION
This allows to find libcrypt.so by full path, and avoid being dependent on the compiler directory search.

Re ECFLOW-1987