### PR TITLE
Correct initialisation of password buffer

### DIFF
--- a/libs/core/src/ecflow/core/Passwd.cpp
+++ b/libs/core/src/ecflow/core/Passwd.cpp
@@ -17,8 +17,8 @@
 double ecf_drand48();
 
 std::string Passwd::generate() {
-    std::string pw{9, '\0'};
-    for (size_t i = 0; i < 8; i++) { /* generate a random password */
+    std::array<char, 8> pw;
+    for (size_t i = 0; i < pw.size(); i++) { /* generate a random password */
 
         pw[i] = 64.0 * ecf_drand48() + '.'; /* Just crack this one! */
         if (pw[i] > '9') {
@@ -29,7 +29,7 @@ std::string Passwd::generate() {
         }
     }
 
-    return pw;
+    return std::string(pw.begin(), pw.end());
 }
 
 double ecf_drand48()


### PR DESCRIPTION
### Description

Correct initialisation of password buffer, detected as a memory corruption issue while using GCC 15.2.1 on Fedora 42.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-266
<!-- PREVIEW-URL_END -->