### PR TITLE
refactor: remove unnecessary replaceall

### DIFF
--- a/libs/attribute/src/ecflow/attribute/NodeAttr.cpp
+++ b/libs/attribute/src/ecflow/attribute/NodeAttr.cpp
@@ -347,7 +347,7 @@ void Label::write(std::string& ret) const {
     else {
         // replace \n, otherwise re-parse will fail
         std::string value = v_;
-        Str::replaceall(value, "\n", "\\n");
+        Str::replace_all(value, "\n", "\\n");
         ret += value;
     }
     ret += "\"";
@@ -399,7 +399,7 @@ void Label::parse(const std::string& line,
         Str::removeSingleQuotes(lineTokens[2]);
         the_value = lineTokens[2];
         if (the_value.find("\\n") != std::string::npos) {
-            Str::replaceall(the_value, "\\n", "\n");
+            Str::replace_all(the_value, "\\n", "\n");
         }
     }
     else {
@@ -422,7 +422,7 @@ void Label::parse(const std::string& line,
         Str::removeSingleQuotes(value);
         the_value = value;
         if (the_value.find("\\n") != std::string::npos) {
-            Str::replaceall(the_value, "\\n", "\n");
+            Str::replace_all(the_value, "\\n", "\n");
         }
 
         // state
@@ -450,7 +450,7 @@ void Label::parse(const std::string& line,
                 the_new_value = new_value;
 
                 if (the_new_value.find("\\n") != std::string::npos) {
-                    Str::replaceall(the_new_value, "\\n", "\n");
+                    Str::replace_all(the_new_value, "\\n", "\n");
                 }
             }
         }

--- a/libs/attribute/src/ecflow/attribute/Variable.cpp
+++ b/libs/attribute/src/ecflow/attribute/Variable.cpp
@@ -76,7 +76,7 @@ void Variable::write(std::string& ret) const {
     else {
         // replace \n, otherwise re-parse will fail
         std::string value = v_;
-        Str::replaceall(value, "\n", "\\n");
+        Str::replace_all(value, "\n", "\\n");
         ret += value;
     }
     ret += "'";

--- a/libs/base/src/ecflow/base/cts/user/AlterCmd.cpp
+++ b/libs/base/src/ecflow/base/cts/user/AlterCmd.cpp
@@ -1511,7 +1511,7 @@ void AlterCmd::extract_name_and_value_for_change(AlterCmd::Change_attr_type theA
                 }
                 value = options[3];
                 if (value.find("\\n") != std::string::npos) {
-                    Str::replaceall(value, "\\n", "\n");
+                    Str::replace_all(value, "\\n", "\n");
                 }
             }
             name = options[2];

--- a/libs/core/src/ecflow/core/Str.cpp
+++ b/libs/core/src/ecflow/core/Str.cpp
@@ -73,21 +73,20 @@ void Str::removeSingleQuotes(std::string& s) {
     }
 }
 
-bool Str::replace(std::string& jobLine, const std::string& stringToFind, const std::string& stringToReplace) {
-    size_t pos = jobLine.find(stringToFind);
-    if (pos != std::string::npos) {
-        jobLine.replace(pos, stringToFind.length(), stringToReplace);
+bool Str::replace(std::string& input, const std::string& find, const std::string& replace) {
+    if (size_t pos = input.find(find); pos != std::string::npos) {
+        input.replace(pos, find.length(), replace);
         return true;
     }
     return false;
 }
 
-bool Str::replace_all(std::string& subject, const std::string& stringToFind, const std::string& stringToReplace) {
+bool Str::replace_all(std::string& input, const std::string& find, const std::string& replace) {
     bool replaced = false;
     size_t pos    = 0;
-    while ((pos = subject.find(stringToFind, pos)) != std::string::npos) {
-        subject.replace(pos, stringToFind.length(), stringToReplace);
-        pos += stringToReplace.length();
+    while ((pos = input.find(find, pos)) != std::string::npos) {
+        input.replace(pos, find.length(), replace);
+        pos += replace.length();
         replaced = true;
     }
     return replaced;
@@ -113,10 +112,6 @@ bool Str::extract_data_member_value(const std::string& str,
         return true;
     }
     return false;
-}
-
-void Str::replaceall(std::string& subject, const std::string& search, const std::string& replace) {
-    boost::replace_all(subject, search, replace);
 }
 
 #define USE_STRINGSPLITTER 1

--- a/libs/core/src/ecflow/core/Str.hpp
+++ b/libs/core/src/ecflow/core/Str.hpp
@@ -173,11 +173,25 @@ public:
     //  fred  -> fred
     static void removeSingleQuotes(std::string&);
 
-    /// Find 'stringToFind' in 'jobLine' and replace with string 'stringToReplace'
-    /// return true if replace ok else returns false;
-    static bool replace(std::string& subject, const std::string& stringToFind, const std::string& stringToReplace);
-    static bool replace_all(std::string& subject, const std::string& stringToFind, const std::string& stringToReplace);
-    static void replaceall(std::string& subject, const std::string& stringToFind, const std::string& stringToReplace);
+    ///
+    /// @brief Replace the first occurrence of 'find' with 'replace' in 'input'.
+    ///
+    /// @param input The input string in which to perform the replacement.
+    /// @param find The string to search for within the input.
+    /// @param replace The string to replace occurrences of 'find' with.
+    /// @return true if a replacement was made, false otherwise.
+    ///
+    static bool replace(std::string& input, const std::string& find, const std::string& replace);
+
+    ///
+    /// @brief Replace all occurrences of 'find' with 'replace' in 'input'.
+    ///
+    /// @param input The input string in which to perform the replacement.
+    /// @param find The string to search for within the input.
+    /// @param replace The string to replace occurrences of 'find' with.
+    /// @return true if at least one replacement was made, false otherwise.
+    ///
+    static bool replace_all(std::string& input, const std::string& find, const std::string& replace);
 
     // extract data member value, ie given a string of the form:
     //   str=cmd a b fred:value

--- a/libs/core/test/TestStr.cpp
+++ b/libs/core/test/TestStr.cpp
@@ -415,44 +415,55 @@ BOOST_AUTO_TEST_CASE(test_str_split_make_split_iterator) {
     check(line, Str::make_split_iterator(line), expected);
 }
 
-static void
-test_replace(std::string& testStr, const std::string& find, const std::string& replace, const std::string& expected) {
-    BOOST_CHECK_MESSAGE(Str::replace(testStr, find, replace),
-                        "Replace failed for " << testStr << " find(" << find << ") replace(" << replace << ")");
-    BOOST_CHECK_MESSAGE(testStr == expected, "Expected '" << expected << "' but found '" << testStr << "'");
+static void test_replace(const std::string& input,
+                         const std::string& find,
+                         const std::string& replace,
+                         const std::string& expected) {
+
+    auto actual = input;
+
+    { // Check that replacement happens as expected
+        auto result = Str::replace(actual, find, replace);
+
+        BOOST_CHECK_MESSAGE(result,
+                            "Replace failed for " << actual << " find(" << find << ") replace(" << replace << ")");
+        BOOST_CHECK_MESSAGE(actual == expected, "Expected '" << expected << "' but found '" << actual << "'");
+    }
 }
 
-static void test_replace_all(std::string& testStr,
+static void test_replace_all(const std::string& input,
                              const std::string& find,
                              const std::string& replace,
                              const std::string& expected) {
-    std::string testStrCopy = testStr;
+    auto actual = input;
 
-    BOOST_CHECK_MESSAGE(Str::replace_all(testStr, find, replace),
-                        "Replace failed for " << testStr << " find(" << find << ") replace(" << replace << ")");
-    BOOST_CHECK_MESSAGE(testStr == expected, "Expected '" << expected << "' but found '" << testStr << "'");
+    { // Check that replacement happens as expected
+        bool result = Str::replace_all(actual, find, replace);
 
-    Str::replaceall(testStrCopy, find, replace);
-    BOOST_CHECK_MESSAGE(testStr == testStrCopy, "Expected '" << testStrCopy << "' but found '" << testStr << "'");
+        BOOST_CHECK_MESSAGE(result,
+                            "Replace successful for " << actual << " find(" << find << ") replace(" << replace << ")");
+        BOOST_CHECK_MESSAGE(actual == expected, "Expected '" << expected << "' but found '" << actual << "'");
+    }
+
+    auto copy = actual;
+
+    { // Ensure that attempting replacement again returns false and does not change the input string
+        bool result = Str::replace_all(copy, find, replace);
+
+        BOOST_CHECK_MESSAGE(!result,
+                            "Replace unsuccessful for " << copy << " find(" << find << ") replace(" << replace
+                                                        << "), since no occurrences were left");
+        BOOST_CHECK_MESSAGE(actual == copy, "Expected '" << actual << "' but found '" << copy << "'");
+    }
 }
 
 BOOST_AUTO_TEST_CASE(test_str_replace) {
     ECF_NAME_THIS_TEST();
 
-    std::string testStr = "This is a string";
-    test_replace(testStr, "This", "That", "That is a string");
-
-    testStr = "This is a string";
-    test_replace(testStr, "This is a string", "", "");
-
-    testStr = "This is a string";
-    test_replace(testStr, "is a", "was a", "This was a string");
-
-    testStr = "This\n is a string";
-    test_replace(testStr, "\n", "\\n", "This\\n is a string");
-
-    testStr = "This\n is\n a\n string\n";
-    test_replace_all(testStr, "\n", "\\n", R"(This\n is\n a\n string\n)");
+    test_replace("This is a string", "This", "That", "That is a string");
+    test_replace("This is a string", "This is a string", "", "");
+    test_replace("This is a string", "is a", "was a", "This was a string");
+    test_replace("This\n is a string", "\n", "\\n", "This\\n is a string");
 
     // Test case insenstive string comparison
     BOOST_CHECK_MESSAGE(Str::caseInsCompare("", ""), " bug1");
@@ -465,23 +476,12 @@ BOOST_AUTO_TEST_CASE(test_str_replace) {
 BOOST_AUTO_TEST_CASE(test_str_replace_all) {
     ECF_NAME_THIS_TEST();
 
-    std::string testStr = "This is a string";
-    test_replace_all(testStr, "This", "That", "That is a string");
-
-    testStr = "This is a string";
-    test_replace_all(testStr, "This is a string", "", "");
-
-    testStr = "This is a string";
-    test_replace_all(testStr, "is a", "was a", "This was a string");
-
-    testStr = "This\n is a string";
-    test_replace_all(testStr, "\n", "\\n", "This\\n is a string");
-
-    testStr = "This\n is\n a\n string\n";
-    test_replace_all(testStr, "\n", "\\n", R"(This\n is\n a\n string\n)");
-
-    testStr = "This\n is\n a\n string\n";
-    test_replace_all(testStr, "\n", "", "This is a string");
+    test_replace_all("This is a string", "This", "That", "That is a string");
+    test_replace_all("This is a string", "This is a string", "", "");
+    test_replace_all("This is a string", "is a", "was a", "This was a string");
+    test_replace_all("This\n is a string", "\n", "\\n", "This\\n is a string");
+    test_replace_all("This\n is\n a\n string\n", "\n", "\\n", R"(This\n is\n a\n string\n)");
+    test_replace_all("This\n is\n a\n string\n", "\n", "", "This is a string");
 }
 
 BOOST_AUTO_TEST_CASE(test_str_to_int) {

--- a/libs/node/src/ecflow/node/Defs.cpp
+++ b/libs/node/src/ecflow/node/Defs.cpp
@@ -692,7 +692,7 @@ std::string Defs::dump_edit_history() const {
             }
             else {
                 std::string h = c;
-                Str::replaceall(h, "\n", "\\n");
+                Str::replace_all(h, "\n", "\\n");
                 ss << " ";
                 ss << h;
             }

--- a/libs/node/src/ecflow/node/NodeContainer.cpp
+++ b/libs/node/src/ecflow/node/NodeContainer.cpp
@@ -1087,7 +1087,7 @@ std::string NodeContainer::archive_path() const {
     }
 
     std::string the_archive_file_name = absNodePath();
-    Str::replaceall(the_archive_file_name, "/", ":"); // we use ':' since it is not allowed in the node names
+    Str::replace_all(the_archive_file_name, "/", ":"); // we use ':' since it is not allowed in the node names
     the_archive_file_name += ".check";
 
     std::string port = ecf::string_constants::default_port_number;

--- a/libs/node/src/ecflow/node/Submittable.cpp
+++ b/libs/node/src/ecflow/node/Submittable.cpp
@@ -205,8 +205,8 @@ void Submittable::write_state(std::string& ret, bool& added_comment_char) const 
     if (!abr_.empty()) {
         add_comment_char(ret, added_comment_char);
         std::string the_abort_reason = abr_;
-        Str::replaceall(the_abort_reason, "\n", "\\n");
-        Str::replaceall(the_abort_reason, ";", " ");
+        Str::replace_all(the_abort_reason, "\n", "\\n");
+        Str::replace_all(the_abort_reason, ";", " ");
         ret += " abort<:";
         ret += the_abort_reason;
         ret += ">abort";

--- a/libs/node/src/ecflow/node/formatter/DefsWriter.hpp
+++ b/libs/node/src/ecflow/node/formatter/DefsWriter.hpp
@@ -1265,7 +1265,7 @@ struct Writer<Label, Stream>
                 }
                 else {
                     std::string value = item.new_value();
-                    Str::replaceall(value, "\n", "\\n");
+                    Str::replace_all(value, "\n", "\\n");
                     output << " # \"";
                     output << value;
                     output << "\"";
@@ -2269,7 +2269,7 @@ private:
                     }
                     else {
                         std::string h = c;
-                        Str::replaceall(h, "\n", "\\n");
+                        Str::replace_all(h, "\n", "\\n");
                         output << "\b";
                         output << h;
                     }

--- a/libs/node/test/parser/ParseTimer.cpp
+++ b/libs/node/test/parser/ParseTimer.cpp
@@ -148,7 +148,7 @@ int main(int argc, char* argv[]) {
 #endif
 
         std::string json_filepath = MESSAGE("/var/tmp/ma0/JSON/" << prefix << fs_path.stem() << ".json");
-        Str::replaceall(json_filepath, "\"", ""); // fs_path.stem() seems to add ", so remove them
+        Str::replace_all(json_filepath, "\"", ""); // fs_path.stem() seems to add ", so remove them
         // cout << "  json_filepath: " << json_filepath << endl;
 
         std::remove(json_filepath.c_str());


### PR DESCRIPTION
### Description

For unclear reasons replaceall is an alias to replace_all function, and thus unnecessary. These changes replace replaceall with the more aptly named replace_all, and completely remove replaceall.

Also, adds documentation and makes use of clear names for the parameters.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-313
<!-- PREVIEW-URL_END -->