### PR TITLE
Clarify use of ZombieCtrlAction

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -272,6 +272,7 @@ set(srcs
   core/src/ecflow/core/User.hpp
   core/src/ecflow/core/Version.hpp
   core/src/ecflow/core/WhiteListFile.hpp
+  core/src/ecflow/core/ZombieCtrlAction.hpp
   core/src/ecflow/core/cereal_boost_time.hpp
   core/src/ecflow/core/cereal_optional_nvp.hpp
   core/src/ecflow/core/perf_timer.hpp

--- a/libs/attribute/src/ecflow/attribute/Zombie.cpp
+++ b/libs/attribute/src/ecflow/attribute/Zombie.cpp
@@ -90,22 +90,22 @@ std::string Zombie::type_str() const {
     return Child::to_string(zombie_type_);
 }
 
-ecf::User::Action Zombie::user_action() const {
+ZombieCtrlAction Zombie::user_action() const {
     // User action needs to take into account, last child command and setting on attr_
     if (fob())
-        return User::FOB;
+        return ZombieCtrlAction::FOB;
     else if (block())
-        return User::BLOCK;
+        return ZombieCtrlAction::BLOCK;
     else if (fail())
-        return User::FAIL;
+        return ZombieCtrlAction::FAIL;
     else if (remove())
-        return User::REMOVE;
+        return ZombieCtrlAction::REMOVE;
     else if (kill())
-        return User::KILL;
+        return ZombieCtrlAction::KILL;
     else if (adopt())
-        return User::ADOPT;
+        return ZombieCtrlAction::ADOPT;
 
-    return User::BLOCK; // the default action
+    return ZombieCtrlAction::BLOCK; // the default action
 }
 
 std::string Zombie::user_action_str() const {
@@ -114,39 +114,45 @@ std::string Zombie::user_action_str() const {
         ret = "manual-";
     else
         ret = "auto-";
-    ret += User::to_string(user_action());
+    ret += ecf::to_string(user_action());
     return ret;
 }
 
 /// accessors
+
 bool Zombie::fob() const {
     if (user_action_set_)
-        return user_action_ == User::FOB;
+        return user_action_ == ZombieCtrlAction::FOB;
     return attr_.fob(last_child_cmd_);
 }
+
 bool Zombie::fail() const {
     if (user_action_set_)
-        return user_action_ == User::FAIL;
+        return user_action_ == ZombieCtrlAction::FAIL;
     return attr_.fail(last_child_cmd_);
 }
+
 bool Zombie::adopt() const {
     if (user_action_set_)
-        return user_action_ == User::ADOPT;
+        return user_action_ == ZombieCtrlAction::ADOPT;
     return attr_.adopt(last_child_cmd_);
 }
+
 bool Zombie::block() const {
     if (user_action_set_)
-        return user_action_ == User::BLOCK;
+        return user_action_ == ZombieCtrlAction::BLOCK;
     return attr_.block(last_child_cmd_);
 }
+
 bool Zombie::remove() const {
     if (user_action_set_)
-        return user_action_ == User::REMOVE;
+        return user_action_ == ZombieCtrlAction::REMOVE;
     return attr_.remove(last_child_cmd_);
 }
+
 bool Zombie::kill() const {
     if (user_action_set_)
-        return user_action_ == User::KILL;
+        return user_action_ == ZombieCtrlAction::KILL;
     return attr_.kill(last_child_cmd_);
 }
 
@@ -155,23 +161,26 @@ int Zombie::allowed_age() const {
 }
 
 void Zombie::set_fob() {
-    user_action_     = User::FOB;
+    user_action_     = ZombieCtrlAction::FOB;
     user_action_set_ = true;
 }
+
 void Zombie::set_fail() {
-    user_action_     = User::FAIL;
+    user_action_     = ZombieCtrlAction::FAIL;
     user_action_set_ = true;
 }
+
 void Zombie::set_adopt() {
-    user_action_     = User::ADOPT;
+    user_action_     = ZombieCtrlAction::ADOPT;
     user_action_set_ = true;
 }
+
 void Zombie::set_block() {
-    user_action_     = User::BLOCK;
+    user_action_     = ZombieCtrlAction::BLOCK;
     user_action_set_ = true;
 }
 void Zombie::set_kill() {
-    user_action_     = User::KILL;
+    user_action_     = ZombieCtrlAction::KILL;
     user_action_set_ = true;
 }
 

--- a/libs/attribute/src/ecflow/attribute/Zombie.hpp
+++ b/libs/attribute/src/ecflow/attribute/Zombie.hpp
@@ -88,7 +88,7 @@ public:
     const std::string& host() const { return host_; }
     int try_no() const { return try_no_; }
     int duration() const { return duration_; }
-    ecf::User::Action user_action() const;
+    ecf::ZombieCtrlAction user_action() const;
     std::string user_action_str() const;
     std::string explanation() const;
 
@@ -131,9 +131,9 @@ public:
     static Zombie& EMPTY_();
 
 private:
-    ecf::User::Action user_action_{ecf::User::BLOCK};      // [ fob, fail, remove, adopt, block, kill ]
-    int try_no_{0};                                        // task try number, set on construction
-    int duration_{0};                                      // How long zombie been alive
+    ecf::ZombieCtrlAction user_action_{ecf::ZombieCtrlAction::BLOCK}; // [ fob, fail, remove, adopt, block, kill ]
+    int try_no_{0};                                                   // task try number, set on construction
+    int duration_{0};                                                 // How long zombie been alive
     int calls_{0};                                         // Number of times we have communicated with server.
     ecf::Child::ZombieType zombie_type_{ecf::Child::USER}; // [ ecf, ecf_pid, ecf_pid_passwd, ecf_passwd, path, user ]
     ecf::Child::CmdType last_child_cmd_{

--- a/libs/attribute/src/ecflow/attribute/ZombieAttr.hpp
+++ b/libs/attribute/src/ecflow/attribute/ZombieAttr.hpp
@@ -14,7 +14,7 @@
 #include <cstdint>
 
 #include "ecflow/core/Child.hpp"
-#include "ecflow/core/User.hpp"
+#include "ecflow/core/ZombieCtrlAction.hpp"
 
 namespace cereal {
 class access;
@@ -27,7 +27,7 @@ class ZombieAttr {
 public:
     ZombieAttr(ecf::Child::ZombieType t,
                const std::vector<ecf::Child::CmdType>& c,
-               ecf::User::Action a,
+               ecf::ZombieCtrlAction a,
                int zombie_lifetime = 0);
     ZombieAttr() = default;
 
@@ -36,7 +36,7 @@ public:
     bool empty() const { return zombie_type_ == ecf::Child::NOT_SET; }
 
     ecf::Child::ZombieType zombie_type() const { return zombie_type_; }
-    ecf::User::Action action() const { return action_; }
+    ecf::ZombieCtrlAction action() const { return action_; }
     int zombie_lifetime() const { return zombie_lifetime_; }
     const std::vector<ecf::Child::CmdType>& child_cmds() const { return child_cmds_; }
 
@@ -71,10 +71,10 @@ private:
     void write(std::string&) const;
 
 private:
-    std::vector<ecf::Child::CmdType> child_cmds_;             // init, event, meter,label, complete
-    ecf::Child::ZombieType zombie_type_{ecf::Child::NOT_SET}; // User,path or ecf
-    ecf::User::Action action_{ecf::User::BLOCK};              // fob, fail,remove, adopt, block, kill
-    int zombie_lifetime_{0};                                  // How long zombie lives in server
+    std::vector<ecf::Child::CmdType> child_cmds_;                // init, event, meter,label, complete
+    ecf::Child::ZombieType zombie_type_{ecf::Child::NOT_SET};    // User,path or ecf
+    ecf::ZombieCtrlAction action_{ecf::ZombieCtrlAction::BLOCK}; // fob, fail,remove, adopt, block, kill
+    int zombie_lifetime_{0};                                     // How long zombie lives in server
 
     friend class cereal::access;
     template <class Archive>

--- a/libs/attribute/test/TestAttrSerialization.cpp
+++ b/libs/attribute/test/TestAttrSerialization.cpp
@@ -344,12 +344,12 @@ BOOST_AUTO_TEST_CASE(test_zombie_attr_serialisation) {
 
     std::vector<ecf::Child::CmdType> child_cmds = ecf::Child::list();
 
-    doSaveAndRestore(fileName, ZombieAttr(ecf::Child::USER, child_cmds, ecf::User::FOB, 10));
-    doSaveAndRestore(fileName, ZombieAttr(ecf::Child::PATH, child_cmds, ecf::User::FAIL, 10));
-    doSaveAndRestore(fileName, ZombieAttr(ecf::Child::ECF, child_cmds, ecf::User::BLOCK, 10));
-    doSaveAndRestore(fileName, ZombieAttr(ecf::Child::ECF_PID, child_cmds, ecf::User::REMOVE, 10));
-    doSaveAndRestore(fileName, ZombieAttr(ecf::Child::ECF_PID_PASSWD, child_cmds, ecf::User::KILL, 10));
-    doSaveAndRestore(fileName, ZombieAttr(ecf::Child::ECF_PASSWD, child_cmds, ecf::User::ADOPT, 10));
+    doSaveAndRestore(fileName, ZombieAttr(ecf::Child::USER, child_cmds, ecf::ZombieCtrlAction::FOB, 10));
+    doSaveAndRestore(fileName, ZombieAttr(ecf::Child::PATH, child_cmds, ecf::ZombieCtrlAction::FAIL, 10));
+    doSaveAndRestore(fileName, ZombieAttr(ecf::Child::ECF, child_cmds, ecf::ZombieCtrlAction::BLOCK, 10));
+    doSaveAndRestore(fileName, ZombieAttr(ecf::Child::ECF_PID, child_cmds, ecf::ZombieCtrlAction::REMOVE, 10));
+    doSaveAndRestore(fileName, ZombieAttr(ecf::Child::ECF_PID_PASSWD, child_cmds, ecf::ZombieCtrlAction::KILL, 10));
+    doSaveAndRestore(fileName, ZombieAttr(ecf::Child::ECF_PASSWD, child_cmds, ecf::ZombieCtrlAction::ADOPT, 10));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/attribute/test/TestMigration.cpp
+++ b/libs/attribute/test/TestMigration.cpp
@@ -167,8 +167,8 @@ BOOST_AUTO_TEST_CASE(test_migration_restore) {
     doSave(file_name + "Event_2", Event("event"));
     doSave(file_name + "Event_3", Event(1, "event", true));
     doSave(file_name + "Meter", Meter("meter", 10, 100, 100));
-    doSave(file_name + "ZombieAttr", ZombieAttr(ecf::Child::USER, child_cmds, ecf::User::FOB));
-    doSave(file_name + "ZombieAttr1", ZombieAttr(ecf::Child::USER, child_cmds, ecf::User::FOB, 500));
+    doSave(file_name + "ZombieAttr", ZombieAttr(ecf::Child::USER, child_cmds, ecf::UserAction::FOB));
+    doSave(file_name + "ZombieAttr1", ZombieAttr(ecf::Child::USER, child_cmds, ecf::UserAction::FOB, 500));
     doSave(file_name + "QueueAttr", QueueAttr("queue", theVec));
     doSave(file_name + "GenericAttr", GenericAttr("gen1", theVec));
 #endif
@@ -196,8 +196,10 @@ BOOST_AUTO_TEST_CASE(test_migration_restore) {
     do_restore<Event>(file_name + "Event_2", Event(string("event")));
     do_restore<Event>(file_name + "Event_3", Event(1, string("event"), true));
     do_restore<Meter>(file_name + "Meter", Meter("meter", 10, 100, 100));
-    do_restore<ZombieAttr>(file_name + "ZombieAttr", ZombieAttr(ecf::Child::USER, child_cmds, ecf::User::FOB));
-    do_restore<ZombieAttr>(file_name + "ZombieAttr1", ZombieAttr(ecf::Child::USER, child_cmds, ecf::User::FOB, 500));
+    do_restore<ZombieAttr>(file_name + "ZombieAttr",
+                           ZombieAttr(ecf::Child::USER, child_cmds, ecf::ZombieCtrlAction::FOB));
+    do_restore<ZombieAttr>(file_name + "ZombieAttr1",
+                           ZombieAttr(ecf::Child::USER, child_cmds, ecf::ZombieCtrlAction::FOB, 500));
     do_restore<QueueAttr>(file_name + "QueueAttr", QueueAttr("queue", theVec));
     do_restore<GenericAttr>(file_name + "GenericAttr", GenericAttr("gen1", theVec));
 }

--- a/libs/attribute/test/TestZombieAttr.cpp
+++ b/libs/attribute/test/TestZombieAttr.cpp
@@ -26,58 +26,67 @@ BOOST_AUTO_TEST_CASE(test_zombie_attr) {
     ECF_NAME_THIS_TEST();
 
     {
-        ZombieAttr ecf(ecf::Child::ECF, std::vector<ecf::Child::CmdType>(), ecf::User::FAIL);
+        ZombieAttr ecf(ecf::Child::ECF, std::vector<ecf::Child::CmdType>(), ecf::ZombieCtrlAction::FAIL);
         BOOST_CHECK_MESSAGE(ecf.zombie_lifetime() == ZombieAttr::default_ecf_zombie_life_time(),
                             "expected " << ZombieAttr::default_ecf_zombie_life_time() << " but got "
                                         << ecf.zombie_lifetime());
 
-        ZombieAttr user(ecf::Child::USER, std::vector<ecf::Child::CmdType>(), ecf::User::FAIL);
+        ZombieAttr user(ecf::Child::USER, std::vector<ecf::Child::CmdType>(), ecf::ZombieCtrlAction::FAIL);
         BOOST_CHECK_MESSAGE(user.zombie_lifetime() == ZombieAttr::default_user_zombie_life_time(),
                             "Zombie life time not as expected");
 
-        ZombieAttr path(ecf::Child::PATH, std::vector<ecf::Child::CmdType>(), ecf::User::FAIL);
+        ZombieAttr path(ecf::Child::PATH, std::vector<ecf::Child::CmdType>(), ecf::ZombieCtrlAction::FAIL);
         BOOST_CHECK_MESSAGE(path.zombie_lifetime() == ZombieAttr::default_path_zombie_life_time(),
                             "Zombie life time not as expected");
     }
     {
         int zombie_life_time = 0;
-        ZombieAttr ecf(ecf::Child::ECF, std::vector<ecf::Child::CmdType>(), ecf::User::FAIL, zombie_life_time);
+        ZombieAttr ecf(
+            ecf::Child::ECF, std::vector<ecf::Child::CmdType>(), ecf::ZombieCtrlAction::FAIL, zombie_life_time);
         BOOST_CHECK_MESSAGE(ecf.zombie_lifetime() == ZombieAttr::default_ecf_zombie_life_time(),
                             "Zombie life time not as expected");
 
-        ZombieAttr user(ecf::Child::USER, std::vector<ecf::Child::CmdType>(), ecf::User::FAIL, zombie_life_time);
+        ZombieAttr user(
+            ecf::Child::USER, std::vector<ecf::Child::CmdType>(), ecf::ZombieCtrlAction::FAIL, zombie_life_time);
         BOOST_CHECK_MESSAGE(user.zombie_lifetime() == ZombieAttr::default_user_zombie_life_time(),
                             "Zombie life time not as expected");
 
-        ZombieAttr path(ecf::Child::PATH, std::vector<ecf::Child::CmdType>(), ecf::User::FAIL, zombie_life_time);
+        ZombieAttr path(
+            ecf::Child::PATH, std::vector<ecf::Child::CmdType>(), ecf::ZombieCtrlAction::FAIL, zombie_life_time);
         BOOST_CHECK_MESSAGE(path.zombie_lifetime() == ZombieAttr::default_path_zombie_life_time(),
                             "Zombie life time not as expected");
     }
     {
         int zombie_life_time = -1;
-        ZombieAttr ecf(ecf::Child::ECF, std::vector<ecf::Child::CmdType>(), ecf::User::FAIL, zombie_life_time);
+        ZombieAttr ecf(
+            ecf::Child::ECF, std::vector<ecf::Child::CmdType>(), ecf::ZombieCtrlAction::FAIL, zombie_life_time);
         BOOST_CHECK_MESSAGE(ecf.zombie_lifetime() == ZombieAttr::default_ecf_zombie_life_time(),
                             "Zombie life time not as expected");
 
-        ZombieAttr user(ecf::Child::USER, std::vector<ecf::Child::CmdType>(), ecf::User::FAIL, zombie_life_time);
+        ZombieAttr user(
+            ecf::Child::USER, std::vector<ecf::Child::CmdType>(), ecf::ZombieCtrlAction::FAIL, zombie_life_time);
         BOOST_CHECK_MESSAGE(user.zombie_lifetime() == ZombieAttr::default_user_zombie_life_time(),
                             "Zombie life time not as expected");
 
-        ZombieAttr path(ecf::Child::PATH, std::vector<ecf::Child::CmdType>(), ecf::User::FAIL, zombie_life_time);
+        ZombieAttr path(
+            ecf::Child::PATH, std::vector<ecf::Child::CmdType>(), ecf::ZombieCtrlAction::FAIL, zombie_life_time);
         BOOST_CHECK_MESSAGE(path.zombie_lifetime() == ZombieAttr::default_path_zombie_life_time(),
                             "Zombie life time not as expected");
     }
     {
         int zombie_life_time = 29;
-        ZombieAttr ecf(ecf::Child::ECF, std::vector<ecf::Child::CmdType>(), ecf::User::FAIL, zombie_life_time);
+        ZombieAttr ecf(
+            ecf::Child::ECF, std::vector<ecf::Child::CmdType>(), ecf::ZombieCtrlAction::FAIL, zombie_life_time);
         BOOST_CHECK_MESSAGE(ecf.zombie_lifetime() == ZombieAttr::minimum_zombie_life_time(),
                             "Zombie life time not as expected");
 
-        ZombieAttr user(ecf::Child::USER, std::vector<ecf::Child::CmdType>(), ecf::User::FAIL, zombie_life_time);
+        ZombieAttr user(
+            ecf::Child::USER, std::vector<ecf::Child::CmdType>(), ecf::ZombieCtrlAction::FAIL, zombie_life_time);
         BOOST_CHECK_MESSAGE(user.zombie_lifetime() == ZombieAttr::minimum_zombie_life_time(),
                             "Zombie life time not as expected");
 
-        ZombieAttr path(ecf::Child::PATH, std::vector<ecf::Child::CmdType>(), ecf::User::FAIL, zombie_life_time);
+        ZombieAttr path(
+            ecf::Child::PATH, std::vector<ecf::Child::CmdType>(), ecf::ZombieCtrlAction::FAIL, zombie_life_time);
         BOOST_CHECK_MESSAGE(path.zombie_lifetime() == ZombieAttr::minimum_zombie_life_time(),
                             "Zombie life time not as expected");
     }
@@ -89,7 +98,7 @@ BOOST_AUTO_TEST_CASE(test_zombie_attr_parsing) {
     {
         ZombieAttr zombie = ZombieAttr::create("user:fob::");
         BOOST_CHECK_MESSAGE(zombie.zombie_type() == ecf::Child::USER, "Type not as expected");
-        BOOST_CHECK_MESSAGE(zombie.action() == ecf::User::FOB, "action not as expected");
+        BOOST_CHECK_MESSAGE(zombie.action() == ecf::ZombieCtrlAction::FOB, "action not as expected");
         BOOST_CHECK_MESSAGE(zombie.zombie_lifetime() == ZombieAttr::default_user_zombie_life_time(),
                             "Zombie life time not as expected");
         BOOST_CHECK_MESSAGE(zombie.child_cmds().empty(), "Expected no children");
@@ -97,7 +106,7 @@ BOOST_AUTO_TEST_CASE(test_zombie_attr_parsing) {
     {
         ZombieAttr zombie = ZombieAttr::create("ecf:fail::");
         BOOST_CHECK_MESSAGE(zombie.zombie_type() == ecf::Child::ECF, "Type not as expected");
-        BOOST_CHECK_MESSAGE(zombie.action() == ecf::User::FAIL, "action not as expected");
+        BOOST_CHECK_MESSAGE(zombie.action() == ecf::ZombieCtrlAction::FAIL, "action not as expected");
         BOOST_CHECK_MESSAGE(zombie.zombie_lifetime() == ZombieAttr::default_ecf_zombie_life_time(),
                             "Zombie life time not as expected");
         BOOST_CHECK_MESSAGE(zombie.child_cmds().empty(), "Expected no children");
@@ -105,7 +114,7 @@ BOOST_AUTO_TEST_CASE(test_zombie_attr_parsing) {
     {
         ZombieAttr zombie = ZombieAttr::create("path:fail::");
         BOOST_CHECK_MESSAGE(zombie.zombie_type() == ecf::Child::PATH, "Type not as expected");
-        BOOST_CHECK_MESSAGE(zombie.action() == ecf::User::FAIL, "action not as expected");
+        BOOST_CHECK_MESSAGE(zombie.action() == ecf::ZombieCtrlAction::FAIL, "action not as expected");
         BOOST_CHECK_MESSAGE(zombie.zombie_lifetime() == ZombieAttr::default_path_zombie_life_time(),
                             "Zombie life time not as expected");
         BOOST_CHECK_MESSAGE(zombie.child_cmds().empty(), "Expected no children");
@@ -114,7 +123,7 @@ BOOST_AUTO_TEST_CASE(test_zombie_attr_parsing) {
     {
         ZombieAttr zombie = ZombieAttr::create("user:fob::29");
         BOOST_CHECK_MESSAGE(zombie.zombie_type() == ecf::Child::USER, "Type not as expected");
-        BOOST_CHECK_MESSAGE(zombie.action() == ecf::User::FOB, "action not as expected");
+        BOOST_CHECK_MESSAGE(zombie.action() == ecf::ZombieCtrlAction::FOB, "action not as expected");
         BOOST_CHECK_MESSAGE(zombie.zombie_lifetime() == ZombieAttr::minimum_zombie_life_time(),
                             "Zombie life time < 60, should default to 60");
         BOOST_CHECK_MESSAGE(zombie.child_cmds().empty(), "Expected no children");
@@ -122,7 +131,7 @@ BOOST_AUTO_TEST_CASE(test_zombie_attr_parsing) {
     {
         ZombieAttr zombie = ZombieAttr::create("user:fob:init:29");
         BOOST_CHECK_MESSAGE(zombie.zombie_type() == ecf::Child::USER, "Type not as expected");
-        BOOST_CHECK_MESSAGE(zombie.action() == ecf::User::FOB, "action not as expected");
+        BOOST_CHECK_MESSAGE(zombie.action() == ecf::ZombieCtrlAction::FOB, "action not as expected");
         BOOST_CHECK_MESSAGE(zombie.zombie_lifetime() == ZombieAttr::minimum_zombie_life_time(),
                             "Zombie life time < 60, should default to 60");
         BOOST_CHECK_MESSAGE(zombie.child_cmds().size() == 1, "Expected one child");

--- a/libs/base/src/ecflow/base/cts/CtsCmdRegistry.cpp
+++ b/libs/base/src/ecflow/base/cts/CtsCmdRegistry.cpp
@@ -93,12 +93,12 @@ CtsCmdRegistry::CtsCmdRegistry(bool addGroupCmd) {
     vec_.push_back(std::make_shared<PathsCmd>(PathsCmd::EDIT_HISTORY));
     vec_.push_back(std::make_shared<PathsCmd>(PathsCmd::ARCHIVE));
     vec_.push_back(std::make_shared<PathsCmd>(PathsCmd::RESTORE));
-    vec_.push_back(std::make_shared<ZombieCmd>(ecf::User::FOB));
-    vec_.push_back(std::make_shared<ZombieCmd>(ecf::User::FAIL));
-    vec_.push_back(std::make_shared<ZombieCmd>(ecf::User::ADOPT));
-    vec_.push_back(std::make_shared<ZombieCmd>(ecf::User::BLOCK));
-    vec_.push_back(std::make_shared<ZombieCmd>(ecf::User::REMOVE));
-    vec_.push_back(std::make_shared<ZombieCmd>(ecf::User::KILL));
+    vec_.push_back(std::make_shared<ZombieCmd>(ecf::ZombieCtrlAction::FOB));
+    vec_.push_back(std::make_shared<ZombieCmd>(ecf::ZombieCtrlAction::FAIL));
+    vec_.push_back(std::make_shared<ZombieCmd>(ecf::ZombieCtrlAction::ADOPT));
+    vec_.push_back(std::make_shared<ZombieCmd>(ecf::ZombieCtrlAction::BLOCK));
+    vec_.push_back(std::make_shared<ZombieCmd>(ecf::ZombieCtrlAction::REMOVE));
+    vec_.push_back(std::make_shared<ZombieCmd>(ecf::ZombieCtrlAction::KILL));
     vec_.push_back(std::make_shared<CtsCmd>(CtsCmd::GET_ZOMBIES));
     vec_.push_back(std::make_shared<CtsCmd>(CtsCmd::SUITES));
     vec_.push_back(std::make_shared<ClientHandleCmd>(ClientHandleCmd::REGISTER));

--- a/libs/base/src/ecflow/base/cts/user/UserCmd.cpp
+++ b/libs/base/src/ecflow/base/cts/user/UserCmd.cpp
@@ -159,7 +159,7 @@ bool UserCmd::setup_user_authentification(AbstractClientEnv& clientEnv) {
     }
 
     // User name is same as login name, if ECF_PASSWD is defined on server side *ALL* user must provide a password.
-    std::string the_user      = User::login_name();
+    std::string the_user      = get_login_name();
     const std::string& passwd = clientEnv.get_user_password(the_user);
     setup_user_authentification(the_user, passwd);
     return true;
@@ -167,7 +167,7 @@ bool UserCmd::setup_user_authentification(AbstractClientEnv& clientEnv) {
 
 void UserCmd::setup_user_authentification() {
     if (user_.empty()) {
-        setup_user_authentification(User::login_name(), Str::EMPTY());
+        setup_user_authentification(get_login_name(), Str::EMPTY());
     }
 }
 

--- a/libs/base/src/ecflow/base/cts/user/ZombieCmd.cpp
+++ b/libs/base/src/ecflow/base/cts/user/ZombieCmd.cpp
@@ -26,22 +26,22 @@ namespace po = boost::program_options;
 
 void ZombieCmd::print(std::string& os) const {
     switch (user_action_) {
-        case User::FOB:
+        case ZombieCtrlAction::FOB:
             user_cmd(os, CtsApi::to_string(CtsApi::zombieFob(paths_, process_id_, password_)));
             break;
-        case User::FAIL:
+        case ZombieCtrlAction::FAIL:
             user_cmd(os, CtsApi::to_string(CtsApi::zombieFail(paths_, process_id_, password_)));
             break;
-        case User::ADOPT:
+        case ZombieCtrlAction::ADOPT:
             user_cmd(os, CtsApi::to_string(CtsApi::zombieAdopt(paths_, process_id_, password_)));
             break;
-        case User::REMOVE:
+        case ZombieCtrlAction::REMOVE:
             user_cmd(os, CtsApi::to_string(CtsApi::zombieRemove(paths_, process_id_, password_)));
             break;
-        case User::BLOCK:
+        case ZombieCtrlAction::BLOCK:
             user_cmd(os, CtsApi::to_string(CtsApi::zombieBlock(paths_, process_id_, password_)));
             break;
-        case User::KILL:
+        case ZombieCtrlAction::KILL:
             user_cmd(os, CtsApi::to_string(CtsApi::zombieKill(paths_, process_id_, password_)));
             break;
         default:
@@ -51,22 +51,22 @@ void ZombieCmd::print(std::string& os) const {
 
 void ZombieCmd::print_only(std::string& os) const {
     switch (user_action_) {
-        case User::FOB:
+        case ZombieCtrlAction::FOB:
             os += CtsApi::to_string(CtsApi::zombieFob(paths_, process_id_, password_));
             break;
-        case User::FAIL:
+        case ZombieCtrlAction::FAIL:
             os += CtsApi::to_string(CtsApi::zombieFail(paths_, process_id_, password_));
             break;
-        case User::ADOPT:
+        case ZombieCtrlAction::ADOPT:
             os += CtsApi::to_string(CtsApi::zombieAdopt(paths_, process_id_, password_));
             break;
-        case User::REMOVE:
+        case ZombieCtrlAction::REMOVE:
             os += CtsApi::to_string(CtsApi::zombieRemove(paths_, process_id_, password_));
             break;
-        case User::BLOCK:
+        case ZombieCtrlAction::BLOCK:
             os += CtsApi::to_string(CtsApi::zombieBlock(paths_, process_id_, password_));
             break;
-        case User::KILL:
+        case ZombieCtrlAction::KILL:
             os += CtsApi::to_string(CtsApi::zombieKill(paths_, process_id_, password_));
             break;
         default:
@@ -89,22 +89,22 @@ bool ZombieCmd::equals(ClientToServerCmd* rhs) const {
 
 STC_Cmd_ptr ZombieCmd::doHandleRequest(AbstractServer* as) const {
     switch (user_action_) {
-        case User::FOB:
+        case ZombieCtrlAction::FOB:
             as->update_stats().zombie_fob_++;
             break;
-        case User::FAIL:
+        case ZombieCtrlAction::FAIL:
             as->update_stats().zombie_fail_++;
             break;
-        case User::ADOPT:
+        case ZombieCtrlAction::ADOPT:
             as->update_stats().zombie_adopt_++;
             break;
-        case User::REMOVE:
+        case ZombieCtrlAction::REMOVE:
             as->update_stats().zombie_remove_++;
             break;
-        case User::BLOCK:
+        case ZombieCtrlAction::BLOCK:
             as->update_stats().zombie_block_++;
             break;
-        case User::KILL:
+        case ZombieCtrlAction::KILL:
             as->update_stats().zombie_kill_++;
             break;
     }
@@ -120,22 +120,22 @@ STC_Cmd_ptr ZombieCmd::doHandleRequest(AbstractServer* as) const {
             if (node.get())
                 task = node->isTask();
             switch (user_action_) {
-                case User::FOB:
+                case ZombieCtrlAction::FOB:
                     as->zombie_ctrl().fobCli(path, task);
                     break;
-                case User::FAIL:
+                case ZombieCtrlAction::FAIL:
                     as->zombie_ctrl().failCli(path, task);
                     break;
-                case User::ADOPT:
+                case ZombieCtrlAction::ADOPT:
                     as->zombie_ctrl().adoptCli(path, task);
                     break;
-                case User::REMOVE:
+                case ZombieCtrlAction::REMOVE:
                     as->zombie_ctrl().removeCli(path, task);
                     break;
-                case User::BLOCK:
+                case ZombieCtrlAction::BLOCK:
                     as->zombie_ctrl().blockCli(path, task);
                     break;
-                case User::KILL:
+                case ZombieCtrlAction::KILL:
                     as->zombie_ctrl().killCli(path, task);
                     break;
             }
@@ -145,22 +145,22 @@ STC_Cmd_ptr ZombieCmd::doHandleRequest(AbstractServer* as) const {
         // expect a single path, process_id and password only apply for a single task
         if (paths_.size() == 1) {
             switch (user_action_) {
-                case User::FOB:
+                case ZombieCtrlAction::FOB:
                     as->zombie_ctrl().fob(paths_[0], process_id_, password_);
                     break;
-                case User::FAIL:
+                case ZombieCtrlAction::FAIL:
                     as->zombie_ctrl().fail(paths_[0], process_id_, password_);
                     break;
-                case User::ADOPT:
+                case ZombieCtrlAction::ADOPT:
                     as->zombie_ctrl().adopt(paths_[0], process_id_, password_);
                     break;
-                case User::REMOVE:
+                case ZombieCtrlAction::REMOVE:
                     as->zombie_ctrl().remove(paths_[0], process_id_, password_);
                     break;
-                case User::BLOCK:
+                case ZombieCtrlAction::BLOCK:
                     as->zombie_ctrl().block(paths_[0], process_id_, password_);
                     break;
-                case User::KILL:
+                case ZombieCtrlAction::KILL:
                     as->zombie_ctrl().kill(paths_[0], process_id_, password_);
                     break;
             }
@@ -177,22 +177,22 @@ STC_Cmd_ptr ZombieCmd::doHandleRequest(AbstractServer* as) const {
 const char* ZombieCmd::theArg() const {
 
     switch (user_action_) {
-        case User::FOB:
+        case ZombieCtrlAction::FOB:
             return CtsApi::zombieFobArg();
             break;
-        case User::FAIL:
+        case ZombieCtrlAction::FAIL:
             return CtsApi::zombieFailArg();
             break;
-        case User::ADOPT:
+        case ZombieCtrlAction::ADOPT:
             return CtsApi::zombieAdoptArg();
             break;
-        case User::REMOVE:
+        case ZombieCtrlAction::REMOVE:
             return CtsApi::zombieRemoveArg();
             break;
-        case User::BLOCK:
+        case ZombieCtrlAction::BLOCK:
             return CtsApi::zombieBlockArg();
             break;
-        case User::KILL:
+        case ZombieCtrlAction::KILL:
             return CtsApi::zombieKillArg();
             break;
         default:
@@ -205,7 +205,7 @@ const char* ZombieCmd::theArg() const {
 void ZombieCmd::addOption(boost::program_options::options_description& desc) const {
     switch (user_action_) {
 
-        case User::FOB: {
+        case ZombieCtrlAction::FOB: {
             desc.add_options()(
                 CtsApi::zombieFobArg(),
                 po::value<vector<string>>()->multitoken(),
@@ -219,7 +219,7 @@ void ZombieCmd::addOption(boost::program_options::options_description& desc) con
                 "  --zombie_fob=/path/to/task1 /path/to/task2");
             break;
         }
-        case User::FAIL: {
+        case ZombieCtrlAction::FAIL: {
             desc.add_options()(CtsApi::zombieFailArg(),
                                po::value<vector<string>>()->multitoken(),
                                "Locates the task in the servers list of zombies, and sets to fail.\n"
@@ -233,7 +233,7 @@ void ZombieCmd::addOption(boost::program_options::options_description& desc) con
                                "  --zombie_fail=/path/to/task  /path/to/task2");
             break;
         }
-        case User::ADOPT: {
+        case ZombieCtrlAction::ADOPT: {
             desc.add_options()(CtsApi::zombieAdoptArg(),
                                po::value<vector<string>>()->multitoken(),
                                "Locates the task in the servers list of zombies, and sets to adopt.\n"
@@ -245,7 +245,7 @@ void ZombieCmd::addOption(boost::program_options::options_description& desc) con
                                "  --zombie_adopt=/path/to/task  /path/to/task2");
             break;
         }
-        case User::REMOVE: {
+        case ZombieCtrlAction::REMOVE: {
             desc.add_options()(
                 CtsApi::zombieRemoveArg(),
                 po::value<vector<string>>()->multitoken(),
@@ -256,7 +256,7 @@ void ZombieCmd::addOption(boost::program_options::options_description& desc) con
                 "  --zombie_remove=/path/to/task  /path/to/task2");
             break;
         }
-        case User::BLOCK: {
+        case ZombieCtrlAction::BLOCK: {
             desc.add_options()(CtsApi::zombieBlockArg(),
                                po::value<vector<string>>()->multitoken(),
                                "Locates the task in the servers list of zombies, and sets flags to block it.\n"
@@ -268,7 +268,7 @@ void ZombieCmd::addOption(boost::program_options::options_description& desc) con
                                "  --zombie_block=/path/to/task  /path/to/task2");
             break;
         }
-        case User::KILL: {
+        case ZombieCtrlAction::KILL: {
             desc.add_options()(CtsApi::zombieKillArg(),
                                po::value<vector<string>>()->multitoken(),
                                "Locates the task in the servers list of zombies, and sets flags to kill\n"

--- a/libs/base/src/ecflow/base/cts/user/ZombieCmd.hpp
+++ b/libs/base/src/ecflow/base/cts/user/ZombieCmd.hpp
@@ -12,11 +12,11 @@
 #define ecflow_base_cts_user_ZombieCmd_HPP
 
 #include "ecflow/base/cts/user/UserCmd.hpp"
-#include "ecflow/core/User.hpp"
+#include "ecflow/core/ZombieCtrlAction.hpp"
 
 class ZombieCmd final : public UserCmd {
 public:
-    ZombieCmd(ecf::User::Action uc,
+    ZombieCmd(ecf::ZombieCtrlAction uc,
               const std::vector<std::string>& paths,
               const std::string& process_id,
               const std::string& password)
@@ -24,7 +24,7 @@ public:
           process_id_(process_id),
           password_(password),
           paths_(paths) {}
-    explicit ZombieCmd(ecf::User::Action uc = ecf::User::BLOCK) : user_action_(uc) {}
+    explicit ZombieCmd(ecf::ZombieCtrlAction uc = ecf::ZombieCtrlAction::BLOCK) : user_action_(uc) {}
 
     const std::vector<std::string>& paths() const { return paths_; }
     const std::string& process_or_remote_id() const { return process_id_; }
@@ -42,7 +42,7 @@ private:
     STC_Cmd_ptr doHandleRequest(AbstractServer*) const override;
     void cleanup() override { std::vector<std::string>().swap(paths_); } /// run in the server, after handlerequest
 
-    ecf::User::Action user_action_;
+    ecf::ZombieCtrlAction user_action_;
     std::string process_id_; // should be empty for multiple paths and when using CLI
     std::string password_;   // should be empty for multiple paths and when using CLI
     std::vector<std::string> paths_;

--- a/libs/base/test/TestRequest.cpp
+++ b/libs/base/test/TestRequest.cpp
@@ -134,23 +134,23 @@ populateCmdVec(std::vector<Cmd_ptr>& cmd_vec, std::vector<STC_Cmd_ptr>& stc_cmd_
     cmd_vec.push_back(Cmd_ptr(new CtsNodeCmd(CtsNodeCmd::GET, "")));                          // return the full defs
     cmd_vec.push_back(Cmd_ptr(new CtsNodeCmd(CtsNodeCmd::GET_STATE, "")));
     cmd_vec.push_back(Cmd_ptr(new CtsNodeCmd(CtsNodeCmd::MIGRATE, "")));
-    cmd_vec.push_back(Cmd_ptr(new ZombieCmd(ecf::User::FOB,
+    cmd_vec.push_back(Cmd_ptr(new ZombieCmd(ecf::ZombieCtrlAction::FOB,
                                             std::vector<std::string>(1, "/suiteName/familyName/taskName"),
                                             Submittable::DUMMY_PROCESS_OR_REMOTE_ID(),
                                             Submittable::DUMMY_JOBS_PASSWORD())));
-    cmd_vec.push_back(Cmd_ptr(new ZombieCmd(ecf::User::FAIL,
+    cmd_vec.push_back(Cmd_ptr(new ZombieCmd(ecf::ZombieCtrlAction::FAIL,
                                             std::vector<std::string>(1, "/suiteName/familyName/taskName"),
                                             Submittable::DUMMY_PROCESS_OR_REMOTE_ID(),
                                             Submittable::DUMMY_JOBS_PASSWORD())));
-    cmd_vec.push_back(Cmd_ptr(new ZombieCmd(ecf::User::ADOPT,
+    cmd_vec.push_back(Cmd_ptr(new ZombieCmd(ecf::ZombieCtrlAction::ADOPT,
                                             std::vector<std::string>(1, "/suiteName/familyName/taskName"),
                                             Submittable::DUMMY_PROCESS_OR_REMOTE_ID(),
                                             Submittable::DUMMY_JOBS_PASSWORD())));
-    cmd_vec.push_back(Cmd_ptr(new ZombieCmd(ecf::User::REMOVE,
+    cmd_vec.push_back(Cmd_ptr(new ZombieCmd(ecf::ZombieCtrlAction::REMOVE,
                                             std::vector<std::string>(1, "/suiteName/familyName/taskName"),
                                             Submittable::DUMMY_PROCESS_OR_REMOTE_ID(),
                                             Submittable::DUMMY_JOBS_PASSWORD())));
-    cmd_vec.push_back(Cmd_ptr(new ZombieCmd(ecf::User::KILL,
+    cmd_vec.push_back(Cmd_ptr(new ZombieCmd(ecf::ZombieCtrlAction::KILL,
                                             std::vector<std::string>(1, "/suiteName/familyName/taskName"),
                                             Submittable::DUMMY_PROCESS_OR_REMOTE_ID(),
                                             Submittable::DUMMY_JOBS_PASSWORD())));
@@ -251,27 +251,27 @@ populateCmdVec(std::vector<Cmd_ptr>& cmd_vec, std::vector<STC_Cmd_ptr>& stc_cmd_
     theGroupCmd->addChild(Cmd_ptr(new CtsNodeCmd(CtsNodeCmd::GET_STATE, "EmptySuite")));
     theGroupCmd->addChild(Cmd_ptr(new CtsNodeCmd(CtsNodeCmd::MIGRATE, "EmptySuite")));
     theGroupCmd->addChild(Cmd_ptr(new ShowCmd()));
-    theGroupCmd->addChild(Cmd_ptr(new ZombieCmd(ecf::User::FOB,
+    theGroupCmd->addChild(Cmd_ptr(new ZombieCmd(ecf::ZombieCtrlAction::FOB,
                                                 std::vector<std::string>(1, "/suiteName/familyName/taskName"),
                                                 Submittable::DUMMY_PROCESS_OR_REMOTE_ID(),
                                                 Submittable::DUMMY_JOBS_PASSWORD())));
-    theGroupCmd->addChild(Cmd_ptr(new ZombieCmd(ecf::User::FAIL,
+    theGroupCmd->addChild(Cmd_ptr(new ZombieCmd(ecf::ZombieCtrlAction::FAIL,
                                                 std::vector<std::string>(1, "/suiteName/familyName/taskName"),
                                                 Submittable::DUMMY_PROCESS_OR_REMOTE_ID(),
                                                 Submittable::DUMMY_JOBS_PASSWORD())));
-    theGroupCmd->addChild(Cmd_ptr(new ZombieCmd(ecf::User::ADOPT,
+    theGroupCmd->addChild(Cmd_ptr(new ZombieCmd(ecf::ZombieCtrlAction::ADOPT,
                                                 std::vector<std::string>(1, "/suiteName/familyName/taskName"),
                                                 Submittable::DUMMY_PROCESS_OR_REMOTE_ID(),
                                                 Submittable::DUMMY_JOBS_PASSWORD())));
-    theGroupCmd->addChild(Cmd_ptr(new ZombieCmd(ecf::User::REMOVE,
+    theGroupCmd->addChild(Cmd_ptr(new ZombieCmd(ecf::ZombieCtrlAction::REMOVE,
                                                 std::vector<std::string>(1, "/suiteName/familyName/taskName"),
                                                 Submittable::DUMMY_PROCESS_OR_REMOTE_ID(),
                                                 Submittable::DUMMY_JOBS_PASSWORD())));
-    theGroupCmd->addChild(Cmd_ptr(new ZombieCmd(ecf::User::KILL,
+    theGroupCmd->addChild(Cmd_ptr(new ZombieCmd(ecf::ZombieCtrlAction::KILL,
                                                 std::vector<std::string>(1, "/suiteName/familyName/taskName"),
                                                 Submittable::DUMMY_PROCESS_OR_REMOTE_ID(),
                                                 Submittable::DUMMY_JOBS_PASSWORD())));
-    theGroupCmd->addChild(Cmd_ptr(new ZombieCmd(ecf::User::BLOCK,
+    theGroupCmd->addChild(Cmd_ptr(new ZombieCmd(ecf::ZombieCtrlAction::BLOCK,
                                                 std::vector<std::string>(1, "/suiteName/familyName/taskName"),
                                                 Submittable::DUMMY_PROCESS_OR_REMOTE_ID(),
                                                 Submittable::DUMMY_JOBS_PASSWORD())));

--- a/libs/client/src/ecflow/client/ClientInvoker.cpp
+++ b/libs/client/src/ecflow/client/ClientInvoker.cpp
@@ -899,104 +899,121 @@ int ClientInvoker::zombieFob(const Zombie& z) const {
     if (testInterface_)
         return invoke(CtsApi::zombieFob(
             std::vector<std::string>(1, z.path_to_task()), z.process_or_remote_id(), z.jobs_password()));
-    return invoke(std::make_shared<ZombieCmd>(
-        User::FOB, std::vector<std::string>(1, z.path_to_task()), z.process_or_remote_id(), z.jobs_password()));
+    return invoke(std::make_shared<ZombieCmd>(ZombieCtrlAction::FOB,
+                                              std::vector<std::string>(1, z.path_to_task()),
+                                              z.process_or_remote_id(),
+                                              z.jobs_password()));
 }
 int ClientInvoker::zombieFail(const Zombie& z) const {
     if (testInterface_)
         return invoke(CtsApi::zombieFail(
             std::vector<std::string>(1, z.path_to_task()), z.process_or_remote_id(), z.jobs_password()));
-    return invoke(std::make_shared<ZombieCmd>(
-        User::FAIL, std::vector<std::string>(1, z.path_to_task()), z.process_or_remote_id(), z.jobs_password()));
+    return invoke(std::make_shared<ZombieCmd>(ZombieCtrlAction::FAIL,
+                                              std::vector<std::string>(1, z.path_to_task()),
+                                              z.process_or_remote_id(),
+                                              z.jobs_password()));
 }
 int ClientInvoker::zombieAdopt(const Zombie& z) const {
     if (testInterface_)
         return invoke(CtsApi::zombieAdopt(
             std::vector<std::string>(1, z.path_to_task()), z.process_or_remote_id(), z.jobs_password()));
-    return invoke(std::make_shared<ZombieCmd>(
-        User::ADOPT, std::vector<std::string>(1, z.path_to_task()), z.process_or_remote_id(), z.jobs_password()));
+    return invoke(std::make_shared<ZombieCmd>(ZombieCtrlAction::ADOPT,
+                                              std::vector<std::string>(1, z.path_to_task()),
+                                              z.process_or_remote_id(),
+                                              z.jobs_password()));
 }
 int ClientInvoker::zombieBlock(const Zombie& z) const {
     if (testInterface_)
         return invoke(CtsApi::zombieBlock(
             std::vector<std::string>(1, z.path_to_task()), z.process_or_remote_id(), z.jobs_password()));
-    return invoke(std::make_shared<ZombieCmd>(
-        User::BLOCK, std::vector<std::string>(1, z.path_to_task()), z.process_or_remote_id(), z.jobs_password()));
+    return invoke(std::make_shared<ZombieCmd>(ZombieCtrlAction::BLOCK,
+                                              std::vector<std::string>(1, z.path_to_task()),
+                                              z.process_or_remote_id(),
+                                              z.jobs_password()));
 }
 int ClientInvoker::zombieRemove(const Zombie& z) const {
     if (testInterface_)
         return invoke(CtsApi::zombieRemove(
             std::vector<std::string>(1, z.path_to_task()), z.process_or_remote_id(), z.jobs_password()));
-    return invoke(std::make_shared<ZombieCmd>(
-        User::REMOVE, std::vector<std::string>(1, z.path_to_task()), z.process_or_remote_id(), z.jobs_password()));
+    return invoke(std::make_shared<ZombieCmd>(ZombieCtrlAction::REMOVE,
+                                              std::vector<std::string>(1, z.path_to_task()),
+                                              z.process_or_remote_id(),
+                                              z.jobs_password()));
 }
 int ClientInvoker::zombieKill(const Zombie& z) const {
     if (testInterface_)
         return invoke(CtsApi::zombieKill(
             std::vector<std::string>(1, z.path_to_task()), z.process_or_remote_id(), z.jobs_password()));
-    return invoke(std::make_shared<ZombieCmd>(
-        User::KILL, std::vector<std::string>(1, z.path_to_task()), z.process_or_remote_id(), z.jobs_password()));
+    return invoke(std::make_shared<ZombieCmd>(ZombieCtrlAction::KILL,
+                                              std::vector<std::string>(1, z.path_to_task()),
+                                              z.process_or_remote_id(),
+                                              z.jobs_password()));
 }
 int ClientInvoker::zombieFobCli(const std::string& absNodePath) const {
     if (testInterface_)
         return invoke(CtsApi::zombieFobCli(absNodePath));
-    return invoke(std::make_shared<ZombieCmd>(User::FOB, std::vector<std::string>(1, absNodePath), "", ""));
+    return invoke(std::make_shared<ZombieCmd>(ZombieCtrlAction::FOB, std::vector<std::string>(1, absNodePath), "", ""));
 }
 int ClientInvoker::zombieFailCli(const std::string& absNodePath) const {
     if (testInterface_)
         return invoke(CtsApi::zombieFailCli(absNodePath));
-    return invoke(std::make_shared<ZombieCmd>(User::FAIL, std::vector<std::string>(1, absNodePath), "", ""));
+    return invoke(
+        std::make_shared<ZombieCmd>(ZombieCtrlAction::FAIL, std::vector<std::string>(1, absNodePath), "", ""));
 }
 int ClientInvoker::zombieAdoptCli(const std::string& absNodePath) const {
     if (testInterface_)
         return invoke(CtsApi::zombieAdoptCli(absNodePath));
-    return invoke(std::make_shared<ZombieCmd>(User::ADOPT, std::vector<std::string>(1, absNodePath), "", ""));
+    return invoke(
+        std::make_shared<ZombieCmd>(ZombieCtrlAction::ADOPT, std::vector<std::string>(1, absNodePath), "", ""));
 }
 int ClientInvoker::zombieBlockCli(const std::string& absNodePath) const {
     if (testInterface_)
         return invoke(CtsApi::zombieBlockCli(absNodePath));
-    return invoke(std::make_shared<ZombieCmd>(User::BLOCK, std::vector<std::string>(1, absNodePath), "", ""));
+    return invoke(
+        std::make_shared<ZombieCmd>(ZombieCtrlAction::BLOCK, std::vector<std::string>(1, absNodePath), "", ""));
 }
 int ClientInvoker::zombieRemoveCli(const std::string& absNodePath) const {
     if (testInterface_)
         return invoke(CtsApi::zombieRemoveCli(absNodePath));
-    return invoke(std::make_shared<ZombieCmd>(User::REMOVE, std::vector<std::string>(1, absNodePath), "", ""));
+    return invoke(
+        std::make_shared<ZombieCmd>(ZombieCtrlAction::REMOVE, std::vector<std::string>(1, absNodePath), "", ""));
 }
 int ClientInvoker::zombieKillCli(const std::string& absNodePath) const {
     if (testInterface_)
         return invoke(CtsApi::zombieKillCli(absNodePath));
-    return invoke(std::make_shared<ZombieCmd>(User::KILL, std::vector<std::string>(1, absNodePath), "", ""));
+    return invoke(
+        std::make_shared<ZombieCmd>(ZombieCtrlAction::KILL, std::vector<std::string>(1, absNodePath), "", ""));
 }
 
 int ClientInvoker::zombieFobCliPaths(const std::vector<std::string>& paths) const {
     if (testInterface_)
         return invoke(CtsApi::zombieFobCli(paths));
-    return invoke(std::make_shared<ZombieCmd>(User::FOB, paths, "", ""));
+    return invoke(std::make_shared<ZombieCmd>(ZombieCtrlAction::FOB, paths, "", ""));
 }
 int ClientInvoker::zombieFailCliPaths(const std::vector<std::string>& paths) const {
     if (testInterface_)
         return invoke(CtsApi::zombieFailCli(paths));
-    return invoke(std::make_shared<ZombieCmd>(User::FAIL, paths, "", ""));
+    return invoke(std::make_shared<ZombieCmd>(ZombieCtrlAction::FAIL, paths, "", ""));
 }
 int ClientInvoker::zombieAdoptCliPaths(const std::vector<std::string>& paths) const {
     if (testInterface_)
         return invoke(CtsApi::zombieAdoptCli(paths));
-    return invoke(std::make_shared<ZombieCmd>(User::ADOPT, paths, "", ""));
+    return invoke(std::make_shared<ZombieCmd>(ZombieCtrlAction::ADOPT, paths, "", ""));
 }
 int ClientInvoker::zombieBlockCliPaths(const std::vector<std::string>& paths) const {
     if (testInterface_)
         return invoke(CtsApi::zombieBlockCli(paths));
-    return invoke(std::make_shared<ZombieCmd>(User::BLOCK, paths, "", ""));
+    return invoke(std::make_shared<ZombieCmd>(ZombieCtrlAction::BLOCK, paths, "", ""));
 }
 int ClientInvoker::zombieRemoveCliPaths(const std::vector<std::string>& paths) const {
     if (testInterface_)
         return invoke(CtsApi::zombieRemoveCli(paths));
-    return invoke(std::make_shared<ZombieCmd>(User::REMOVE, paths, "", ""));
+    return invoke(std::make_shared<ZombieCmd>(ZombieCtrlAction::REMOVE, paths, "", ""));
 }
 int ClientInvoker::zombieKillCliPaths(const std::vector<std::string>& paths) const {
     if (testInterface_)
         return invoke(CtsApi::zombieKillCli(paths));
-    return invoke(std::make_shared<ZombieCmd>(User::KILL, paths, "", ""));
+    return invoke(std::make_shared<ZombieCmd>(ZombieCtrlAction::KILL, paths, "", ""));
 }
 
 // ======================================================================================================

--- a/libs/client/test/TestCustomUser.cpp
+++ b/libs/client/test/TestCustomUser.cpp
@@ -42,7 +42,7 @@ public:
         auto* put = const_cast<char*>(ecf_passwd_.c_str());
         BOOST_CHECK_MESSAGE(putenv(put) == 0, "putenv failed for " << put);
 
-        ecf_user_ += User::login_name();
+        ecf_user_ += get_login_name();
         auto* put2 = const_cast<char*>(ecf_user_.c_str());
         BOOST_CHECK_MESSAGE(putenv(put2) == 0, "putenv failed for " << put2);
     }
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(test_custom_user) {
 
         // reset to a valid user again:
         theClient.set_user_name(
-            User::login_name()); // this should clear password, so that its reloaded when *next* cmd runs
+            get_login_name()); // this should clear password, so that its reloaded when *next* cmd runs
 
         // all client command should now pass. Invoking a client request that requires authorisation
         BOOST_CHECK_MESSAGE(theClient.reloadcustompasswdfile() == 0,

--- a/libs/client/test/TestLogAndCheckptErrors.cpp
+++ b/libs/client/test/TestLogAndCheckptErrors.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(test_log_and_checkpt_write_errors) {
     }
 
     // When this test is run in Bamboo/Docker, the users is root, hence the chmod below will not work and test will fail
-    if (User::login_name() == "root") {
+    if (get_login_name() == "root") {
         cout << "Ignoring test when user is root." << endl;
         return;
     }

--- a/libs/core/src/ecflow/core/Enumerate.hpp
+++ b/libs/core/src/ecflow/core/Enumerate.hpp
@@ -16,6 +16,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace ecf {

--- a/libs/core/src/ecflow/core/PasswdFile.cpp
+++ b/libs/core/src/ecflow/core/PasswdFile.cpp
@@ -293,8 +293,10 @@ bool PasswdFile::createWithAccess(const std::string& pathToFile,
 
     lines.emplace_back("4.5.0");
 
+    auto username = get_login_name();
+
     string line;
-    line += User::login_name();
+    line += username;
     line += " ";
     line += host;
     line += " ";
@@ -304,7 +306,7 @@ bool PasswdFile::createWithAccess(const std::string& pathToFile,
     lines.push_back(line);
 
     line.clear();
-    line += User::login_name();
+    line += username;
     line += " ";
     line += Str::LOCALHOST();
     line += " ";

--- a/libs/core/src/ecflow/core/User.cpp
+++ b/libs/core/src/ecflow/core/User.cpp
@@ -18,51 +18,9 @@
 #include <stdexcept>
 #include <unistd.h> // ofr getuid()
 
-#include "ecflow/core/Enumerate.hpp"
-
 namespace ecf {
 
-namespace detail {
-
-template <>
-struct EnumTraits<User::Action>
-{
-    using underlying_t = std::underlying_type_t<User::Action>;
-
-    static constexpr std::array map = std::array{
-        // clang-format off
-        std::make_pair(User::Action::FOB, "fob"),
-        std::make_pair(User::Action::FAIL, "fail"),
-        std::make_pair(User::Action::ADOPT, "adopt"),
-        std::make_pair(User::Action::REMOVE, "remove"),
-        std::make_pair(User::Action::BLOCK, "block"),
-        std::make_pair(User::Action::KILL, "kill"),
-        // clang-format on
-    };
-    static constexpr size_t size = map.size();
-
-    static_assert(EnumTraits<User::Action>::size == map.back().first + 1);
-};
-
-} // namespace detail
-
-bool User::valid_user_action(const std::string& s) {
-    return Enumerate<User::Action>::is_valid(s);
-}
-
-User::Action User::user_action(const std::string& s) {
-    return Enumerate<User::Action>::to_enum(s).value_or(User::BLOCK);
-}
-
-std::string User::to_string(User::Action uc) {
-    if (auto found = Enumerate<User::Action>::to_string(uc); found) {
-        return std::string{found.value()};
-    }
-    assert(false);
-    return std::string();
-}
-
-std::string User::login_name() {
+std::string get_login_name() {
     static std::string the_user_name;
     if (the_user_name.empty()) {
 

--- a/libs/core/src/ecflow/core/User.hpp
+++ b/libs/core/src/ecflow/core/User.hpp
@@ -15,23 +15,7 @@
 
 namespace ecf {
 
-class User {
-public:
-    enum Action { FOB, FAIL, ADOPT, REMOVE, BLOCK, KILL };
-
-    // Disable default construction
-    User(const User&) = delete;
-    // Disable copy (and move) semantics
-    const User& operator=(const User&) = delete;
-    User()                             = delete;
-
-    static bool valid_user_action(const std::string&);
-    static Action user_action(const std::string&);
-    static std::string to_string(Action);
-
-    // return login name: will throw if there are any errors
-    static std::string login_name();
-};
+std::string get_login_name();
 
 } // namespace ecf
 

--- a/libs/core/src/ecflow/core/WhiteListFile.cpp
+++ b/libs/core/src/ecflow/core/WhiteListFile.cpp
@@ -554,7 +554,7 @@ bool WhiteListFile::createWithReadAccess(const std::string& pathToFile, std::str
     lines.reserve(2);
 
     lines.emplace_back("4.4.14");
-    lines.push_back("-" + User::login_name());
+    lines.push_back("-" + get_login_name());
 
     return File::create(pathToFile, lines, errorMsg);
 }
@@ -564,7 +564,7 @@ bool WhiteListFile::createWithWriteAccess(const std::string& pathToFile, std::st
     lines.reserve(2);
 
     lines.emplace_back("4.4.14");
-    lines.push_back(User::login_name()); // equivalent to the login name
+    lines.push_back(get_login_name()); // equivalent to the login name
 
     return File::create(pathToFile, lines, errorMsg);
 }
@@ -591,7 +591,7 @@ bool WhiteListFile::createEmpty(const std::string& pathToFile, std::string& erro
 }
 
 void WhiteListFile::allow_write_access_for_server_user() {
-    std::string user = User::login_name();
+    std::string user = get_login_name();
     if (verify_write_access(user))
         return;
 

--- a/libs/core/src/ecflow/core/ZombieCtrlAction.hpp
+++ b/libs/core/src/ecflow/core/ZombieCtrlAction.hpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2009- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#ifndef ecflow_core_ZombieCtrlAction_HPP
+#define ecflow_core_ZombieCtrlAction_HPP
+
+#include <cassert>
+#include <string>
+
+#include "ecflow/core/Enumerate.hpp"
+
+namespace ecf {
+
+enum class ZombieCtrlAction { FOB, FAIL, ADOPT, REMOVE, BLOCK, KILL };
+
+namespace detail {
+
+template <>
+struct EnumTraits<ZombieCtrlAction>
+{
+    using underlying_t = std::underlying_type_t<ZombieCtrlAction>;
+
+    /**
+     * The mapping between enum values and their designations
+     *
+     * @note The order of the entries in the array must be the same as the order of the enum values
+     */
+    static constexpr std::array map = std::array{
+        // clang-format off
+        std::make_pair(ZombieCtrlAction::FOB, "fob"),
+        std::make_pair(ZombieCtrlAction::FAIL, "fail"),
+        std::make_pair(ZombieCtrlAction::ADOPT, "adopt"),
+        std::make_pair(ZombieCtrlAction::REMOVE, "remove"),
+        std::make_pair(ZombieCtrlAction::BLOCK, "block"),
+        std::make_pair(ZombieCtrlAction::KILL, "kill"),
+        // clang-format on
+    };
+    static constexpr size_t size = map.size();
+
+    static_assert(EnumTraits<ZombieCtrlAction>::size == static_cast<underlying_t>(map.back().first) + 1);
+};
+
+} // namespace detail
+
+inline std::string to_string(ZombieCtrlAction uc) {
+    if (auto found = Enumerate<ZombieCtrlAction>::to_string(uc); found) {
+        return std::string{found.value()};
+    }
+    assert(false);
+    return std::string();
+}
+
+} // namespace ecf
+
+#endif /* ecflow_core_ZombieCtrlAction_HPP */

--- a/libs/core/test/TestFile.cpp
+++ b/libs/core/test/TestFile.cpp
@@ -26,7 +26,6 @@
 
 #include "ecflow/core/File.hpp"
 #include "ecflow/core/NodePath.hpp"
-#include "ecflow/core/User.hpp"
 #include "ecflow/test/scaffold/Naming.hpp"
 
 using namespace boost;

--- a/libs/node/test/MyDefsFixture.hpp
+++ b/libs/node/test/MyDefsFixture.hpp
@@ -126,20 +126,20 @@ private:
         suiteTask->add_part_complete(PartExpression("t2 == complete", true));
 
         std::vector<ecf::Child::CmdType> child_cmds = ecf::Child::list();
-        suiteTask->addZombie(ZombieAttr(ecf::Child::USER, child_cmds, ecf::User::FOB, 10));
-        suiteTask->addZombie(ZombieAttr(ecf::Child::PATH, child_cmds, ecf::User::BLOCK, 100));
-        suiteTask->addZombie(ZombieAttr(ecf::Child::ECF, child_cmds, ecf::User::FAIL, 100));
-        suiteTask->addZombie(ZombieAttr(ecf::Child::ECF_PID, child_cmds, ecf::User::FAIL, 100));
-        suiteTask->addZombie(ZombieAttr(ecf::Child::ECF_PASSWD, child_cmds, ecf::User::FAIL, 100));
-        suiteTask->addZombie(ZombieAttr(ecf::Child::ECF_PID_PASSWD, child_cmds, ecf::User::FAIL, 100));
+        suiteTask->addZombie(ZombieAttr(ecf::Child::USER, child_cmds, ecf::ZombieCtrlAction::FOB, 10));
+        suiteTask->addZombie(ZombieAttr(ecf::Child::PATH, child_cmds, ecf::ZombieCtrlAction::BLOCK, 100));
+        suiteTask->addZombie(ZombieAttr(ecf::Child::ECF, child_cmds, ecf::ZombieCtrlAction::FAIL, 100));
+        suiteTask->addZombie(ZombieAttr(ecf::Child::ECF_PID, child_cmds, ecf::ZombieCtrlAction::FAIL, 100));
+        suiteTask->addZombie(ZombieAttr(ecf::Child::ECF_PASSWD, child_cmds, ecf::ZombieCtrlAction::FAIL, 100));
+        suiteTask->addZombie(ZombieAttr(ecf::Child::ECF_PID_PASSWD, child_cmds, ecf::ZombieCtrlAction::FAIL, 100));
 
         task_ptr suiteTask4 = suite->add_task("t4");
-        suiteTask4->addZombie(ZombieAttr(ecf::Child::USER, child_cmds, ecf::User::ADOPT, 10));
-        suiteTask4->addZombie(ZombieAttr(ecf::Child::PATH, child_cmds, ecf::User::BLOCK, 100));
-        suiteTask4->addZombie(ZombieAttr(ecf::Child::ECF, child_cmds, ecf::User::REMOVE, 100));
-        suiteTask4->addZombie(ZombieAttr(ecf::Child::ECF_PID, child_cmds, ecf::User::KILL, 100));
-        suiteTask4->addZombie(ZombieAttr(ecf::Child::ECF_PASSWD, child_cmds, ecf::User::FOB, 100));
-        suiteTask4->addZombie(ZombieAttr(ecf::Child::ECF_PID_PASSWD, child_cmds, ecf::User::BLOCK, 100));
+        suiteTask4->addZombie(ZombieAttr(ecf::Child::USER, child_cmds, ecf::ZombieCtrlAction::ADOPT, 10));
+        suiteTask4->addZombie(ZombieAttr(ecf::Child::PATH, child_cmds, ecf::ZombieCtrlAction::BLOCK, 100));
+        suiteTask4->addZombie(ZombieAttr(ecf::Child::ECF, child_cmds, ecf::ZombieCtrlAction::REMOVE, 100));
+        suiteTask4->addZombie(ZombieAttr(ecf::Child::ECF_PID, child_cmds, ecf::ZombieCtrlAction::KILL, 100));
+        suiteTask4->addZombie(ZombieAttr(ecf::Child::ECF_PASSWD, child_cmds, ecf::ZombieCtrlAction::FOB, 100));
+        suiteTask4->addZombie(ZombieAttr(ecf::Child::ECF_PID_PASSWD, child_cmds, ecf::ZombieCtrlAction::BLOCK, 100));
 
         ecf::CronAttr cronAttr;
         ecf::TimeSlot start(0, 0);

--- a/libs/node/test/TestAssignmentOperator.cpp
+++ b/libs/node/test/TestAssignmentOperator.cpp
@@ -61,9 +61,9 @@ BOOST_AUTO_TEST_CASE(test_suite_assignment_operator) {
     s1.add_task("t1");
     s1.add_family("f1");
     std::vector<ecf::Child::CmdType> child_cmds = ecf::Child::list();
-    s1.addZombie(ZombieAttr(ecf::Child::USER, child_cmds, ecf::User::FOB, 10));
-    s1.addZombie(ZombieAttr(ecf::Child::ECF, child_cmds, ecf::User::FAIL, 100));
-    s1.addZombie(ZombieAttr(ecf::Child::PATH, child_cmds, ecf::User::BLOCK, 100));
+    s1.addZombie(ZombieAttr(ecf::Child::USER, child_cmds, ecf::ZombieCtrlAction::FOB, 10));
+    s1.addZombie(ZombieAttr(ecf::Child::ECF, child_cmds, ecf::ZombieCtrlAction::FAIL, 100));
+    s1.addZombie(ZombieAttr(ecf::Child::PATH, child_cmds, ecf::ZombieCtrlAction::BLOCK, 100));
 
     ecf::CronAttr cronAttr;
     ecf::TimeSlot start(0, 0);
@@ -116,9 +116,9 @@ BOOST_AUTO_TEST_CASE(test_task_assignment_operator) {
     s1.addAutoCancel(ecf::AutoCancelAttr(2));
     s1.addVariable(Variable("VAR", "value"));
     std::vector<ecf::Child::CmdType> child_cmds = ecf::Child::list();
-    s1.addZombie(ZombieAttr(ecf::Child::USER, child_cmds, ecf::User::FOB, 10));
-    s1.addZombie(ZombieAttr(ecf::Child::ECF, child_cmds, ecf::User::FAIL, 100));
-    s1.addZombie(ZombieAttr(ecf::Child::PATH, child_cmds, ecf::User::BLOCK, 100));
+    s1.addZombie(ZombieAttr(ecf::Child::USER, child_cmds, ecf::ZombieCtrlAction::FOB, 10));
+    s1.addZombie(ZombieAttr(ecf::Child::ECF, child_cmds, ecf::ZombieCtrlAction::FAIL, 100));
+    s1.addZombie(ZombieAttr(ecf::Child::PATH, child_cmds, ecf::ZombieCtrlAction::BLOCK, 100));
 
     ecf::CronAttr cronAttr;
     ecf::TimeSlot start(0, 0);

--- a/libs/node/test/TestZombies.cpp
+++ b/libs/node/test/TestZombies.cpp
@@ -51,17 +51,17 @@ BOOST_AUTO_TEST_CASE(test_zombies) {
     // ADD
     std::vector<ecf::Child::CmdType> child_cmds = ecf::Child::list();
     {
-        s->addZombie(ZombieAttr(ecf::Child::USER, child_cmds, ecf::User::FOB, 10));
+        s->addZombie(ZombieAttr(ecf::Child::USER, child_cmds, ecf::ZombieCtrlAction::FOB, 10));
         BOOST_REQUIRE_MESSAGE(s->zombies().size() == 1, "Expected 1 zombie but found " << s->zombies().size());
-        s->addZombie(ZombieAttr(ecf::Child::ECF, child_cmds, ecf::User::FAIL, 100));
+        s->addZombie(ZombieAttr(ecf::Child::ECF, child_cmds, ecf::ZombieCtrlAction::FAIL, 100));
         BOOST_REQUIRE_MESSAGE(s->zombies().size() == 2, "Expected 2 zombie but found " << s->zombies().size());
-        s->addZombie(ZombieAttr(ecf::Child::ECF_PID, child_cmds, ecf::User::FAIL, 100));
+        s->addZombie(ZombieAttr(ecf::Child::ECF_PID, child_cmds, ecf::ZombieCtrlAction::FAIL, 100));
         BOOST_REQUIRE_MESSAGE(s->zombies().size() == 3, "Expected 3 zombie but found " << s->zombies().size());
-        s->addZombie(ZombieAttr(ecf::Child::ECF_PID_PASSWD, child_cmds, ecf::User::FAIL, 100));
+        s->addZombie(ZombieAttr(ecf::Child::ECF_PID_PASSWD, child_cmds, ecf::ZombieCtrlAction::FAIL, 100));
         BOOST_REQUIRE_MESSAGE(s->zombies().size() == 4, "Expected 4 zombie but found " << s->zombies().size());
-        s->addZombie(ZombieAttr(ecf::Child::ECF_PASSWD, child_cmds, ecf::User::FAIL, 100));
+        s->addZombie(ZombieAttr(ecf::Child::ECF_PASSWD, child_cmds, ecf::ZombieCtrlAction::FAIL, 100));
         BOOST_REQUIRE_MESSAGE(s->zombies().size() == 5, "Expected 5 zombie but found " << s->zombies().size());
-        s->addZombie(ZombieAttr(ecf::Child::PATH, child_cmds, ecf::User::BLOCK, 100));
+        s->addZombie(ZombieAttr(ecf::Child::PATH, child_cmds, ecf::ZombieCtrlAction::BLOCK, 100));
         BOOST_REQUIRE_MESSAGE(s->zombies().size() == 6, "Expected 6 zombie but found " << s->zombies().size());
     }
 

--- a/libs/node/test/parser/TestMementoPersistAndReload.cpp
+++ b/libs/node/test/parser/TestMementoPersistAndReload.cpp
@@ -458,7 +458,7 @@ BOOST_AUTO_TEST_CASE(test_memento_persist_and_reload) {
 
         std::vector<ecf::Child::CmdType> child_cmds = ecf::Child::list();
 
-        ZombieAttr attr(ecf::Child::USER, child_cmds, ecf::User::FOB, 10);
+        ZombieAttr attr(ecf::Child::USER, child_cmds, ecf::ZombieCtrlAction::FOB, 10);
 
         NodeZombieMemento memento(attr);
         t->set_memento(&memento, aspects, aspect_only); // add zombie;

--- a/libs/pyext/src/ecflow/python/ExportNodeAttr.cpp
+++ b/libs/pyext/src/ecflow/python/ExportNodeAttr.cpp
@@ -250,7 +250,7 @@ static std::shared_ptr<GenericAttr> create_generic(const std::string& name, cons
 }
 
 static std::shared_ptr<ZombieAttr>
-create_ZombieAttr(Child::ZombieType zt, const bp::list& list, User::Action uc, int life_time_in_server) {
+create_ZombieAttr(Child::ZombieType zt, const bp::list& list, ZombieCtrlAction uc, int life_time_in_server) {
     std::vector<Child::CmdType> vec;
     int the_list_size = len(list);
     vec.reserve(the_list_size);
@@ -260,7 +260,7 @@ create_ZombieAttr(Child::ZombieType zt, const bp::list& list, User::Action uc, i
     return std::make_shared<ZombieAttr>(zt, vec, uc, life_time_in_server);
 }
 
-static std::shared_ptr<ZombieAttr> create_ZombieAttr1(Child::ZombieType zt, const bp::list& list, User::Action uc) {
+static std::shared_ptr<ZombieAttr> create_ZombieAttr1(Child::ZombieType zt, const bp::list& list, ZombieCtrlAction uc) {
     std::vector<Child::CmdType> vec;
     int the_list_size = len(list);
     vec.reserve(the_list_size);
@@ -502,13 +502,13 @@ void export_NodeAttr() {
         .value("user", Child::USER)
         .value("path", Child::PATH);
 
-    enum_<User::Action>("ZombieUserActionType", NodeAttrDoc::zombie_user_action_type_doc())
-        .value("fob", User::FOB)
-        .value("fail", User::FAIL)
-        .value("remove", User::REMOVE)
-        .value("adopt", User::ADOPT)
-        .value("block", User::BLOCK)
-        .value("kill", User::KILL);
+    enum_<ZombieCtrlAction>("ZombieUserActionType", NodeAttrDoc::zombie_user_action_type_doc())
+        .value("fob", ZombieCtrlAction::FOB)
+        .value("fail", ZombieCtrlAction::FAIL)
+        .value("remove", ZombieCtrlAction::REMOVE)
+        .value("adopt", ZombieCtrlAction::ADOPT)
+        .value("block", ZombieCtrlAction::BLOCK)
+        .value("kill", ZombieCtrlAction::KILL);
 
     enum_<Child::CmdType>("ChildCmdType", NodeAttrDoc::child_cmd_type_doc())
         .value("init", Child::INIT)
@@ -529,8 +529,6 @@ void export_NodeAttr() {
         .value("variable", Attr::VARIABLE)
         .value("all", Attr::ALL);
 
-    // 	ZombieAttr(ecf::Child::ZombieType t, const std::vector<ecf::Child::CmdType>& c, ecf::User::Action a, int
-    // zombie_lifetime);
     class_<ZombieAttr>("ZombieAttr", NodeAttrDoc::zombie_doc())
         .def("__init__", make_constructor(&create_ZombieAttr))
         .def("__init__", make_constructor(&create_ZombieAttr1))
@@ -1002,8 +1000,8 @@ void export_NodeAttr() {
         .def("step", &Repeat::step, "The increment for the repeat, as an integer")
         .def("value", &Repeat::last_valid_value, "The current value of the repeat as an integer");
 
-    void (CronAttr::* add_time_series)(const TimeSeries&) = &CronAttr::addTimeSeries;
-    void (CronAttr::* add_time_series_2)(const TimeSlot& s, const TimeSlot& f, const TimeSlot& i) =
+    void (CronAttr::*add_time_series)(const TimeSeries&) = &CronAttr::addTimeSeries;
+    void (CronAttr::*add_time_series_2)(const TimeSlot& s, const TimeSlot& f, const TimeSlot& i) =
         &CronAttr::addTimeSeries;
     class_<CronAttr, std::shared_ptr<CronAttr>>("Cron", NodeAttrDoc::cron_doc())
         .def("__init__", raw_function(&cron_raw_constructor, 1)) // will call -> cron_init or cron_init1

--- a/libs/rest/src/ecflow/http/TypeToJson.cpp
+++ b/libs/rest/src/ecflow/http/TypeToJson.cpp
@@ -12,7 +12,6 @@
 
 #include "ecflow/core/Child.hpp"
 #include "ecflow/core/SState.hpp"
-#include "ecflow/core/User.hpp"
 
 using ecf::http::ojson;
 
@@ -254,7 +253,7 @@ void to_json(ojson& j, const ::QueueAttr& a) {
 
 void to_json(ojson& j, const ::ZombieAttr& a) {
     j["type"]           = ecf::Child::to_string(a.zombie_type());
-    j["action"]         = ecf::User::to_string(a.action());
+    j["action"]         = ecf::to_string(a.action());
     j["child_commands"] = ecf::Child::to_string(a.child_cmds());
     j["lifetime"]       = a.zombie_lifetime();
 }

--- a/libs/test/TestZombies.cpp
+++ b/libs/test/TestZombies.cpp
@@ -482,7 +482,7 @@ create_and_start_test(Defs& theDefs, const std::string& suite_name, const std::s
     TestFixture::client().zombieGet();
     if (!TestFixture::client().server_reply().zombies().empty()) {
         (void)ZombieUtil::do_zombie_user_action(
-            User::REMOVE, TestFixture::client().server_reply().zombies().size(), timeout);
+            ZombieCtrlAction::REMOVE, TestFixture::client().server_reply().zombies().size(), timeout);
     }
 
     if (ecf_debug_enabled)
@@ -680,7 +680,7 @@ BOOST_AUTO_TEST_CASE(test_path_zombie_creation) {
     // Hence after this command, the number of fobed zombies may *NOT* be the same
     // as the number of tasks. Since the fobed zombies are auto deleted when a complete
     // child command is received.
-    int no_of_fobed_zombies = ZombieUtil::do_zombie_user_action(User::FOB, NUM_OF_TASKS, timeout);
+    int no_of_fobed_zombies = ZombieUtil::do_zombie_user_action(ZombieCtrlAction::FOB, NUM_OF_TASKS, timeout);
     BOOST_CHECK_MESSAGE(no_of_fobed_zombies > 0, "*error* Expected some fobed zombies but found none ?");
 
     // Wait for zombies to be deleted in the server
@@ -719,7 +719,7 @@ BOOST_AUTO_TEST_CASE(test_user_zombies_for_delete_fob) {
     // Hence after this command, the number of fobed zombies may *NOT* be the same
     // as the number of tasks. Since the fobed zombies are auto deleted when a complete
     // child command is recieved.
-    int no_of_fobed_zombies = ZombieUtil::do_zombie_user_action(User::FOB, NUM_OF_TASKS, timeout);
+    int no_of_fobed_zombies = ZombieUtil::do_zombie_user_action(ZombieCtrlAction::FOB, NUM_OF_TASKS, timeout);
     BOOST_CHECK_MESSAGE(no_of_fobed_zombies > 0, "*error* Expected some fobed zombies but found none ?");
 
     // Wait for zombies to be deleted in the server
@@ -752,7 +752,7 @@ BOOST_AUTO_TEST_CASE(test_user_zombies_for_delete_fail) {
     check_at_least_one_zombie();
 
     // Fail all the zombies. This will UNBLOCK and terminate the child commands allowing them to finish
-    int no_of_failed_zombies = ZombieUtil::do_zombie_user_action(User::FAIL, NUM_OF_TASKS, timeout);
+    int no_of_failed_zombies = ZombieUtil::do_zombie_user_action(ZombieCtrlAction::FAIL, NUM_OF_TASKS, timeout);
     BOOST_CHECK_MESSAGE(no_of_failed_zombies > 0, "*error* Expected > 0 Failed zombies but found none");
 
     check_at_least_one_zombie();
@@ -797,7 +797,7 @@ BOOST_AUTO_TEST_CASE(test_user_zombies_for_begin) {
     // child command is received.
     //
     /// When we have two sets of completes, we just fob, automatically. See TaskCmd::authenticate
-    int no_of_fobed_zombies = ZombieUtil::do_zombie_user_action(User::FOB, no_of_zombies, timeout);
+    int no_of_fobed_zombies = ZombieUtil::do_zombie_user_action(ZombieCtrlAction::FOB, no_of_zombies, timeout);
     BOOST_CHECK_MESSAGE(no_of_fobed_zombies > 0, "*error* Expected some fobed zombies but found none ?");
 
     // Fobing does *NOT* alter node tree state, however child COMPLETE should auto delete the zombie
@@ -878,7 +878,7 @@ BOOST_AUTO_TEST_CASE(test_user_zombies_for_adopt) {
 
     /// Adopt all the zombies. This will UNBLOCK the child commands allowing them to finish
     /// This test below fail on AIX, its too fast , task's may already be adopted and hence don't fail
-    int no_of_adopted_zombied = ZombieUtil::do_zombie_user_action(User::ADOPT, NUM_OF_TASKS, timeout);
+    int no_of_adopted_zombied = ZombieUtil::do_zombie_user_action(ZombieCtrlAction::ADOPT, NUM_OF_TASKS, timeout);
     if (ecf_debug_enabled)
         cout << "   found " << no_of_adopted_zombied << " zombies for adoption\n";
 
@@ -960,7 +960,7 @@ BOOST_AUTO_TEST_CASE(test_user_zombie_creation_via_complete) {
     check_at_least_one_zombie();
 
     // Fob all the zombies child commands allowing them to finish
-    (void)ZombieUtil::do_zombie_user_action(User::FOB, NUM_OF_TASKS, timeout);
+    (void)ZombieUtil::do_zombie_user_action(ZombieCtrlAction::FOB, NUM_OF_TASKS, timeout);
 
     // Wait for zombies to complete, they should get removed automatically
     wait_for_no_zombies(timeout);
@@ -986,7 +986,7 @@ BOOST_AUTO_TEST_CASE(test_user_zombie_creation_via_abort) {
     check_at_least_one_zombie();
 
     // Fob all the zombies child commands allowing them to finish
-    (void)ZombieUtil::do_zombie_user_action(User::FOB, NUM_OF_TASKS, timeout);
+    (void)ZombieUtil::do_zombie_user_action(ZombieCtrlAction::FOB, NUM_OF_TASKS, timeout);
 
     // Wait for zombies to complete, they should get removed automatically
     wait_for_no_zombies(timeout);
@@ -1009,12 +1009,15 @@ BOOST_AUTO_TEST_CASE(test_zombie_inheritance) {
     Defs theDefs;
     populate_defs(theDefs, suite_name);
     suite_ptr suite = theDefs.findSuite(suite_name);
-    suite->addZombie(ZombieAttr(ecf::Child::USER, std::vector<ecf::Child::CmdType>(), ecf::User::FOB, -1));
-    suite->addZombie(ZombieAttr(ecf::Child::ECF, std::vector<ecf::Child::CmdType>(), ecf::User::FOB, -1));
-    suite->addZombie(ZombieAttr(ecf::Child::ECF_PID, std::vector<ecf::Child::CmdType>(), ecf::User::FOB, -1));
-    suite->addZombie(ZombieAttr(ecf::Child::ECF_PID_PASSWD, std::vector<ecf::Child::CmdType>(), ecf::User::FOB, -1));
-    suite->addZombie(ZombieAttr(ecf::Child::ECF_PASSWD, std::vector<ecf::Child::CmdType>(), ecf::User::FOB, -1));
-    suite->addZombie(ZombieAttr(ecf::Child::PATH, std::vector<ecf::Child::CmdType>(), ecf::User::FOB, -1));
+    suite->addZombie(ZombieAttr(ecf::Child::USER, std::vector<ecf::Child::CmdType>(), ecf::ZombieCtrlAction::FOB, -1));
+    suite->addZombie(ZombieAttr(ecf::Child::ECF, std::vector<ecf::Child::CmdType>(), ecf::ZombieCtrlAction::FOB, -1));
+    suite->addZombie(
+        ZombieAttr(ecf::Child::ECF_PID, std::vector<ecf::Child::CmdType>(), ecf::ZombieCtrlAction::FOB, -1));
+    suite->addZombie(
+        ZombieAttr(ecf::Child::ECF_PID_PASSWD, std::vector<ecf::Child::CmdType>(), ecf::ZombieCtrlAction::FOB, -1));
+    suite->addZombie(
+        ZombieAttr(ecf::Child::ECF_PASSWD, std::vector<ecf::Child::CmdType>(), ecf::ZombieCtrlAction::FOB, -1));
+    suite->addZombie(ZombieAttr(ecf::Child::PATH, std::vector<ecf::Child::CmdType>(), ecf::ZombieCtrlAction::FOB, -1));
 
     create_and_start_test(theDefs, suite_name, "complete");
 
@@ -1025,9 +1028,9 @@ BOOST_AUTO_TEST_CASE(test_zombie_inheritance) {
     std::vector<Zombie> zombies = TestFixture::client().server_reply().zombies();
     BOOST_CHECK_MESSAGE(!zombies.empty(), "No zombies found");
     for (const Zombie& z : zombies) {
-        BOOST_CHECK_MESSAGE(z.user_action() == ecf::User::FOB,
+        BOOST_CHECK_MESSAGE(z.user_action() == ecf::ZombieCtrlAction::FOB,
                             "*error* Expected zombies with user action of type FOB but found "
-                                << User::to_string(z.user_action()));
+                                << ecf::to_string(z.user_action()));
         break;
     }
 
@@ -1084,7 +1087,7 @@ BOOST_AUTO_TEST_CASE(test_zombie_kill) {
 
     // kill all the zombies, i.e kill -15 on the script
     // This will be trapped by the signal and hence will call abort
-    (void)ZombieUtil::do_zombie_user_action(User::KILL, NUM_OF_TASKS, timeout);
+    (void)ZombieUtil::do_zombie_user_action(ZombieCtrlAction::KILL, NUM_OF_TASKS, timeout);
 
     // wait for kill zombies. This should eventually lead to process terminating
     int killed = wait_for_killed_zombies(NUM_OF_TASKS, timeout);
@@ -1146,7 +1149,7 @@ BOOST_AUTO_TEST_CASE(test_zombie_kill) {
     }
 
     // remove the killed zombies
-    (void)ZombieUtil::do_zombie_user_action(User::REMOVE, NUM_OF_TASKS, timeout, false);
+    (void)ZombieUtil::do_zombie_user_action(ZombieCtrlAction::REMOVE, NUM_OF_TASKS, timeout, false);
 
     wait_for_no_zombies(timeout);
 
@@ -1210,7 +1213,7 @@ BOOST_AUTO_TEST_CASE(test_ecf_zombie_type_creation) {
     // wait of at least *ONE* zombie of type *ECF*
     wait_for_zombies_of_type(Child::ECF, NUM_OF_TASKS, timeout);
 
-    int no_of_fobed_zombies = ZombieUtil::do_zombie_user_action(User::FOB, NUM_OF_TASKS, timeout);
+    int no_of_fobed_zombies = ZombieUtil::do_zombie_user_action(ZombieCtrlAction::FOB, NUM_OF_TASKS, timeout);
     BOOST_CHECK_MESSAGE(no_of_fobed_zombies > 0, "*error* Expected some fobed zombies but found none ?");
 
     // Fobing does *NOT* alter node tree state, however child COMPLETE should auto delete the zombie

--- a/libs/test/harness/ZombieUtil.hpp
+++ b/libs/test/harness/ZombieUtil.hpp
@@ -12,7 +12,7 @@
 #define ecflow_test_harness_ZombieUtil_HPP
 
 #include "ecflow/core/Child.hpp"
-#include "ecflow/core/User.hpp"
+#include "ecflow/core/ZombieCtrlAction.hpp"
 
 class ClientInvoker;
 
@@ -23,7 +23,7 @@ private:
 
 public:
     static void test_clean_up(int timeout);
-    static int do_zombie_user_action(ecf::User::Action uc,
+    static int do_zombie_user_action(ecf::ZombieCtrlAction uc,
                                      int expected_action_cnt,
                                      int max_time_to_wait,
                                      bool fail_if_to_long = true);

--- a/libs/test/harness/ZombieUtill.cpp
+++ b/libs/test/harness/ZombieUtill.cpp
@@ -32,7 +32,7 @@ void ZombieUtil::test_clean_up(int timeout) {
         cout << Zombie::pretty_print(zombies, 9) << "\n, attempting to *fob* then *remove* ...\n";
 
         int no_fobed =
-            do_zombie_user_action(User::FOB, zombies.size(), timeout, false /* don't fail if it takes to long */);
+            do_zombie_user_action(ZombieCtrlAction::FOB, zombies.size(), timeout, false /* don't fail if it takes to long */);
 
         // In order to FOB, we must wait, till a child command, talks to the server.
         if (no_fobed) {
@@ -44,11 +44,11 @@ void ZombieUtil::test_clean_up(int timeout) {
                  << "s before attempting to remove\n";
             sleep(wait);
         }
-        (void)do_zombie_user_action(User::REMOVE, no_fobed, timeout, false /* don't fail if it takes to long */);
+        (void)do_zombie_user_action(ZombieCtrlAction::REMOVE, no_fobed, timeout, false /* don't fail if it takes to long */);
     }
 }
 
-int ZombieUtil::do_zombie_user_action(User::Action uc,
+int ZombieUtil::do_zombie_user_action(ZombieCtrlAction uc,
                                       int expected_action_cnt,
                                       int max_time_to_wait,
                                       bool fail_if_to_long) {
@@ -56,8 +56,8 @@ int ZombieUtil::do_zombie_user_action(User::Action uc,
     bool ecf_debug_zombies = false;
     if (ecf::environment::has("ECF_DEBUG_ZOMBIES")) {
         ecf_debug_zombies = true;
-        cout << "\n   do_zombie_user_action " << User::to_string(uc) << " expected_action_cnt " << expected_action_cnt
-             << "\n";
+        cout << "\n   do_zombie_user_action " << ecf::to_string(uc) << " expected_action_cnt "
+             << expected_action_cnt << "\n";
     }
 
     int action_set = 0;
@@ -71,7 +71,7 @@ int ZombieUtil::do_zombie_user_action(User::Action uc,
         bool continue_looping       = false;
         for (const Zombie& z : zombies) {
             switch (uc) {
-                case User::FOB: {
+                case ZombieCtrlAction::FOB: {
                     if (!z.fob()) {
                         TestFixture::client().zombieFob(z); // UNBLOCK, child commands, allow zombie to complete, will
                                                             // clear server_reply().zombies()
@@ -81,7 +81,7 @@ int ZombieUtil::do_zombie_user_action(User::Action uc,
                     }
                     break;
                 }
-                case User::FAIL: {
+                case ZombieCtrlAction::FAIL: {
                     if (!z.fail()) {
                         TestFixture::client().zombieFail(z); // UNBLOCK, child commands, allow zombie to complete, will
                                                              // clear server_reply().zombies()
@@ -91,7 +91,7 @@ int ZombieUtil::do_zombie_user_action(User::Action uc,
                     }
                     break;
                 }
-                case User::ADOPT: {
+                case ZombieCtrlAction::ADOPT: {
                     if (!z.adopt()) {
                         TestFixture::client().zombieAdopt(z); // UNBLOCK, child commands, allow zombie to complete, will
                                                               // clear server_reply().zombies()
@@ -101,7 +101,7 @@ int ZombieUtil::do_zombie_user_action(User::Action uc,
                     }
                     break;
                 }
-                case User::REMOVE: {
+                case ZombieCtrlAction::REMOVE: {
                     if (!z.remove()) {                         // should always return false
                         TestFixture::client().zombieRemove(z); // This should be immediate, and is not remembered
                         continue_looping = true;
@@ -110,7 +110,7 @@ int ZombieUtil::do_zombie_user_action(User::Action uc,
                     }
                     break;
                 }
-                case User::BLOCK: {
+                case ZombieCtrlAction::BLOCK: {
                     if (!z.block()) {
                         TestFixture::client().zombieBlock(z);
                         continue_looping = true;
@@ -119,7 +119,7 @@ int ZombieUtil::do_zombie_user_action(User::Action uc,
                     }
                     break;
                 }
-                case User::KILL: {
+                case ZombieCtrlAction::KILL: {
                     if (!z.kill()) {
                         TestFixture::client().zombieKill(z);
                         continue_looping = true;
@@ -152,7 +152,7 @@ int ZombieUtil::do_zombie_user_action(User::Action uc,
 
             std::stringstream ss;
             ss << "do_zombie_user_action:\nExpected " << expected_action_cnt << " zombies with user action "
-               << User::to_string(uc) << " but found " << action_set << "\naction set zombies\n"
+               << ecf::to_string(uc) << " but found " << action_set << "\naction set zombies\n"
                << Zombie::pretty_print(action_set_zombies, 6) << ", Test taking longer than time constraint of "
                << assertTimer.timeConstraint();
             if (fail_if_to_long) {
@@ -167,7 +167,7 @@ int ZombieUtil::do_zombie_user_action(User::Action uc,
     }
 
     if (ecf_debug_zombies) {
-        cout << "   " << action_set << " zombies set to user action " << User::to_string(uc) << " returning\n";
+        cout << "   " << action_set << " zombies set to user action " << ecf::to_string(uc) << " returning\n";
         cout << Zombie::pretty_print(action_set_zombies, 6);
     }
     return action_set;


### PR DESCRIPTION
This is a refactoring change, where the inaptly named enum Action in "namespace class" User is renamed to a clearer ZombieCtrlAction, and moved into a properly named header file.
This change also releases the class "User" to actually represent a user and its related characteristics, and thus supports ECFLOW-1960.