### PR TITLE
Restrict s_foolproof test execution on ArchLinux

### DIFF
--- a/.github/workflows/extra.yml
+++ b/.github/workflows/extra.yml
@@ -28,12 +28,12 @@ jobs:
           - almalinux-9.7
           - almalinux-10.1
         preset:
-          - linux.gcc.all.relwithdebinfo
-          - linux.clang.all.relwithdebinfo
+          - linux.gcc.all.release
+          - linux.clang.all.release
         jobs: [ 4 ]
         exclude:
           - os: almalinux-9.7
-            preset: linux.clang.all.relwithdebinfo
+            preset: linux.clang.all.release
             # This combination is not supported, as Clang fails to compile Chrono.hpp which does #include <boost/date_time/local_time/conversion.hpp
             # and ends up with the following error:
             #   /usr/include/boost/mpl/aux_/integral_wrapper.hpp:73:31: error: non-type template argument is not a constant expression
@@ -76,25 +76,25 @@ jobs:
           cmake --build --preset ${{ matrix.preset }} --jobs ${{ matrix.jobs }}
 
       - name: Test ecflow (default)
-        if: ${{ matrix.os != 'alpine-3.23' }}
+        if: ${{ matrix.os != 'alpine-3.23' && matrix.os != 'arch-20260104'}}
         run: |
           cd ${RUNNER_WORKSPACE}/ecflow/ecflow
           ctest --preset  ${{ matrix.preset }} --output-on-failure -L nightly -j ${{ matrix.jobs }}
 
-      - name: Test ecflow (specific to Alpine, due to Boost.Test crash)
-        if: ${{ matrix.os == 'alpine-3.23' }}
+      - name: Test ecflow (specific to some distros, due to Boost.Test crash)
+        if: ${{ matrix.os == 'alpine-3.23' || matrix.os == 'arch-20260104'}}
         run: |
           cd ${RUNNER_WORKSPACE}/ecflow/ecflow
           ctest --preset  ${{ matrix.preset }} --output-on-failure -L nightly -E s_foolproof -j ${{ matrix.jobs }}
 
       - name: Lint ecflow
-        if: ${{ matrix.preset == 'linux.clang.all.relwithdebinfo' && matrix.os == 'ubuntu-24.04' && !always() }} # Disable until we have a stable build
+        if: ${{ matrix.preset == 'linux.clang.all.release' && matrix.os == 'ubuntu-24.04' && !always() }} # Disable until we have a stable build
         run: |
           cd ${RUNNER_WORKSPACE}/ecflow/ecflow
           run-clang-tidy -j ${{ matrix.jobs }} -p ${RUNNER_WORKSPACE}/ecflow/ecflow/.deploy/build/${{ matrix.preset }} | tee clang-tidy-report.txt
 
       - name: Archive lint report 
