### PR TITLE
Correct display of Repeat attributes in UI ECFLOW-1905

### DIFF
--- a/Viewer/ecflowUI/src/VRepeatAttr.cpp
+++ b/Viewer/ecflowUI/src/VRepeatAttr.cpp
@@ -410,18 +410,40 @@ QString VRepeatDateListAttr::allValues() const {
     return vals;
 }
 
+namespace {
+
+/**
+ * This helper function determines the position of the repeat value in the list,
+ * indicating if the value is the first, middle, or last in the list.
+ *
+ * @tparam REPEAT
+ * @param repeat
+ * @return 0 == First, 1 == Middle, 2 == Last, -1 == Invalid
+ */
+template <typename REPEAT>
+static int get_repeat_position(const REPEAT& repeat) {
+    if (repeat.indexNum() < 2) {
+        return -1; // == Invalid
+    }
+
+    if (repeat.index_or_value() == 0) {
+        return 0; // == First
+    }
+
+    if (repeat.index_or_value() == repeat.indexNum()) {
+        return 2; // == Last
+    }
+
+    return 1; // == Middle
+}
+
+} // namespace
+
 int VRepeatDateListAttr::currentPosition() const {
     if (node_ptr node = parent_->node()) {
         const Repeat& r = node->repeat();
         if (auto* rdl = static_cast<RepeatDateList*>(r.repeatBase())) {
-            if (rdl->indexNum() < 2)
-                return -1;
-            else if (rdl->index_or_value() == 0)
-                return 0;
-            else if (rdl->index_or_value() == rdl->indexNum() - 1)
-                return 2;
-            else
-                return 1;
+            return get_repeat_position(*rdl);
         }
     }
     return -1;
@@ -487,13 +509,13 @@ int VRepeatIntAttr::currentPosition() const {
     if (node_ptr node = parent_->node()) {
         const Repeat& r = node->repeat();
         if (r.start() == r.end())
-            return -1;
+            return -1; // == Invalid
         else if (r.value() == r.start())
-            return 0;
+            return 0; // == First
         else if (r.value() == r.end() || r.value() + r.step() > r.end())
-            return 2;
+            return 2; // == Last
         else
-            return 1;
+            return 1; // == Middle
     }
     return -1;
 }
@@ -586,15 +608,8 @@ QString VRepeatEnumAttr::allValues() const {
 int VRepeatEnumAttr::currentPosition() const {
     if (node_ptr node = parent_->node()) {
         const Repeat& r = node->repeat();
-        if (auto* rdl = static_cast<RepeatEnumerated*>(r.repeatBase())) {
-            if (rdl->indexNum() < 2)
-                return -1;
-            else if (rdl->index_or_value() == 0)
-                return 0;
-            else if (rdl->index_or_value() == rdl->indexNum() - 1)
-                return 2;
-            else
-                return 1;
+        if (auto* repeat = static_cast<RepeatEnumerated*>(r.repeatBase()); repeat) {
+            return get_repeat_position(*repeat);
         }
     }
     return -1;
@@ -666,14 +681,7 @@ int VRepeatStringAttr::currentPosition() const {
     if (node_ptr node = parent_->node()) {
         const Repeat& r = node->repeat();
         if (auto* rdl = static_cast<RepeatString*>(r.repeatBase())) {
-            if (rdl->indexNum() < 2)
-                return -1;
-            else if (rdl->index_or_value() == 0)
-                return 0;
-            else if (rdl->index_or_value() == rdl->indexNum() - 1)
-                return 2;
-            else
-                return 1;
+            return get_repeat_position(*rdl);
         }
     }
     return -1;

--- a/docs/ug/user_manual/text_based_suite_definition/attributes/repeat_for_loop.rst
+++ b/docs/ug/user_manual/text_based_suite_definition/attributes/repeat_for_loop.rst
@@ -10,7 +10,7 @@ Any node can be **repeated** in a number of different ways. Only suites can be r
 
   repeat day step # only for suites
   repeat integer VARIABLE start end [step]
-  repeat enumerated date VARIABLE first [second [third ...]]
+  repeat enumerated VARIABLE first [second [third ...]]
   repeat string VARIABLE str1 [str2 ...]
   repeat file VARIABLE filename
   repeat date VARIABLE yyyymmdd yyyymmdd [step]
@@ -38,6 +38,7 @@ end time.
   repeat string INPUT str1 str2 str3
   repeat integer HOUR 6 24 6
   repeat date YMD 20200130 20200203
+  repeat enumerated ENUM one two three
 
 .. note:: 
   


### PR DESCRIPTION
This ensures the correct (...) are shown when the iteration is ongoing/finished:
 - <value>..., on first item
 - ... <value> ..., on any middle item
 - ... <value>, on the last item (even after complete)

This fixes the issue for several kinds of Repeat:
 - enumerated
 - string
 - datelist

Re ECFLOW-1905