### PR TITLE
Correct parsing of Variable entries ECFLOW-2089

### DIFF
--- a/libs/node/src/ecflow/node/parser/VariableParser.cpp
+++ b/libs/node/src/ecflow/node/parser/VariableParser.cpp
@@ -104,41 +104,84 @@ bool VariableParser::doParse(const std::string& line, std::vector<std::string>& 
     std::string value;
     std::string marker;
 
-    if (first_quote == std::string::npos && last_quote == std::string::npos) {
-        // CASE: unquoted value, e.g.
-        //   1) edit <name> <value>            [OK]
-        //   2) edit <name> <value> # comment  [OK]
-        //   3) edit <name> # comment          [NOK!]
+    if (lineTokens[1].find(':') != std::string::npos) {
+        // CASE: handling an alias variable...
+        //   a) edit <name>:<default-value> '<actual-value>' # some comment
+        //   b) edit <name>:<some default value> '<some actual value>' # some comment
+        //
+        // - The presence of the `:` character in the second token is used as an indicator for
+        //   an alias variable, which has a different format than a regular variable.
+        //
+        // - If single quotes are present, then they enclose the actual value.
+        //
+        // - If single quotes are absent, then the 2nd and 3rd tokens in the line are the name and value respectively,
+        //   and the rest of the line is considered as comentary
+        //
+        // - consecutive spaces in both default and actual value are retained without loss
 
-        name  = lineTokens[1];
-        value = lineTokens[2];
+        auto addr_at_0    = static_cast<const char*>(&line[0]);
+        auto addr_at_name = static_cast<const char*>(&token_idxs.at(1)[0]);
 
-        // Handle case 3)!
-        if (value[0] == '#') {
-            std::ostringstream ss;
-            ss << "VariableParser::doParse: Expected value but found comment at line:" << line << "\n";
-            if (node) {
-                ss << "At node: " << node->debugNodePath() << "\n";
+        size_t name_start        = std::distance(addr_at_0, addr_at_name);
+        size_t first_alias_quote = line.find('\'');
+        size_t last_alias_quote  = line.rfind('\'');
+
+        if (first_alias_quote == std::string::npos && last_alias_quote == std::string::npos) {
+
+            name  = lineTokens[1];
+            value = lineTokens[2];
+
+            const size_t first_coment_token = 3;
+            for (size_t i = first_coment_token; i < lineTokens.size(); ++i) {
+                if (i > first_coment_token) {
+                    marker += " ";
+                }
+                marker += lineTokens[i];
             }
-            throw std::runtime_error(ss.str());
         }
-
-        const size_t first_coment_token = 3;
-        for (size_t i = first_coment_token; i < lineTokens.size(); ++i) {
-            if (i > first_coment_token) {
-                marker += " ";
-            }
-            marker += lineTokens[i];
+        else {
+            name   = line.substr(name_start, first_alias_quote - name_start - 1);
+            value  = line.substr(first_alias_quote + 1, last_alias_quote - first_alias_quote - 1);
+            marker = line.substr(last_alias_quote + 1);
         }
     }
     else {
-        // CASE: quoted value, e.g.
-        //   1) edit <name> '<value>' (# comment)
-        //   2) edit <name> "<value>" (# comment)
+        if (first_quote == std::string::npos && last_quote == std::string::npos) {
+            // CASE: unquoted value, e.g.
+            //   1) edit <name> <value>            [OK]
+            //   2) edit <name> <value> # comment  [OK]
+            //   3) edit <name> # comment          [NOK!]
 
-        name   = lineTokens[1];
-        value  = line.substr(first_quote + 1, last_quote - first_quote - 1);
-        marker = line.substr(last_quote + 1);
+            name  = lineTokens[1];
+            value = lineTokens[2];
+
+            // Handle case 3)!
+            if (value[0] == '#') {
+                std::ostringstream ss;
+                ss << "VariableParser::doParse: Expected value but found comment at line:" << line << "\n";
+                if (node) {
+                    ss << "At node: " << node->debugNodePath() << "\n";
+                }
+                throw std::runtime_error(ss.str());
+            }
+
+            const size_t first_coment_token = 3;
+            for (size_t i = first_coment_token; i < lineTokens.size(); ++i) {
+                if (i > first_coment_token) {
+                    marker += " ";
+                }
+                marker += lineTokens[i];
+            }
+        }
+        else {
+            // CASE: quoted value, e.g.
+            //   1) edit <name> '<value>' (# comment)
+            //   2) edit <name> "<value>" (# comment)
+
+            name   = lineTokens[1];
+            value  = line.substr(first_quote + 1, last_quote - first_quote - 1);
+            marker = line.substr(last_quote + 1);
+        }
     }
 
     //

--- a/libs/node/test/parser/TestVariableParsing.cpp
+++ b/libs/node/test/parser/TestVariableParsing.cpp
@@ -395,27 +395,39 @@ BOOST_AUTO_TEST_CASE(test_parsing_variable_with_alias_format) {
     std::vector<Expected> expectations = {
         {"a:\"x\"", "'a'"},
         {"b:x", "b"},
-        {"c:0", "0"},
+        {"c:0", "0 1 2"},
         {"d:1", "1"},
-        {"e:", "1"},
-        {"f:", "1"},
+        {"e:", "1 2"},
+        {"f:", "1 2 3 "},
+        {"g:x y z", "a b#c"},
+        {"h:x -y", "a -# b"},
+        {"i:-x y", "+a -b"},
+        {"variable:some  default  value", "some actual value"},
+        {"resolve:${resolve / }", "${resolve / } "},
+        {"empty:default", ""},
     };
 
     auto content = R"--(
-suite x
-  family f
-    task t
-      alias alias1
-        edit a:"x" ''a'' # some " comment
-        edit b:x "b" # some ' comment
-        edit c:0 0 # some ' comment
-        edit d:1 '1'
-        edit e: '1'
-        edit f: '1'
-      endalias
-  endfamily
-endsuite
-)--";
+    suite x
+      family f
+        task t
+          alias alias1
+            edit a:"x" ''a'' # some " comment
+            edit b:x 'b' # some comment
+            edit c:0 '0 1 2' # some comment
+            edit d:1 '1'
+            edit e: '1 2'
+            edit f: '1 2 3 '
+            edit g:x y z 'a b#c' # some comment
+            edit h:x -y 'a -# b' #
+            edit i:-x y '+a -b'
+            edit variable:some  default  value 'some actual value' # some valid comment
+            edit resolve:${resolve / } '${resolve / } ' # some valid comment
+            edit empty:default ''
+          endalias
+      endfamily
+    endsuite
+    )--";
 
     auto defs = Defs{};
     defs.restore_from_string(content);
@@ -754,6 +766,58 @@ endsuite
     catch (std::exception& e) {
         std::string_view msg = e.what();
         BOOST_CHECK_MESSAGE(msg.find("Mismatched quote detected (only one quote found) in line") != std::string::npos,
+                            "Parsing failed as expected with error: " << msg);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_parsing_alias_unquoted_variable_with_incorrect_format_due_to_invalid_comment_start_marker) {
+    ECF_NAME_THIS_TEST();
+
+    auto content = R"--(
+suite x
+  family f
+    task t
+      alias alias1
+        edit a:default value invalid comment as it does not start with a # marker
+      endalias
+  endfamily
+endsuite
+)--";
+
+    auto defs = Defs{};
+    try {
+        defs.restore_from_string(content);
+        BOOST_CHECK_MESSAGE(false, "Expected parsing to fail due to incorrect variable format, but it succeeded");
+    }
+    catch (std::exception& e) {
+        std::string_view msg = e.what();
+        BOOST_CHECK_MESSAGE(msg.find("Invalid comment at line") != std::string::npos,
+                            "Parsing failed as expected with error: " << msg);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_parsing_alias_quoted_variable_with_incorrect_format_due_to_invalid_comment_start_marker) {
+    ECF_NAME_THIS_TEST();
+
+    auto content = R"--(
+suite x
+  family f
+    task t
+      alias alias1
+        edit a:some default value 'some actual value' invalid comment as it does not start with a # marker
+      endalias
+  endfamily
+endsuite
+)--";
+
+    auto defs = Defs{};
+    try {
+        defs.restore_from_string(content);
+        BOOST_CHECK_MESSAGE(false, "Expected parsing to fail due to incorrect variable format, but it succeeded");
+    }
+    catch (std::exception& e) {
+        std::string_view msg = e.what();
+        BOOST_CHECK_MESSAGE(msg.find("Invalid comment at line") != std::string::npos,
                             "Parsing failed as expected with error: " << msg);
     }
 }


### PR DESCRIPTION

### Description

This corrects the VariableParser handling of Alias Variables for the cases where the default value has spaces.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-334
<!-- PREVIEW-URL_END -->