### PR TITLE
Fix clashing tests

### DIFF
--- a/libs/rest/test/TestApiV1.cpp
+++ b/libs/rest/test/TestApiV1.cpp
@@ -35,11 +35,20 @@ const std::string API_KEY_pbkdf2  = TokenFile::generate_token();
 const std::string API_KEY_expired = TokenFile::generate_token();
 const std::string API_KEY_revoked = TokenFile::generate_token();
 
+int get_random_port(int min, int max) {
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    static std::uniform_int_distribution<> distrib(min, max);
+    return distrib(gen);
+}
+
 #if defined(ECF_TEST_HTTP_BACKEND)
-static const std::string ECF_TEST_HTTP_PORT        = "8081";
+static const int ECF_TEST_HTTP_PORT_NR             = get_random_port(8000, 8999);
+static const std::string ECF_TEST_HTTP_PORT        = std::to_string(ECF_TEST_HTTP_PORT_NR);
 static const std::string ECF_TEST_HTTP_TOKENS_FILE = "api-tokens.using_http_backend.json";
 #else
-static const std::string ECF_TEST_HTTP_PORT        = "8080";
+static const int ECF_TEST_HTTP_PORT_NR             = get_random_port(9000, 9999);
+static const std::string ECF_TEST_HTTP_PORT        = std::to_string(ECF_TEST_HTTP_PORT_NR);
 static const std::string ECF_TEST_HTTP_TOKENS_FILE = "api-tokens.using_tcpip_backend.json";
 #endif
 
@@ -138,11 +147,7 @@ httplib::Result request(const std::string& method,
                         const std::string& payload             = "",
                         const std::string& token               = "",
                         const httplib::Headers& custom_headers = {}) {
-#if defined(ECF_TEST_HTTP_BACKEND)
-    httplib::SSLClient c(API_HOST, 8081);
-#else
-    httplib::SSLClient c(API_HOST, 8080);
-#endif
+    httplib::SSLClient c(API_HOST, ECF_TEST_HTTP_PORT_NR);
 
     c.enable_server_certificate_verification(false);
     c.set_connection_timeout(3);

--- a/libs/udp/test/TestSupport.hpp
+++ b/libs/udp/test/TestSupport.hpp
@@ -243,7 +243,7 @@ public:
                     {"--port", std::to_string(port), "--ecflow_port", std::to_string(ecflow_port), "--verbose"});
 
         // Wait for server to start...
-        std::this_thread::sleep_for(std::chrono::milliseconds(2500));
+        std::this_thread::sleep_for(std::chrono::milliseconds(5000));
 
         return server;
     }


### PR DESCRIPTION
### Description

(Quick) Fix two of the problematic tests:
 - multiple s_http* tests, from different CI instances(?), clash attempting to use port 8080/8081
   - (naive) solution: randomise the port used for testing
 - s_udp, doesn't wait for the daemon to be responding to start the test execution
   - (non-)solution: increase amount of time waiting for the daemon to be up-and-running

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-322
<!-- PREVIEW-URL_END -->