-        if: ${{ matrix.preset == 'linux.clang.all.relwithdebinfo' && matrix.os == 'ubuntu-24.04' && !always() }} # Disable until we have a stable build
+        if: ${{ matrix.preset == 'linux.clang.all.release' && matrix.os == 'ubuntu-24.04' && !always() }} # Disable until we have a stable build
         uses: actions/upload-artifact@v4
         with:
           name: cling-tidy-report

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -41,6 +41,40 @@
       "environment"   : {}
     },
     {
+      "name"          : "linux.gcc.all.release",
+      "description"   : "Build environment on 'Linux', compiled with 'GNU GCC'",
+      "generator"     : "Ninja",
+      "binaryDir"     : "${sourceDir}/.deploy/build/${presetName}",
+      "installDir"    : "${sourceDir}/.deploy/install/${presetName}",
+      "condition"     : {
+        "type": "equals",
+        "lhs" : "${hostSystemName}",
+        "rhs" : "Linux"
+      },
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE"             : "Release",
+        "CMAKE_VERBOSE_MAKEFILE"       : "ON",
+        "CMAKE_COLOR_DIAGNOSTICS"      : "ON",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "CMAKE_C_COMPILER"             : "gcc",
+        "CMAKE_CXX_COMPILER"           : "g++",
+        "CPACK_PACKAGE_NAME"           : "ecflow",
+        "ENABLE_TESTS"                 : "ON",
+        "ENABLE_ALL_TESTS"             : "ON",
+        "ENABLE_DOCS"                  : "OFF",
+        "ENABLE_PYTHON"                : "ON",
+        "ENABLE_SERVER"                : "ON",
+        "ENABLE_SSL"                   : "ON",
+        "ENABLE_UDP"                   : "ON",
+        "ENABLE_HTTP"                  : "ON",
+        "ENABLE_UI"                    : "ON",
+        "ENABLE_STATIC_BOOST_LIBS"     : "OFF",
+        "ENABLE_DEBIAN_PACKAGE"        : "ON",
+        "Boost_INCLUDE_DIR"            : "/usr/include"
+      },
+      "environment"   : {}
+    },
+    {
       "name"          : "linux.clang.all.relwithdebinfo",
       "description"   : "Build environment on 'Linux', compiled with 'LLVM Clang'",
       "generator"     : "Ninja",
@@ -53,6 +87,40 @@
       },
       "cacheVariables": {
         "CMAKE_BUILD_TYPE"             : "RelWithDebInfo",
+        "CMAKE_VERBOSE_MAKEFILE"       : "ON",
+        "CMAKE_COLOR_DIAGNOSTICS"      : "ON",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "CMAKE_C_COMPILER"             : "clang",
+        "CMAKE_CXX_COMPILER"           : "clang++",
+        "CPACK_PACKAGE_NAME"           : "ecflow",
+        "ENABLE_TESTS"                 : "ON",
+        "ENABLE_ALL_TESTS"             : "ON",
+        "ENABLE_DOCS"                  : "OFF",
+        "ENABLE_PYTHON"                : "ON",
+        "ENABLE_SERVER"                : "ON",
+        "ENABLE_SSL"                   : "ON",
+        "ENABLE_UDP"                   : "ON",
+        "ENABLE_HTTP"                  : "ON",
+        "ENABLE_UI"                    : "ON",
+        "ENABLE_STATIC_BOOST_LIBS"     : "OFF",
+        "ENABLE_DEBIAN_PACKAGE"        : "ON",
+        "Boost_INCLUDE_DIR"            : "/usr/include"
+      },
+      "environment"   : {}
+    },
+    {
+      "name"          : "linux.clang.all.release",
+      "description"   : "Build environment on 'Linux', compiled with 'LLVM Clang'",
+      "generator"     : "Ninja",
+      "binaryDir"     : "${sourceDir}/.deploy/build/${presetName}",
+      "installDir"    : "${sourceDir}/.deploy/install/${presetName}",
+      "condition"     : {
+        "type": "equals",
+        "lhs" : "${hostSystemName}",
+        "rhs" : "Linux"
+      },
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE"             : "Release",
         "CMAKE_VERBOSE_MAKEFILE"       : "ON",
         "CMAKE_COLOR_DIAGNOSTICS"      : "ON",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
@@ -115,8 +183,16 @@
       "configurePreset": "linux.gcc.all.relwithdebinfo"
     },
     {
+      "name"           : "linux.gcc.all.release",
+      "configurePreset": "linux.gcc.all.release"
+    },
+    {
       "name"           : "linux.clang.all.relwithdebinfo",
       "configurePreset": "linux.clang.all.relwithdebinfo"
+    },
+    {
+      "name"           : "linux.clang.all.release",
+      "configurePreset": "linux.clang.all.release"
     },
     {
       "name": "linux.gcc.serveronly.relwithdebinfo",
@@ -136,8 +212,30 @@
       }
     },
     {
+      "name"           : "linux.gcc.all.release",
+      "configurePreset": "linux.gcc.all.release",
+      "output"         : {
+        "outputOnFailure": true
+      },
+      "execution"      : {
+        "noTestsAction": "error",
+        "stopOnFailure": true
+      }
+    },
+    {
       "name"           : "linux.clang.all.relwithdebinfo",
       "configurePreset": "linux.clang.all.relwithdebinfo",
+      "output"         : {
+        "outputOnFailure": true
+      },
+      "execution"      : {
+        "noTestsAction": "error",
+        "stopOnFailure": true
+      }
+    },
+    {
+      "name"           : "linux.clang.all.release",
+      "configurePreset": "linux.clang.all.release",
       "output"         : {
         "outputOnFailure": true
       },


### PR DESCRIPTION
### Description

Restrict s_foolproof test execution on ArchLinux

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-282
<!-- PREVIEW-URL_END -->