### PR TITLE
Update the hash function used to sign the Certificates

### DIFF
--- a/libs/rest/test/Certificate.hpp
+++ b/libs/rest/test/Certificate.hpp
@@ -138,7 +138,7 @@ inline X509* Certificate::generate_x509(EVP_PKEY* pkey) {
     X509_set_issuer_name(x509, name);
 
     /* Actually sign the certificate with our key. */
-    if (!X509_sign(x509, pkey, EVP_sha1())) {
+    if (!X509_sign(x509, pkey, EVP_sha256())) {
         X509_free(x509);
         EVP_PKEY_free(pkey);
         throw std::runtime_error("Error signing certificate");


### PR DESCRIPTION
### Description

Update the hash function used to sign the Certificates
This is used only for the REST API testing, and is necessary because the certificate signature was failing on AlmaLinux 10.x.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-267
<!-- PREVIEW-URL_END -->