### PR TITLE
refactor: remove duplicate get_token implementations ECFLOW-2076

### DIFF
--- a/libs/core/src/ecflow/core/Str.cpp
+++ b/libs/core/src/ecflow/core/Str.cpp
@@ -253,26 +253,21 @@ std::vector<std::string_view> Str::tokenize_quotation(const std::string& s, std:
     return tokens;
 }
 
-bool Str::get_token(std::string_view str, size_t pos, std::string& token, std::string_view delims) {
-    //   Time for StringSplitter::get_token 250000 times = 1.457s wall, (1.460s user + 0.000s system = 1.460s) CPU
-    //   (100.2%) Time for Str::get_token            250000 times = 0.566s wall, (0.560s user + 0.000s system = 0.560s)
-    //   CPU (99.0%) Time for Str::get_token2           250000 times = 0.668s wall, (0.670s user + 0.000s system =
-    //   0.670s) CPU (100.3%) Time for Str::get_token3           250000 times = 0.620s wall, (0.620s user + 0.000s
-    //   system = 0.620s) CPU (100.0%)
+bool Str::get_token(std::string_view input, size_t index, std::string& token, std::string_view delimiters) {
 
-    size_t current_pos = 0;
-    auto first         = std::cbegin(str);
-    auto end           = std::cend(str);
+    size_t current_index = 0;
+    auto first           = std::cbegin(input);
+    auto end             = std::cend(input);
 
     while (first != end) {
-        const auto second = std::find_first_of(first, end, std::cbegin(delims), std::cend(delims));
+        const auto second = std::find_first_of(first, end, std::cbegin(delimiters), std::cend(delimiters));
 
         if (first != second) {
-            if (current_pos == pos) {
+            if (current_index == index) {
                 token = std::string(first, second);
                 return true;
             }
-            current_pos++;
+            current_index++;
         }
 
         if (second == end) {
@@ -280,47 +275,6 @@ bool Str::get_token(std::string_view str, size_t pos, std::string& token, std::s
         }
 
         first = std::next(second);
-    }
-    return false;
-}
-
-bool Str::get_token2(std::string_view strv, size_t pos, std::string& token, std::string_view delims) {
-    size_t current_pos = 0;
-    size_t first       = 0;
-    while (first < strv.size()) {
-        const auto second = strv.find_first_of(delims, first);
-
-        if (first != second) {
-            if (current_pos == pos) {
-                std::string_view ref = strv.substr(first, second - first);
-                token                = std::string(ref.begin(), ref.end());
-                return true;
-            }
-            current_pos++;
-        }
-
-        if (second == std::string_view::npos) {
-            break;
-        }
-
-        first = second + 1;
-    }
-    return false;
-}
-
-bool Str::get_token3(std::string_view str, size_t pos, std::string& token, std::string_view delims) {
-    size_t current_pos = 0;
-    for (auto first = str.data(), second = str.data(), last = first + str.size(); second != last && first != last;
-         first = second + 1) {
-
-        second = std::find_first_of(first, last, std::cbegin(delims), std::cend(delims));
-        if (first != second) {
-            if (current_pos == pos) {
-                token = std::string(first, second - first);
-                return true;
-            }
-            current_pos++;
-        }
     }
     return false;
 }

--- a/libs/core/src/ecflow/core/Str.hpp
+++ b/libs/core/src/ecflow/core/Str.hpp
@@ -224,10 +224,17 @@ public:
                                          std::vector<std::string>& tokens,
                                          std::string_view delimiters = " \t");
 
-    // Get token at a given pos. Two different implementations
-    static bool get_token(std::string_view line, size_t pos, std::string& token, std::string_view sep = " \t");
-    static bool get_token2(std::string_view line, size_t pos, std::string& token, std::string_view sep = " \t");
-    static bool get_token3(std::string_view line, size_t pos, std::string& token, std::string_view sep = " \t");
+    ///
+    /// @brief Extract the token at the specified index from the input string, using the given delimiters.
+    ///
+    /// @param input The input string to tokenise.
+    /// @param index The (0-based) index of the token to extract.
+    /// @param token The extracted token.
+    /// @param delimiters The set of characters to use as token separators.
+    /// @return true if a token was found at the specified index, false otherwise.
+    ///
+    static bool
+    get_token(std::string_view input, size_t index, std::string& token, std::string_view delimiters = " \t");
 
     // Uses boost::make_split_iterator will remove
     // consecutive delimiters in the middle of the string

--- a/libs/core/test/TestStr.cpp
+++ b/libs/core/test/TestStr.cpp
@@ -186,26 +186,20 @@ static void check_splitters(const std::string& line, const std::vector<std::stri
 
     // While were at it also check get_token
     for (size_t i = 0; i < result1.size(); i++) {
-        std::string token;
-        BOOST_CHECK_MESSAGE(Str::get_token(line, i, token) && token == result1[i],
-                            "Str::get_token failed for pos " << i << " line:'" << line << "' expected '" << result1[i]
-                                                             << "' but found '" << token << "'");
+        {
+            std::string token;
+            BOOST_CHECK_MESSAGE(Str::get_token(line, i, token) && token == result1[i],
+                                "Str::get_token failed for pos " << i << " line:'" << line << "' expected '"
+                                                                 << result1[i] << "' but found '" << token << "'");
+        }
 
-        token.clear();
-        BOOST_CHECK_MESSAGE(Str::get_token2(line, i, token) && token == result1[i],
-                            "Str::get_token2 failed for pos " << i << " line:'" << line << "' expected '" << result1[i]
-                                                              << "' but found '" << token << "'");
-
-        token.clear();
-        BOOST_CHECK_MESSAGE(Str::get_token3(line, i, token) && token == result1[i],
-                            "Str::get_token3 failed for pos " << i << " line:'" << line << "' expected '" << result1[i]
-                                                              << "' but found '" << token << "'");
-
-        token.clear();
-        BOOST_CHECK_MESSAGE(StringSplitter::get_token(line, i, token) && token == result1[i],
-                            "StringSplitter::get_token failed for pos " << i << " line:'" << line << "' expected '"
-                                                                        << result1[i] << "' but found '" << token
-                                                                        << "'");
+        {
+            std::string token;
+            BOOST_CHECK_MESSAGE(StringSplitter::get_token(line, i, token) && token == result1[i],
+                                "StringSplitter::get_token failed for pos " << i << " line:'" << line << "' expected '"
+                                                                            << result1[i] << "' but found '" << token
+                                                                            << "'");
+        }
     }
 }
 
@@ -916,6 +910,67 @@ BOOST_AUTO_TEST_CASE(test_str_split_by) {
                             "Failed for input: '" << testCase.input << "' pattern: '" << testCase.pattern
                                                   << "'. Expected: " << toString(testCase.expected)
                                                   << " but found: " << toString(result));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_str_get_token) {
+
+    struct TestCase
+    {
+        std::string input;
+        size_t index;
+        std::string delimiters;
+        bool expected_outcome;
+        std::string expected_token;
+    };
+
+    std::vector<TestCase> testCases = {
+        // all tokens can be accessed
+        {"0,1,2,3,4,5,6,7,8,9,10", 0, ",", true, "0"},
+        {"0,1,2,3,4,5,6,7,8,9,10", 1, ",", true, "1"},
+        {"0,1,2,3,4,5,6,7,8,9,10", 2, ",", true, "2"},
+        {"0,1,2,3,4,5,6,7,8,9,10", 3, ",", true, "3"},
+        {"0,1,2,3,4,5,6,7,8,9,10", 4, ",", true, "4"},
+        {"0,1,2,3,4,5,6,7,8,9,10", 5, ",", true, "5"},
+        {"0,1,2,3,4,5,6,7,8,9,10", 6, ",", true, "6"},
+        {"0,1,2,3,4,5,6,7,8,9,10", 7, ",", true, "7"},
+        {"0,1,2,3,4,5,6,7,8,9,10", 8, ",", true, "8"},
+        {"0,1,2,3,4,5,6,7,8,9,10", 9, ",", true, "9"},
+        {"0,1,2,3,4,5,6,7,8,9,10", 10, ",", true, "10"},
+
+        // out-of-range tokens are correctly handled
+        {"0,1,2,3,4,5,6,7,8,9,10", 11, ",", false, ""},
+        {"0,1,2,3,4,5,6,7,8,9,10", 12, ",", false, ""},
+
+        // now using another delimiter
+        {"0 1 2 3 4 5 6 7 8 9 10", 0, " ", true, "0"},
+        {"0 1 2 3 4 5 6 7 8 9 10", 5, " ", true, "5"},
+        {"0 1 2 3 4 5 6 7 8 9 10", 10, " ", true, "10"},
+        {"0 1 2 3 4 5 6 7 8 9 10", 42, " ", false, ""},
+
+        // now using multiple delimiters
+        {"0 1\t2 3\t4 5\t6 7\t8 9\t10", 0, " \t", true, "0"},
+        {"0 1\t2 3\t4 5\t6 7\t8 9\t10", 5, " \t", true, "5"},
+        {"0 1\t2 3\t4 5\t6 7\t8 9\t10", 10, " \t", true, "10"},
+        {"0 1\t2 3\t4 5\t6 7\t8 9\t10", 42, " \t", false, ""},
+    };
+
+    for (const auto& testCase : testCases) {
+        std::string actual_token;
+        auto actual_outcome = ecf::Str::get_token(testCase.input, testCase.index, actual_token, testCase.delimiters);
+
+        BOOST_REQUIRE_MESSAGE(actual_outcome == testCase.expected_outcome,
+                              "Correct output getting token from '" << testCase.input << "' at index " << testCase.index
+                                                                    << " with delimiters '" << testCase.delimiters
+                                                                    << "'");
+
+        if (testCase.expected_outcome) {
+            BOOST_CHECK_MESSAGE(actual_token == testCase.expected_token,
+                                "Found correct token with input: '"
+                                    << testCase.input << "' at index " << testCase.index << " with delimiters '"
+                                    << testCase.delimiters << "'. Expected '" << testCase.expected_token << "' found '"
+                                    << actual_token << "'");
+        }
     }
 }
 


### PR DESCRIPTION
### Description

Remove duplicate get_token implementations, while adding documentation and tests to cover the functionality.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-314
<!-- PREVIEW-URL_END -->