### PR TITLE
Use uint64_t when parsing state change ECFLOW-2042

### DIFF
--- a/libs/attribute/src/ecflow/attribute/DateAttr.cpp
+++ b/libs/attribute/src/ecflow/attribute/DateAttr.cpp
@@ -328,7 +328,7 @@ void DateAttr::getDate(const std::string& date, int& day, int& month, int& year)
         day = 0;
     }
     else {
-        day = Extract::theInt(theDay, "DateAttr::getDate: Invalid day :" + date);
+        day = Extract::value<int>(theDay, "DateAttr::getDate: Invalid day :" + date);
         if (day < 1 || day > 31) {
             throw std::runtime_error("DateAttr::getDate: Invalid clock date: " + date);
         }
@@ -338,7 +338,7 @@ void DateAttr::getDate(const std::string& date, int& day, int& month, int& year)
         month = 0;
     }
     else {
-        month = Extract::theInt(theMonth, "DateAttr::getDate: Invalid month :" + date);
+        month = Extract::value<int>(theMonth, "DateAttr::getDate: Invalid month :" + date);
         if (month < 1 || month > 12) {
             throw std::runtime_error("DateAttr::getDate Invalid clock date: " + date);
         }
@@ -348,7 +348,7 @@ void DateAttr::getDate(const std::string& date, int& day, int& month, int& year)
         year = 0;
     }
     else {
-        year = Extract::theInt(theYear, "DateAttr::getDate: Invalid year :" + date);
+        year = Extract::value<int>(theYear, "DateAttr::getDate: Invalid year :" + date);
     }
 
     if (day == -1 || month == -1 || year == -1) {

--- a/libs/attribute/src/ecflow/attribute/QueueAttr.cpp
+++ b/libs/attribute/src/ecflow/attribute/QueueAttr.cpp
@@ -12,7 +12,6 @@
 
 #include <stdexcept>
 
-#include "ecflow/core/Converter.hpp"
 #include "ecflow/core/Ecf.hpp"
 #include "ecflow/core/Extract.hpp"
 #include "ecflow/core/Serialization.hpp"
@@ -231,7 +230,7 @@ void QueueAttr::parse(QueueAttr& queAttr,
         for (size_t i = 3; i < line_tokens_size; i++) {
             if (lineTokens[i] == "#" && i + 1 < line_tokens_size) {
                 i++;
-                index = Extract::theInt(lineTokens[i], "QueueAttr::parse, could not extract index");
+                index = Extract::value<int>(lineTokens[i], "QueueAttr::parse, could not extract index");
                 i++;
                 for (; i < line_tokens_size; i++) {
                     NState::State state = NState::toState(lineTokens[i]);

--- a/libs/core/src/ecflow/core/Ecf.hpp
+++ b/libs/core/src/ecflow/core/Ecf.hpp
@@ -38,7 +38,7 @@
 
 class Ecf {
 public:
-    using counter_t        = unsigned int;
+    using counter_t        = uint64_t;
     using atomic_counter_t = std::atomic<counter_t>;
 
     // Disable default construction

--- a/libs/core/src/ecflow/core/Extract.cpp
+++ b/libs/core/src/ecflow/core/Extract.cpp
@@ -13,15 +13,6 @@
 #include <stdexcept>
 
 #include "ecflow/core/Chrono.hpp"
-#include "ecflow/core/Converter.hpp"
-
-// #define DEBUG_PARSER 1
-
-template <class T>
-std::ostream& operator<<(std::ostream& os, const std::vector<T>& v) {
-    std::copy(v.begin(), v.end(), std::ostream_iterator<T>(std::cout, ","));
-    return os;
-}
 
 bool Extract::pathAndName(const std::string& token, std::string& path, std::string& name) {
     if (token.empty()) {
@@ -56,18 +47,6 @@ bool Extract::split_get_second(const std::string& str, std::string& ret, char se
     return true;
 }
 
-/// extract integer or throw a std::runtime exception on failure
-int Extract::theInt(const std::string& token, const std::string& errorMsg) {
-    int the_int = -1;
-    try {
-        the_int = ecf::convert_to<int>(token);
-    }
-    catch (const ecf::bad_conversion&) {
-        throw std::runtime_error(errorMsg);
-    }
-    return the_int;
-}
-
 /// extract YMD, integer of the form yyyymmdd
 int Extract::ymd(const std::string& ymdToken, std::string& errorMsg) {
     if (ymdToken.size() != 8) {
@@ -84,17 +63,5 @@ int Extract::ymd(const std::string& ymdToken, std::string& errorMsg) {
         throw std::runtime_error(errorMsg + " YMD is not a valid date");
     }
 
-    return theInt(ymdToken, errorMsg);
-}
-
-int Extract::optionalInt(const std::vector<std::string>& tokens,
-                         int pos,
-                         int defaultValue,
-                         const std::string& errorMsg) {
-    int the_int = defaultValue;
-    if (static_cast<int>(tokens.size()) >= pos + 1 && tokens[pos][0] != '#') {
-
-        the_int = theInt(tokens[pos], errorMsg);
-    }
-    return the_int;
+    return value<int>(ymdToken, errorMsg);
 }

--- a/libs/core/src/ecflow/core/Extract.hpp
+++ b/libs/core/src/ecflow/core/Extract.hpp
@@ -46,14 +46,6 @@ public:
     static bool split_get_second(const std::string& str, std::string& ret, char separator = ':');
 
     ///
-    /// Extract an integer from the given token
-    ///
-    /// @returns the extracted integer
-    /// @throws std::runtime_error if extractions fails, with the provided error message included in exception message
-    ///
-    static int theInt(const std::string& token, const std::string& errorMsg);
-
-    ///
     /// Extract a value of the given type from the provided token
     ///
     /// @tparam TO the type of the value to extract
@@ -115,7 +107,15 @@ public:
     /// @returns the extracted integer, if extraction succeeded; default value if selected token starts with '#'
     /// @throws std::runtime_error if extractions fails, with the provided error message included in exception message
     ///
-    static int optionalInt(const std::vector<std::string>& tokens, int pos, int defValue, const std::string& errorMsg);
+    ///
+    template <typename TO>
+    static int
+    optional_value(const std::vector<std::string>& tokens, size_t pos, int defaultValue, const std::string& errorMsg) {
+        if (pos < tokens.size() && tokens[pos][0] != '#') {
+            return value<TO>(tokens[pos], errorMsg);
+        }
+        return defaultValue;
+    }
 };
 
 #endif /* ecflow_core_Extract_HPP */

--- a/libs/core/src/ecflow/core/Extract.hpp
+++ b/libs/core/src/ecflow/core/Extract.hpp
@@ -14,6 +14,9 @@
 #include <string>
 #include <vector>
 
+#include "ecflow/core/Converter.hpp"
+#include "ecflow/core/Result.hpp"
+
 class Extract {
 public:
     // Disable default construction
@@ -49,6 +52,41 @@ public:
     /// @throws std::runtime_error if extractions fails, with the provided error message included in exception message
     ///
     static int theInt(const std::string& token, const std::string& errorMsg);
+
+    ///
+    /// Extract a value of the given type from the provided token
+    ///
+    /// @tparam TO the type of the value to extract
+    /// @param token the input token
+    /// @return a Result object, containing either the extracted value, or an error message
+    ///
+    template <typename TO, typename = std::enable_if_t<std::is_arithmetic_v<TO>>>
+    static ecf::Result<TO> value(const std::string& token) {
+        try {
+            TO v = ecf::convert_to<TO>(token);
+            return ecf::Result<TO>::success(v);
+        }
+        catch (const ecf::bad_conversion&) {
+            return ecf::Result<TO>::failure("Unable to convert '" + token + "' as " + typeid(TO).name() + "");
+        }
+    }
+
+    ///
+    /// Extract a value of the given type from the provided token
+    ///
+    /// @tparam TO the type of the value to extract
+    /// @param token the input token
+    /// @param error the error message to the included in the thrown exception
+    /// @return the extracted value, or throws std::runtime_error exception with the specified error message
+    ///
+    template <typename TO>
+    static TO value(const std::string& token, const std::string& error) {
+        if (auto result = Extract::value<TO>(token); result.ok()) {
+            return result.value();
+        }
+
+        throw std::runtime_error(error);
+    }
 
     ///
     /// Extract YMD integer, of the form yyyymmdd, from the given token

--- a/libs/core/src/ecflow/core/NState.hpp
+++ b/libs/core/src/ecflow/core/NState.hpp
@@ -11,6 +11,7 @@
 #ifndef ecflow_core_NState_HPP
 #define ecflow_core_NState_HPP
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -27,6 +28,8 @@ class access;
 //
 class NState {
 public:
+    using state_change_no_t = uint64_t;
+
     enum State { UNKNOWN = 0, COMPLETE = 1, QUEUED = 2, ABORTED = 3, SUBMITTED = 4, ACTIVE = 5 };
 
     explicit NState(State s) : st_(s), state_change_no_(0) {}
@@ -37,7 +40,7 @@ public:
     void setState(State);
 
     // The state_change_no is never reset. Must be incremented if it can affect equality
-    unsigned int state_change_no() const { return state_change_no_; }
+    state_change_no_t state_change_no() const { return state_change_no_; }
 
     bool operator==(const NState& rhs) const { return st_ == rhs.st_; }
     bool operator!=(const NState& rhs) const { return st_ != rhs.st_; }
@@ -67,7 +70,7 @@ public:
 
 private:
     State st_;
-    unsigned int state_change_no_{0}; // *not* persisted, only used on server side
+    state_change_no_t state_change_no_{0}; // *not* persisted, only used on server side
 
     // *IMPORTANT* no version for a simple class
     friend class cereal::access;

--- a/libs/core/src/ecflow/core/TimeSeries.cpp
+++ b/libs/core/src/ecflow/core/TimeSeries.cpp
@@ -932,8 +932,8 @@ bool TimeSeries::getTime(const std::string& time, int& hour, int& min, bool chec
         throw std::runtime_error("TimeSeries::getTime: Invalid minute :" + theMin);
     }
 
-    hour = Extract::theInt(theHour, "TimeSeries::getTime: hour must be a integer : " + theHour);
-    min  = Extract::theInt(theMin, "TimeSeries::getTime: minute must be integer : " + theMin);
+    hour = Extract::value<int>(theHour, "TimeSeries::getTime: hour must be a integer : " + theHour);
+    min  = Extract::value<int>(theMin, "TimeSeries::getTime: minute must be integer : " + theMin);
 
     if (check_time) {
         testTime(hour, min);

--- a/libs/core/test/TestExtract.cpp
+++ b/libs/core/test/TestExtract.cpp
@@ -65,20 +65,76 @@ BOOST_AUTO_TEST_CASE(can_extract_second_token) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(can_extract_integer) {
+BOOST_AUTO_TEST_CASE(can_extract_integer_throw_on_failure, *boost::unit_test_framework::tolerance(0.00000001)) {
     ECF_NAME_THIS_TEST();
 
     using namespace std::string_literals;
-    { BOOST_CHECK_THROW(Extract::theInt("", "error message"s), std::runtime_error); }
-    { BOOST_CHECK_THROW(Extract::theInt("a", "error message"s), std::runtime_error); }
-    { BOOST_CHECK_THROW(Extract::theInt("abc", "error message"s), std::runtime_error); }
-    { BOOST_CHECK_THROW(Extract::theInt("#", "error message"s), std::runtime_error); }
-    { BOOST_CHECK_THROW(Extract::theInt(":", "error message"s), std::runtime_error); }
-    { BOOST_CHECK_EQUAL(Extract::theInt("42", "error message"s), 42); }
-    { BOOST_CHECK_EQUAL(Extract::theInt("-42", "error message"s), -42); }
-    { BOOST_CHECK_THROW(Extract::theInt("42 ", "error message"s), std::runtime_error); }
-    { BOOST_CHECK_THROW(Extract::theInt("42 42", "error message"s), std::runtime_error); }
-    { BOOST_CHECK_THROW(Extract::theInt("42.42", "error message"s), std::runtime_error); }
+    { BOOST_CHECK_THROW(Extract::value<int>("", "error message"s), std::runtime_error); }
+    { BOOST_CHECK_THROW(Extract::value<int>("a", "error message"s), std::runtime_error); }
+    { BOOST_CHECK_THROW(Extract::value<int>("abc", "error message"s), std::runtime_error); }
+    { BOOST_CHECK_THROW(Extract::value<int>("#", "error message"s), std::runtime_error); }
+    { BOOST_CHECK_THROW(Extract::value<int>(":", "error message"s), std::runtime_error); }
+    { BOOST_CHECK_EQUAL(Extract::value<int>("42", "error message"s), 42); }
+    { BOOST_CHECK_EQUAL(Extract::value<int>("-42", "error message"s), -42); }
+    { BOOST_CHECK_THROW(Extract::value<int>("42 ", "error message"s), std::runtime_error); }
+    { BOOST_CHECK_THROW(Extract::value<int>("42 42", "error message"s), std::runtime_error); }
+    { BOOST_CHECK_THROW(Extract::value<int>("42.42", "error message"s), std::runtime_error); }
+    {
+        auto value = Extract::value<double>("42.42", "error message"s);
+        BOOST_CHECK_CLOSE(value, 42.42, 1.0e-9);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(can_extract_integer_return_result) {
+    ECF_NAME_THIS_TEST();
+
+    {
+        auto result = Extract::value<int>("");
+        BOOST_CHECK(!result.ok());
+    }
+    {
+        auto result = Extract::value<int>("a");
+        BOOST_CHECK(!result.ok());
+    }
+    {
+        auto result = Extract::value<int>("abc");
+        BOOST_CHECK(!result.ok());
+    }
+    {
+        auto result = Extract::value<int>("#");
+        BOOST_CHECK(!result.ok());
+    }
+    {
+        auto result = Extract::value<int>(":");
+        BOOST_CHECK(!result.ok());
+    }
+    {
+        auto result = Extract::value<int>("42");
+        BOOST_CHECK(result.ok());
+        BOOST_CHECK_EQUAL(result.value(), 42);
+    }
+    {
+        auto result = Extract::value<int>("-42");
+        BOOST_CHECK(result.ok());
+        BOOST_CHECK_EQUAL(result.value(), -42);
+    }
+    {
+        auto result = Extract::value<int>("42 ");
+        BOOST_CHECK(!result.ok());
+    }
+    {
+        auto result = Extract::value<int>("42 42");
+        BOOST_CHECK(!result.ok());
+    }
+    {
+        auto result = Extract::value<int>("42.42");
+        BOOST_CHECK(!result.ok());
+    }
+    {
+        auto result = Extract::value<double>("42.42");
+        BOOST_CHECK(result.ok());
+        BOOST_CHECK_CLOSE(result.value(), 42.42, 1.0e-9);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(can_extract_optional_integer) {
@@ -87,24 +143,24 @@ BOOST_AUTO_TEST_CASE(can_extract_optional_integer) {
     using namespace std::string_literals;
     {
         auto tokens = std::vector{"repeat"s, "integer"s, "variable"s, "1"s, "2"s, "#a"s, "comment"s};
-        { BOOST_CHECK_THROW(Extract::optionalInt(tokens, 0, 42, "error message"s), std::runtime_error); }
-        { BOOST_CHECK_THROW(Extract::optionalInt(tokens, 1, 42, "error message"s), std::runtime_error); }
-        { BOOST_CHECK_THROW(Extract::optionalInt(tokens, 2, 42, "error message"s), std::runtime_error); }
-        { BOOST_CHECK_EQUAL(Extract::optionalInt(tokens, 3, 42, "error message"), 1); }
-        { BOOST_CHECK_EQUAL(Extract::optionalInt(tokens, 4, 42, "error message"), 2); }
-        { BOOST_CHECK_EQUAL(Extract::optionalInt(tokens, 5, 42, "error message"), 42); }
-        { BOOST_CHECK_THROW(Extract::optionalInt(tokens, 6, 42, "error message"s), std::runtime_error); }
+        { BOOST_CHECK_THROW(Extract::optional_value<int>(tokens, 0, 42, "error message"s), std::runtime_error); }
+        { BOOST_CHECK_THROW(Extract::optional_value<int>(tokens, 1, 42, "error message"s), std::runtime_error); }
+        { BOOST_CHECK_THROW(Extract::optional_value<int>(tokens, 2, 42, "error message"s), std::runtime_error); }
+        { BOOST_CHECK_EQUAL(Extract::optional_value<int>(tokens, 3, 42, "error message"), 1); }
+        { BOOST_CHECK_EQUAL(Extract::optional_value<int>(tokens, 4, 42, "error message"), 2); }
+        { BOOST_CHECK_EQUAL(Extract::optional_value<int>(tokens, 5, 42, "error message"), 42); }
+        { BOOST_CHECK_THROW(Extract::optional_value<int>(tokens, 6, 42, "error message"s), std::runtime_error); }
     }
     {
         auto tokens = std::vector{"repeat"s, "integer"s, "variable"s, "1"s, "2"s, "#"s, "a"s, "comment"s};
-        { BOOST_CHECK_THROW(Extract::optionalInt(tokens, 0, 42, "error message"s), std::runtime_error); }
-        { BOOST_CHECK_THROW(Extract::optionalInt(tokens, 1, 42, "error message"s), std::runtime_error); }
-        { BOOST_CHECK_THROW(Extract::optionalInt(tokens, 2, 42, "error message"s), std::runtime_error); }
-        { BOOST_CHECK_EQUAL(Extract::optionalInt(tokens, 3, 42, "error message"s), 1); }
-        { BOOST_CHECK_EQUAL(Extract::optionalInt(tokens, 4, 42, "error message"s), 2); }
-        { BOOST_CHECK_EQUAL(Extract::optionalInt(tokens, 5, 42, "error message"s), 42); }
-        { BOOST_CHECK_THROW(Extract::optionalInt(tokens, 6, 42, "error message"s), std::runtime_error); }
-        { BOOST_CHECK_THROW(Extract::optionalInt(tokens, 7, 42, "error message"s), std::runtime_error); }
+        { BOOST_CHECK_THROW(Extract::optional_value<int>(tokens, 0, 42, "error message"s), std::runtime_error); }
+        { BOOST_CHECK_THROW(Extract::optional_value<int>(tokens, 1, 42, "error message"s), std::runtime_error); }
+        { BOOST_CHECK_THROW(Extract::optional_value<int>(tokens, 2, 42, "error message"s), std::runtime_error); }
+        { BOOST_CHECK_EQUAL(Extract::optional_value<int>(tokens, 3, 42, "error message"s), 1); }
+        { BOOST_CHECK_EQUAL(Extract::optional_value<int>(tokens, 4, 42, "error message"s), 2); }
+        { BOOST_CHECK_EQUAL(Extract::optional_value<int>(tokens, 5, 42, "error message"s), 42); }
+        { BOOST_CHECK_THROW(Extract::optional_value<int>(tokens, 6, 42, "error message"s), std::runtime_error); }
+        { BOOST_CHECK_THROW(Extract::optional_value<int>(tokens, 7, 42, "error message"s), std::runtime_error); }
     }
 }
 

--- a/libs/node/src/ecflow/node/Defs.cpp
+++ b/libs/node/src/ecflow/node/Defs.cpp
@@ -739,14 +739,16 @@ void Defs::read_state(const std::string& line, const std::vector<std::string>& l
             if (!Extract::split_get_second(line_token_i, token)) {
                 throw std::runtime_error("Defs::read_state: Invalid state_change specified : " + line);
             }
-            int sc = Extract::theInt(token, "Defs::read_state: invalid state_change specified : " + line);
+            auto sc = Extract::value<Defs::state_change_no_t>(
+                token, "Defs::read_state: invalid state_change specified : " + line);
             set_state_change_no(sc);
         }
         else if (line_token_i.find("modify_change:") != std::string::npos) {
             if (!Extract::split_get_second(line_token_i, token)) {
                 throw std::runtime_error("Defs::read_state: Invalid modify_change specified : " + line);
             }
-            int mc = Extract::theInt(token, "Defs::read_state: invalid state_change specified : " + line);
+            auto mc = Extract::value<Defs::modify_change_no_t>(
+                token, "Defs::read_state: invalid state_change specified : " + line);
             set_modify_change_no(mc);
         }
         else if (line_token_i.find("server_state:") != std::string::npos) {
@@ -762,7 +764,8 @@ void Defs::read_state(const std::string& line, const std::vector<std::string>& l
             if (!Extract::split_get_second(line_token_i, token)) {
                 throw std::runtime_error("Defs::read_state: Invalid cal_count specified : " + line);
             }
-            updateCalendarCount_ = Extract::theInt(token, "Defs::read_state: invalid cal_count specified : " + line);
+            updateCalendarCount_ = Extract::value<Defs::calendar_count_t>(
+                token, "Defs::read_state: invalid cal_count specified : " + line);
         }
     }
 }
@@ -1763,12 +1766,12 @@ unsigned int Defs::defs_only_max_state_change_no() const {
     // ************************************************************************************************
     // make sure this is in sync with collate_defs_changes_only()
     // ************************************************************************************************
-    unsigned int max_change_no = 0;
-    max_change_no              = std::max(max_change_no, state_.state_change_no());
-    max_change_no              = std::max(max_change_no, order_state_change_no_);
-    max_change_no              = std::max(max_change_no, flag_.state_change_no());
-    max_change_no              = std::max(max_change_no, server_.state_change_no());
-    max_change_no              = std::max(max_change_no, server_.variable_state_change_no());
+    uint64_t max_change_no = 0;
+    max_change_no          = std::max(max_change_no, state_.state_change_no());
+    max_change_no          = std::max(max_change_no, order_state_change_no_);
+    max_change_no          = std::max(max_change_no, flag_.state_change_no());
+    max_change_no          = std::max(max_change_no, server_.state_change_no());
+    max_change_no          = std::max(max_change_no, server_.variable_state_change_no());
     return max_change_no;
 }
 

--- a/libs/node/src/ecflow/node/Defs.hpp
+++ b/libs/node/src/ecflow/node/Defs.hpp
@@ -48,6 +48,11 @@ class CalendarUpdateParams;
 
 class Defs {
 public:
+    using state_change_no_t       = uint64_t;
+    using modify_change_no_t      = uint64_t;
+    using calendar_count_t        = uint64_t;
+    using order_state_change_no_t = uint64_t;
+
     static defs_ptr create();
     static defs_ptr create(const std::string& port);
     Defs();
@@ -347,9 +352,9 @@ public:
     unsigned int defs_only_max_state_change_no() const;
 
     /// Change functions, used for *transferring* change number, from server to client
-    void set_state_change_no(unsigned int x) { state_change_no_ = x; }
+    void set_state_change_no(state_change_no_t x) { state_change_no_ = x; }
     unsigned int state_change_no() const { return state_change_no_; }
-    void set_modify_change_no(unsigned int x) { modify_change_no_ = x; }
+    void set_modify_change_no(modify_change_no_t x) { modify_change_no_ = x; }
     unsigned int modify_change_no() const { return modify_change_no_; }
 
     ClientSuiteMgr& client_suite_mgr() { return client_suite_mgr_; }
@@ -436,14 +441,14 @@ private:
 private:
     /// Note: restoring from a check point file will reset, defs state and modify numbers
     mutable size_t print_cache_{0}; // NOT persisted
-    unsigned int state_change_no_{
-        0}; // persisted since passed to client, however side effect, is it will be in checkpoint file
-    unsigned int modify_change_no_{
-        0}; // persisted since passed to client, however side effect, is it will be in checkpoint file
-    unsigned int updateCalendarCount_{0};
-    unsigned int order_state_change_no_{0}; // *NOT* persisted
-    unsigned int ecf_prune_node_log_{0};    // *NOT* persisted, only used on the server side
-    NState state_;                          // state & change_no, i,e attribute changed
+    // the following is persisted, since it is passed to client, with the side-effect that it will be in checkpoint file
+    state_change_no_t state_change_no_{0};
+    // the following is persisted, since it is passed to client, with the side-effect that it will be in checkpoint file
+    modify_change_no_t modify_change_no_{0};
+    calendar_count_t updateCalendarCount_{0};
+    order_state_change_no_t order_state_change_no_{0}; // *NOT* persisted
+    unsigned int ecf_prune_node_log_{0};               // *NOT* persisted, only used on the server side
+    NState state_;                                     // state & change_no, i,e attribute changed
     ServerState server_;
     std::vector<suite_ptr> suiteVec_;
     std::unordered_map<std::string, std::vector<std::string>> edit_history_; // path,request

--- a/libs/node/src/ecflow/node/Flag.hpp
+++ b/libs/node/src/ecflow/node/Flag.hpp
@@ -43,6 +43,8 @@ namespace ecf {
 
 class Flag {
 public:
+    using state_change_no_t = uint64_t;
+
     using underlying_type_t = int;
     static_assert(sizeof(underlying_type_t) >= 4, "Flag's underlying type must have at least 4 bytes");
 
@@ -153,8 +155,8 @@ public:
     static const char* enum_to_char_star(Flag::Type flag);
 
     /// Used to determine change in state relative to client
-    void set_state_change_no(unsigned int n) { state_change_no_ = n; }
-    unsigned int state_change_no() const { return state_change_no_; }
+    void set_state_change_no(state_change_no_t n) { state_change_no_ = n; }
+    state_change_no_t state_change_no() const { return state_change_no_; }
 
     /// returns the list of all flag types
     static std::vector<Flag::Type> list();
@@ -168,7 +170,7 @@ public:
 
 private:
     underlying_type_t flag_{0};
-    unsigned int state_change_no_{0}; // *not* persisted, only used on server side
+    state_change_no_t state_change_no_{0}; // *not* persisted, only used on server side
 
     friend class cereal::access;
     template <class Archive>

--- a/libs/node/src/ecflow/node/ServerState.hpp
+++ b/libs/node/src/ecflow/node/ServerState.hpp
@@ -30,6 +30,9 @@
 // By choosing RUNNING, it allows the Defs related test, to run without explicitly setting the state
 class ServerState {
 public:
+    using state_change_no_t         = uint64_t;
+    using variable_state_change_no_t = uint64_t;
+
     ServerState();
     explicit ServerState(const std::string& port); // used in test to init server variables
     ServerState(const ServerState& other)            = default;
@@ -99,8 +102,8 @@ public:
     std::pair<std::string, std::string> hostPort() const { return hostPort_; }
 
     /// Currently only SState::State server_state_ recorded
-    unsigned int state_change_no() const { return state_change_no_; }
-    unsigned int variable_state_change_no() const { return variable_state_change_no_; }
+    state_change_no_t state_change_no() const { return state_change_no_; }
+    variable_state_change_no_t variable_state_change_no() const { return variable_state_change_no_; }
 
     /// determines why the node is not running.
     bool why(std::vector<std::string>& theReasonWhy) const; // return true if why found
@@ -112,9 +115,9 @@ private:
     void setup_default_env(const std::string& port);
 
 private:
-    int jobSubmissionInterval_{60};            // NOT persisted, since set in the server
-    unsigned int state_change_no_{0};          // *not* persisted, only used on server side
-    unsigned int variable_state_change_no_{0}; // *not* persisted, only used on server side
+    int jobSubmissionInterval_{60};                          // NOT persisted, since set in the server
+    state_change_no_t state_change_no_{0};                   // *not* persisted, only used on server side
+    variable_state_change_no_t variable_state_change_no_{0}; // *not* persisted, only used on server side
 
     SState::State server_state_;
     std::vector<Variable> server_variables_;

--- a/libs/node/src/ecflow/node/Submittable.cpp
+++ b/libs/node/src/ecflow/node/Submittable.cpp
@@ -242,7 +242,7 @@ void Submittable::read_state(const std::string& line, const std::vector<std::str
             if (!Extract::split_get_second(line_token_i, try_number)) {
                 throw std::runtime_error("Submittable::read_state failed for try number : " + name());
             }
-            tryNo_ = Extract::theInt(try_number, "Submittable::read_state failed for try number");
+            tryNo_ = Extract::value<int>(try_number, "Submittable::read_state failed for try number");
         }
     }
 

--- a/libs/node/src/ecflow/node/Task.cpp
+++ b/libs/node/src/ecflow/node/Task.cpp
@@ -117,7 +117,7 @@ void Task::read_state(const std::string& line, const std::vector<std::string>& l
                 if (!Extract::split_get_second(lineTokens[i], token)) {
                     THROW_RUNTIME("Task::read_state could not read alias_no for task " + name());
                 }
-                alias_no_ = Extract::theInt(token, "Task::read_state: invalid alias_no specified : " + line);
+                alias_no_ = Extract::value<int>(token, "Task::read_state: invalid alias_no specified : " + line);
                 break;
             }
         }

--- a/libs/node/src/ecflow/node/parser/AutoArchiveParser.cpp
+++ b/libs/node/src/ecflow/node/parser/AutoArchiveParser.cpp
@@ -48,8 +48,7 @@ bool AutoArchiveParser::doParse(const std::string& line, std::vector<std::string
         // Must be of the form:
         // autoarchive 10        # archive 10 days after complete
         // autoarchive 0         # archive immediately after complete
-        int days = Extract::theInt(lineTokens[1], "invalid autoarchive " + line);
-
+        auto days = Extract::value<int>(lineTokens[1], "invalid autoarchive " + line);
         nodeStack_top()->add_autoarchive(AutoArchiveAttr(days, has_idle_flag(lineTokens)));
     }
     else {

--- a/libs/node/src/ecflow/node/parser/AutoCancelParser.cpp
+++ b/libs/node/src/ecflow/node/parser/AutoCancelParser.cpp
@@ -38,8 +38,7 @@ bool AutoCancelParser::doParse(const std::string& line, std::vector<std::string>
         // Must be of the form:
         // autocancel 10        # cancel 10 days after complete
         // autocancel 0         # cancel immediately after complete
-        int days = Extract::theInt(lineTokens[1], "invalid autocancel " + line);
-
+        auto days = Extract::value<int>(lineTokens[1], "invalid autocancel " + line);
         nodeStack_top()->addAutoCancel(AutoCancelAttr(days));
     }
     else {

--- a/libs/node/src/ecflow/node/parser/ClockParser.cpp
+++ b/libs/node/src/ecflow/node/parser/ClockParser.cpp
@@ -30,14 +30,13 @@ static void extractTheGain(const std::string& theGainToken, ClockAttr& clockAttr
         return;
     }
 
-    long theGain           = 0;
     std::string theGainStr = theGainToken;
     bool positiveGain      = false;
     if (theGainStr[0] == '+') {
         positiveGain = true;
         theGainStr.erase(theGainStr.begin());
     }
-    theGain = Extract::theInt(theGainStr, "Invalid clock gain:" + theGainToken);
+    auto theGain = Extract::value<int>(theGainStr, "Invalid clock gain:" + theGainToken);
     clockAttr.set_gain_in_seconds(theGain, positiveGain);
 }
 

--- a/libs/node/src/ecflow/node/parser/InlimitParser.cpp
+++ b/libs/node/src/ecflow/node/parser/InlimitParser.cpp
@@ -56,7 +56,7 @@ bool InlimitParser::doParse(const std::string& line, std::vector<std::string>& l
     }
 
     token_pos++;
-    int tokens = Extract::optionalInt(lineTokens, token_pos, 1, "Invalid in limit : " + line);
+    int tokens = Extract::optional_value<int>(lineTokens, token_pos, 1, "Invalid in limit : " + line);
 
     bool check = (rootParser()->get_file_type() != PrintStyle::NET);
 

--- a/libs/node/src/ecflow/node/parser/LimitParser.cpp
+++ b/libs/node/src/ecflow/node/parser/LimitParser.cpp
@@ -30,7 +30,7 @@ bool LimitParser::doParse(const std::string& line, std::vector<std::string>& lin
         throw std::runtime_error("LimitParser::doParse: Could not add limit as node stack is empty at line: " + line);
     }
 
-    int limitValue = Extract::theInt(lineTokens[2], "LimitParser::doParse: Invalid limit value: " + line);
+    int limitValue = Extract::value<int>(lineTokens[2], "LimitParser::doParse: Invalid limit value: " + line);
 
     Node* node = nodeStack_top();
 
@@ -43,7 +43,7 @@ bool LimitParser::doParse(const std::string& line, std::vector<std::string>& lin
         for (size_t i = 3; i < line_tokens_size; i++) {
             if (comment_fnd) {
                 if (!value_processed) {
-                    value           = Extract::theInt(lineTokens[i],
+                    value           = Extract::value<int>(lineTokens[i],
                                             "LimitParser::doParse: Could not extract limit value: " + lineTokens[i]);
                     value_processed = true;
                 }

--- a/libs/node/src/ecflow/node/parser/MeterParser.cpp
+++ b/libs/node/src/ecflow/node/parser/MeterParser.cpp
@@ -30,9 +30,10 @@ bool MeterParser::doParse(const std::string& line, std::vector<std::string>& lin
         throw std::runtime_error("MeterParser::doParse: Could not add meter as node stack is empty at line: " + line);
     }
 
-    int min         = Extract::theInt(lineTokens[2], "Invalid meter : " + line);
-    int max         = Extract::theInt(lineTokens[3], "Invalid meter : " + line);
-    int colorChange = Extract::optionalInt(lineTokens, 4, std::numeric_limits<int>::max(), "Invalid meter : " + line);
+    int min = Extract::value<int>(lineTokens[2], "Invalid meter : " + line);
+    int max = Extract::value<int>(lineTokens[3], "Invalid meter : " + line);
+    int colorChange =
+        Extract::optional_value<int>(lineTokens, 4, std::numeric_limits<int>::max(), "Invalid meter : " + line);
 
     // state
     int value = std::numeric_limits<int>::max();
@@ -41,7 +42,7 @@ bool MeterParser::doParse(const std::string& line, std::vector<std::string>& lin
         for (size_t i = 3; i < line_tokens_size; i++) {
             if (comment_fnd) {
                 // token after comment is the value
-                value = Extract::theInt(lineTokens[i], "MeterParser::doParse, could not extract meter value");
+                value = Extract::value<int>(lineTokens[i], "MeterParser::doParse, could not extract meter value");
                 break;
             }
             if (lineTokens[i] == "#") {

--- a/libs/node/src/ecflow/node/parser/RepeatParser.cpp
+++ b/libs/node/src/ecflow/node/parser/RepeatParser.cpp
@@ -42,7 +42,7 @@ bool RepeatParser::doParse(const std::string& line, std::vector<std::string>& li
         string name  = lineTokens[2];
         int startYMD = Extract::ymd(lineTokens[3], errorMsg);
         int endYMD   = Extract::ymd(lineTokens[4], errorMsg);
-        int delta    = Extract::optionalInt(lineTokens, 5, 1, errorMsg);
+        int delta    = Extract::optional_value<int>(lineTokens, 5, 1, errorMsg);
         RepeatDate rep(name, startYMD, endYMD, delta);
         int value = 0;
         if (get_value(lineTokens, value)) {
@@ -150,9 +150,9 @@ bool RepeatParser::doParse(const std::string& line, std::vector<std::string>& li
         }
 
         string name = lineTokens[2];
-        int start   = Extract::theInt(lineTokens[3], errorMsg);
-        int end     = Extract::theInt(lineTokens[4], errorMsg);
-        int step    = Extract::optionalInt(lineTokens, 5, 1, errorMsg);
+        auto start  = Extract::value<int>(lineTokens[3], errorMsg);
+        auto end    = Extract::value<int>(lineTokens[4], errorMsg);
+        auto step   = Extract::optional_value<int>(lineTokens, 5, 1, errorMsg);
         RepeatInteger rep(name, start, end, step);
         int value = 0;
         if (get_value(lineTokens, value)) {
@@ -165,7 +165,7 @@ bool RepeatParser::doParse(const std::string& line, std::vector<std::string>& li
         // repeat day step [ yyyymmdd ]  # the step can be positive or negative
         // *** See RepeatAttr.h ***
         // *** We will not support end date until there is a clear requirement for this
-        int step = Extract::theInt(lineTokens[2], "Invalid repeat day:");
+        auto step = Extract::value<int>(lineTokens[2], "Invalid repeat day:");
 
         // report end date as a parser error
         if (line_token_size >= 4 && lineTokens[3][0] != '#') {
@@ -254,7 +254,8 @@ bool RepeatParser::get_value(const std::vector<std::string>& lineTokens, int& va
         for (size_t i = lineTokens.size() - 1; i > 3; i--) {
             if (lineTokens[i] == "#") {
                 // token after comment is the value
-                value = Extract::theInt(token_after_comment, "RepeatParser::doParse, could not extract repeat value");
+                value =
+                    Extract::value<int>(token_after_comment, "RepeatParser::doParse, could not extract repeat value");
                 return true;
             }
             else {

--- a/libs/node/src/ecflow/node/parser/VerifyParser.cpp
+++ b/libs/node/src/ecflow/node/parser/VerifyParser.cpp
@@ -48,8 +48,8 @@ bool VerifyParser::doParse(const std::string& line, std::vector<std::string>& li
             throw std::runtime_error("VerifyParser::doParse: Invalid state :" + line);
         }
 
-        NState::State theState  = NState::toState(state);
-        int theExpectedStateCnt = Extract::theInt(expected, "Invalid verify");
+        auto theState            = NState::toState(state);
+        auto theExpectedStateCnt = Extract::value<int>(expected, "Invalid verify");
 
         // STATE
         int actual = 0;


### PR DESCRIPTION
### Description

This ensures a consistent use of uint64_t when parsing and setting modify/state change counts from the Checkpoint files.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-227
<!-- PREVIEW-URL_END -->