### PR TITLE
Restrict Mirror minimum polling period to 60 seconds ECFLOW-1995

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -1441,6 +1441,11 @@ Glossary
         - :code:`polling`, the value (in seconds) used to periodically contact the remote ecFlow server
         - :code:`auth`, the location to the Mirror authentication credentials file
 
+      .. warning::
+
+        The minimum value allowed for :code:`polling` is 60 seconds. When a lower value is provided,
+        it will be automatically reset to the minimum value.
+
       The value of the properties :code:`remote_host`, :code:`remote_port`, :code:`polling`,
       and :code:`auth` can be composed of :term:`Variables<variable>`. When
       these properties are not provided, the following default values are used:


### PR DESCRIPTION
Re ECFLOW-1995

### Description

Restrict Mirror minimum polling period to 60 seconds

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-244
<!-- PREVIEW-URL_END -->