### PR TITLE
Enable current_index/_value for Repeat in Python API ECFLOW-2084

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -287,6 +287,7 @@ set(srcs
   core/src/ecflow/core/TimeSeries.hpp
   core/src/ecflow/core/TimeSlot.hpp
   core/src/ecflow/core/TimeStamp.hpp
+  core/src/ecflow/core/TypeTraits.hpp
   core/src/ecflow/core/User.hpp
   core/src/ecflow/core/Version.hpp
   core/src/ecflow/core/WhiteListFile.hpp

--- a/libs/attribute/src/ecflow/attribute/RepeatAttr.cpp
+++ b/libs/attribute/src/ecflow/attribute/RepeatAttr.cpp
@@ -312,6 +312,14 @@ void RepeatDate::setToLastValue() {
     set_value(end_);
 }
 
+long RepeatDate::current_index() const {
+    // Use Julian-day arithmetic so the index is correct even when the
+    // date sequence crosses a month or year boundary.
+    auto start_julian = ecf::CalendarDate(start_).as_julian_day().value();
+    auto value_julian = ecf::CalendarDate(value_).as_julian_day().value();
+    return (value_julian - start_julian) / delta_;
+}
+
 long RepeatDate::last_valid_value() const {
     return valid_value(value_);
 }

--- a/libs/attribute/src/ecflow/attribute/RepeatAttr.hpp
+++ b/libs/attribute/src/ecflow/attribute/RepeatAttr.hpp
@@ -25,6 +25,7 @@
 #include <iomanip>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <vector>
 

--- a/libs/attribute/src/ecflow/attribute/RepeatAttr.hpp
+++ b/libs/attribute/src/ecflow/attribute/RepeatAttr.hpp
@@ -884,4 +884,94 @@ private:
     void serialize(Archive& ar, std::uint32_t const version);
 };
 
+template <typename Result, typename RepeatType>
+inline std::optional<Result> current_value_of(const RepeatType& repeat) {
+    return std::nullopt; // default implementation returns empty optional for all RepeatTypes
+}
+
+template <>
+inline std::optional<int> current_value_of(const RepeatDate& repeat) {
+    return repeat.value();
+}
+
+template <>
+inline std::optional<int> current_value_of(const RepeatDateList& repeat) {
+    return repeat.value();
+}
+
+template <>
+inline std::optional<std::string> current_value_of(const RepeatDateTime& repeat) {
+    return repeat.current_value();
+}
+
+template <>
+inline std::optional<std::string> current_value_of(const RepeatDateTimeList& repeat) {
+    return repeat.current_value();
+}
+
+template <>
+inline std::optional<int> current_value_of(const RepeatInteger& repeat) {
+    return repeat.value();
+}
+
+template <>
+inline std::optional<std::string> current_value_of(const RepeatEnumerated& repeat) {
+    return repeat.current_value();
+}
+
+template <>
+inline std::optional<std::string> current_value_of(const RepeatString& repeat) {
+    return repeat.current_value();
+}
+
+template <>
+inline std::optional<int> current_value_of(const RepeatDay& repeat) {
+    return repeat.value();
+}
+
+template <typename Result>
+inline std::optional<Result> current_value_as(const RepeatBase& base) {
+    if (base.isDate()) {
+        auto& repeat = dynamic_cast<const RepeatDate&>(base);
+        return current_value_of<Result>(repeat);
+    }
+    else if (base.isDateTime()) {
+        auto& repeat = dynamic_cast<const RepeatDateTime&>(base);
+        return current_value_of<Result>(repeat);
+    }
+    else if (base.isDateList()) {
+        auto& repeat = dynamic_cast<const RepeatDateList&>(base);
+        return current_value_of<Result>(repeat);
+    }
+    else if (base.isDateTimeList()) {
+        auto& repeat = dynamic_cast<const RepeatDateTimeList&>(base);
+        return current_value_of<Result>(repeat);
+    }
+    else if (base.isInteger()) {
+        auto& repeat = dynamic_cast<const RepeatInteger&>(base);
+        return current_value_of<Result>(repeat);
+    }
+    else if (base.isEnumerated()) {
+        auto& repeat = dynamic_cast<const RepeatEnumerated&>(base);
+        return current_value_of<Result>(repeat);
+    }
+    else if (base.isString()) {
+        auto& repeat = dynamic_cast<const RepeatString&>(base);
+        return current_value_of<Result>(repeat);
+    }
+    else if (base.isDay()) {
+        auto& repeat = dynamic_cast<const RepeatDay&>(base);
+        return current_value_of<Result>(repeat);
+    }
+    else {
+        return std::nullopt;
+    }
+}
+
+template <typename T>
+std::optional<T> current_value_as(const Repeat& repeat) {
+    auto base = repeat.repeatBase();
+    return (base) ? current_value_as<T>(*base) : std::nullopt;
+}
+
 #endif /* ecflow_attribute_RepeatAttr_HPP */

--- a/libs/attribute/src/ecflow/attribute/RepeatAttr.hpp
+++ b/libs/attribute/src/ecflow/attribute/RepeatAttr.hpp
@@ -48,24 +48,19 @@ public:
     virtual int end() const   = 0;
     virtual int step() const  = 0;
 
+    ///
+    /// @brief Retrieve the zero-based index of the current repeat position.
+    ///
+    /// @return the zero-based index of the current repeat position
+    ///
     virtual long current_index() const = 0;
-    ///< Returns the zero-based index of the current repeat position.
-    ///< For index-based types (RepeatString, RepeatEnumerated, RepeatDateList,
-    ///< RepeatDateTimeList) this equals the raw currentIndex_ field.
-    ///< For range-based types (RepeatDate, RepeatDateTime, RepeatInteger) it
-    ///< equals (current_value - start) / step using the appropriate arithmetic
-    ///< for the type (calendar days for dates, seconds for datetimes, integers
-    ///< for integers).  RepeatDay returns its step value unchanged.
-    ///<
-    ///< Returns 0 when the repeat is freshly constructed or has been reset.
 
+    ///
+    /// @brief Retrieve the current repeat value
+    ///
+    /// @return the current repeat value as a human-readable string.
+    ///
     virtual std::string current_value() const = 0;
-    ///< Returns the current repeat value as a human-readable string.
-    ///< For date types the format is yyyymmdd; for date-time types it is
-    ///< yyyymmddTHHMMSS; for integer/day types it is the decimal representation;
-    ///< for string/enumerated types it is the string at the current index.
-    ///<
-    ///< Returns an empty string when the repeat is empty or out of bounds.
 
     // Handle generated variables
     virtual void gen_variables(std::vector<Variable>& vec) const { vec.push_back(var_); }
@@ -167,10 +162,19 @@ public:
     long last_valid_value_minus(int value) const override;
     long last_valid_value_plus(int value) const override;
 
+    ///
+    /// @brief Retrieve the current zero-based index
+    ///
+    /// @return the zero-based index into the repeat sequence
+    ///
     long current_index() const override;
-    ///< Returns the zero-based calendar-day index: (julianDay(value) - julianDay(start)) / delta.
+
+    ///
+    /// @brief Retrieve the current value
+    ///
+    /// @return the current value as a yyyymmdd decimal string.
+    ///
     std::string current_value() const override { return std::to_string(value_); }
-    ///< Returns the current date as a yyyymmdd decimal string.
 
     void delta(int d) { delta_ = d; }
     int delta() const { return delta_; }
@@ -254,10 +258,19 @@ public:
     long last_valid_value_minus(int value) const override;
     long last_valid_value_plus(int value) const override;
 
+    ///
+    /// @brief Retrieve the current zero-based index
+    ///
+    /// @return the zero-based index into the repeat sequence
+    ///
     long current_index() const override { return (value() - start()) / step(); };
-    ///< Returns (seconds(value) - seconds(start)) / seconds(step).
+
+    ///
+    /// @brief Retrieve the current value
+    ///
+    /// @return the current value as a yyyymmddTHHMMSS decimal string.
+    ///
     std::string current_value() const override { return ecf::Instant::format(value_); }
-    ///< Returns the current instant formatted as yyyymmddTHHMMSS.
 
     void delta(const ecf::Duration& d) { delta_ = d; }
     bool operator==(const RepeatDateTime& rhs) const;
@@ -357,14 +370,23 @@ public:
     long last_valid_value_minus(int value) const override;
     long last_valid_value_plus(int value) const override;
 
+    ///
+    /// @brief Retrieve the current zero-based index
+    ///
+    /// @return the zero-based index into the repeat sequence
+    ///
     long current_index() const override { return currentIndex_; };
-    ///< Returns the current list index (0-based).
+
+    ///
+    /// @brief Retrieve the current value
+    ///
+    /// @return the current value as a yyyymmddT decimal string, or "" if out of bounds.
+    ///
     std::string current_value() const override {
         return currentIndex_ >= 0 && currentIndex_ < static_cast<int>(list_.size())
                    ? std::to_string(list_[currentIndex_])
                    : "";
     }
-    ///< Returns the current date as a yyyymmdd decimal string, or "" if out of bounds.
 
     RepeatBase* clone() const override { return new RepeatDateList(name_, list_, currentIndex_); }
     bool compare(RepeatBase*) const override;
@@ -433,14 +455,23 @@ public:
     long last_valid_value_minus(int value) const override;
     long last_valid_value_plus(int value) const override;
 
+    ///
+    /// @brief Retrieve the current zero-based index
+    ///
+    /// @return the zero-based index into the repeat sequence
+    ///
     long current_index() const override { return currentIndex_; };
-    ///< Returns the current list index (0-based).
+
+    ///
+    /// @brief Retrieve the current value
+    ///
+    /// @return the current value as a yyyymmddTHHMMSS decimal string, or "" if out of bounds.
+    ///
     std::string current_value() const override {
         return currentIndex_ >= 0 && currentIndex_ < static_cast<int>(list_.size())
                    ? ecf::Instant::format(list_[currentIndex_])
                    : "";
     }
-    ///< Returns the current instant as yyyymmddTHHMMSS, or "" if out of bounds.
 
     RepeatBase* clone() const override { return new RepeatDateTimeList(name_, list_, currentIndex_); }
     bool compare(RepeatBase*) const override;
@@ -513,10 +544,19 @@ public:
     long last_valid_value() const override;
     int delta() const { return delta_; }
 
+    ///
+    /// @brief Retrieve the current zero-based index
+    ///
+    /// @return the zero-based index into the repeat sequence
+    ///
     long current_index() const override { return (value_ - start_) / delta_; };
-    ///< Returns (value - start) / delta as a zero-based integer index.
+
+    ///
+    /// @brief Retrieve the current value
+    ///
+    /// @return the current value as a decimal string.
+    ///
     std::string current_value() const override { return std::to_string(value_); }
-    ///< Returns the current integer value as a decimal string.
 
     RepeatInteger* clone() const override { return new RepeatInteger(name_, start_, end_, delta_, value_); }
     bool compare(RepeatBase*) const override;
@@ -578,10 +618,15 @@ public:
 
     long current_index() const override { return currentIndex_; };
     ///< Returns the current enumeration index (0-based).
+
+    ///
+    /// @brief Retrieve the current value
+    ///
+    /// @return the current string value, or "" if out of bounds.
+    ///
     std::string current_value() const override {
         return currentIndex_ >= 0 && currentIndex_ < static_cast<int>(theEnums_.size()) ? theEnums_[currentIndex_] : "";
     }
-    ///< Returns the enumeration string at the current index, or "" if out of bounds.
 
     const std::vector<std::string>& values() const { return theEnums_; }
 
@@ -636,13 +681,22 @@ public:
     long index_or_value() const override { return currentIndex_; }
     long last_valid_value() const override; // returns the index
 
+    ///
+    /// @brief Retrieve the current zero-based index
+    ///
+    /// @return the zero-based index into the repeat sequence
+    ///
     long current_index() const override { return currentIndex_; };
-    ///< Returns the current string index (0-based).
+
+    ///
+    /// @brief Retrieve the current value
+    ///
+    /// @return the current string value, or "" if out of bounds.
+    ///
     std::string current_value() const override {
         return currentIndex_ >= 0 && currentIndex_ < static_cast<int>(theStrings_.size()) ? theStrings_[currentIndex_]
                                                                                           : "";
     }
-    ///< Returns the string at the current index, or "" if out of bounds.
 
     RepeatBase* clone() const override { return new RepeatString(name_, theStrings_, currentIndex_); }
     bool compare(RepeatBase*) const override;
@@ -722,10 +776,25 @@ public:
     long index_or_value() const override { return step_; }
     long last_valid_value() const override { return step_; }
 
+    ///
+    /// @brief Retrieve the current index
+    ///
+    /// For RepeatDay the index is not really meaningful, but we return the step value for consistency with other Repeat
+    /// types.
+    ///
+    /// @return the current index
+    ///
     long current_index() const override { return step_; };
-    ///< RepeatDay has no position concept; returns the step value itself.
+
+    ///
+    /// @brief Retrieve the current value
+    ///
+    /// For RepeatDay the value is not really meaningful, but we return the step value as a string for consistency with
+    /// other Repeat types.
+    ///
+    /// @return the current value as a decimal string.
+    ///
     std::string current_value() const override { return std::to_string(step_); }
-    ///< Returns the step value as a decimal string.
 
     RepeatBase* clone() const override { return new RepeatDay(step_, valid_); }
     bool compare(RepeatBase*) const override;
@@ -815,10 +884,19 @@ public:
     long last_valid_value_minus(int val) const { return (type_) ? type_->last_valid_value_minus(val) : -val; }
     long last_valid_value_plus(int val) const { return (type_) ? type_->last_valid_value_plus(val) : val; }
 
+    ///
+    /// @brief Retrieve the current zero-based index
+    ///
+    /// @return the current index, or 0 if not holding a specific Repeat type.
+    ///
     long current_index() const { return (type_) ? type_->current_index() : 0; }
-    ///< Delegates to the wrapped RepeatBase; returns 0 if empty.
+
+    ///
+    /// @brief Retrieve the current value
+    ///
+    /// @return the current string value, or "" if not holding a specific Repeat type.
+    ///
     std::string current_value() const { return (type_) ? type_->current_value() : std::string{}; }
-    ///< Delegates to the wrapped RepeatBase; returns "" if empty.
 
     bool valid() const { return (type_) ? type_->valid() : false; }
     void setToLastValue() {

--- a/libs/attribute/src/ecflow/attribute/RepeatAttr.hpp
+++ b/libs/attribute/src/ecflow/attribute/RepeatAttr.hpp
@@ -47,6 +47,25 @@ public:
     virtual int end() const   = 0;
     virtual int step() const  = 0;
 
+    virtual long current_index() const = 0;
+    ///< Returns the zero-based index of the current repeat position.
+    ///< For index-based types (RepeatString, RepeatEnumerated, RepeatDateList,
+    ///< RepeatDateTimeList) this equals the raw currentIndex_ field.
+    ///< For range-based types (RepeatDate, RepeatDateTime, RepeatInteger) it
+    ///< equals (current_value - start) / step using the appropriate arithmetic
+    ///< for the type (calendar days for dates, seconds for datetimes, integers
+    ///< for integers).  RepeatDay returns its step value unchanged.
+    ///<
+    ///< Returns 0 when the repeat is freshly constructed or has been reset.
+
+    virtual std::string current_value() const = 0;
+    ///< Returns the current repeat value as a human-readable string.
+    ///< For date types the format is yyyymmdd; for date-time types it is
+    ///< yyyymmddTHHMMSS; for integer/day types it is the decimal representation;
+    ///< for string/enumerated types it is the string at the current index.
+    ///<
+    ///< Returns an empty string when the repeat is empty or out of bounds.
+
     // Handle generated variables
     virtual void gen_variables(std::vector<Variable>& vec) const { vec.push_back(var_); }
     virtual const Variable& find_gen_variable(const std::string& name) const {
@@ -147,6 +166,11 @@ public:
     long last_valid_value_minus(int value) const override;
     long last_valid_value_plus(int value) const override;
 
+    long current_index() const override;
+    ///< Returns the zero-based calendar-day index: (julianDay(value) - julianDay(start)) / delta.
+    std::string current_value() const override { return std::to_string(value_); }
+    ///< Returns the current date as a yyyymmdd decimal string.
+
     void delta(int d) { delta_ = d; }
     int delta() const { return delta_; }
     bool operator==(const RepeatDate& rhs) const;
@@ -228,6 +252,11 @@ public:
     long last_valid_value() const override;
     long last_valid_value_minus(int value) const override;
     long last_valid_value_plus(int value) const override;
+
+    long current_index() const override { return (value() - start()) / step(); };
+    ///< Returns (seconds(value) - seconds(start)) / seconds(step).
+    std::string current_value() const override { return ecf::Instant::format(value_); }
+    ///< Returns the current instant formatted as yyyymmddTHHMMSS.
 
     void delta(const ecf::Duration& d) { delta_ = d; }
     bool operator==(const RepeatDateTime& rhs) const;
@@ -327,6 +356,15 @@ public:
     long last_valid_value_minus(int value) const override;
     long last_valid_value_plus(int value) const override;
 
+    long current_index() const override { return currentIndex_; };
+    ///< Returns the current list index (0-based).
+    std::string current_value() const override {
+        return currentIndex_ >= 0 && currentIndex_ < static_cast<int>(list_.size())
+                   ? std::to_string(list_[currentIndex_])
+                   : "";
+    }
+    ///< Returns the current date as a yyyymmdd decimal string, or "" if out of bounds.
+
     RepeatBase* clone() const override { return new RepeatDateList(name_, list_, currentIndex_); }
     bool compare(RepeatBase*) const override;
     bool valid() const override { return (currentIndex_ >= 0 && currentIndex_ < static_cast<int>(list_.size())); }
@@ -393,6 +431,15 @@ public:
     long last_valid_value() const override;
     long last_valid_value_minus(int value) const override;
     long last_valid_value_plus(int value) const override;
+
+    long current_index() const override { return currentIndex_; };
+    ///< Returns the current list index (0-based).
+    std::string current_value() const override {
+        return currentIndex_ >= 0 && currentIndex_ < static_cast<int>(list_.size())
+                   ? ecf::Instant::format(list_[currentIndex_])
+                   : "";
+    }
+    ///< Returns the current instant as yyyymmddTHHMMSS, or "" if out of bounds.
 
     RepeatBase* clone() const override { return new RepeatDateTimeList(name_, list_, currentIndex_); }
     bool compare(RepeatBase*) const override;
@@ -465,6 +512,11 @@ public:
     long last_valid_value() const override;
     int delta() const { return delta_; }
 
+    long current_index() const override { return (value_ - start_) / delta_; };
+    ///< Returns (value - start) / delta as a zero-based integer index.
+    std::string current_value() const override { return std::to_string(value_); }
+    ///< Returns the current integer value as a decimal string.
+
     RepeatInteger* clone() const override { return new RepeatInteger(name_, start_, end_, delta_, value_); }
     bool compare(RepeatBase*) const override;
     bool valid() const override { return (delta_ > 0) ? (value_ <= end_) : (value_ >= end_); }
@@ -523,6 +575,13 @@ public:
     long index_or_value() const override { return currentIndex_; }
     long last_valid_value() const override;
 
+    long current_index() const override { return currentIndex_; };
+    ///< Returns the current enumeration index (0-based).
+    std::string current_value() const override {
+        return currentIndex_ >= 0 && currentIndex_ < static_cast<int>(theEnums_.size()) ? theEnums_[currentIndex_] : "";
+    }
+    ///< Returns the enumeration string at the current index, or "" if out of bounds.
+
     const std::vector<std::string>& values() const { return theEnums_; }
 
     RepeatBase* clone() const override { return new RepeatEnumerated(name_, theEnums_, currentIndex_); }
@@ -575,6 +634,14 @@ public:
     long value() const override { return currentIndex_; }
     long index_or_value() const override { return currentIndex_; }
     long last_valid_value() const override; // returns the index
+
+    long current_index() const override { return currentIndex_; };
+    ///< Returns the current string index (0-based).
+    std::string current_value() const override {
+        return currentIndex_ >= 0 && currentIndex_ < static_cast<int>(theStrings_.size()) ? theStrings_[currentIndex_]
+                                                                                          : "";
+    }
+    ///< Returns the string at the current index, or "" if out of bounds.
 
     RepeatBase* clone() const override { return new RepeatString(name_, theStrings_, currentIndex_); }
     bool compare(RepeatBase*) const override;
@@ -653,6 +720,11 @@ public:
     long value() const override { return step_; }
     long index_or_value() const override { return step_; }
     long last_valid_value() const override { return step_; }
+
+    long current_index() const override { return step_; };
+    ///< RepeatDay has no position concept; returns the step value itself.
+    std::string current_value() const override { return std::to_string(step_); }
+    ///< Returns the step value as a decimal string.
 
     RepeatBase* clone() const override { return new RepeatDay(step_, valid_); }
     bool compare(RepeatBase*) const override;
@@ -741,6 +813,11 @@ public:
     long last_valid_value() const { return (type_) ? type_->last_valid_value() : 0; }
     long last_valid_value_minus(int val) const { return (type_) ? type_->last_valid_value_minus(val) : -val; }
     long last_valid_value_plus(int val) const { return (type_) ? type_->last_valid_value_plus(val) : val; }
+
+    long current_index() const { return (type_) ? type_->current_index() : 0; }
+    ///< Delegates to the wrapped RepeatBase; returns 0 if empty.
+    std::string current_value() const { return (type_) ? type_->current_value() : std::string{}; }
+    ///< Delegates to the wrapped RepeatBase; returns "" if empty.
 
     bool valid() const { return (type_) ? type_->valid() : false; }
     void setToLastValue() {

--- a/libs/attribute/src/ecflow/attribute/RepeatAttr.hpp
+++ b/libs/attribute/src/ecflow/attribute/RepeatAttr.hpp
@@ -27,10 +27,12 @@
 #include <memory>
 #include <optional>
 #include <sstream>
+#include <type_traits>
 #include <vector>
 
 #include "ecflow/attribute/Variable.hpp"
 #include "ecflow/core/Chrono.hpp"
+#include "ecflow/core/TypeTraits.hpp"
 
 /////////////////////////////////////////////////////////////////////////
 // Node can only have one repeat.
@@ -172,7 +174,7 @@ public:
     ///
     /// @brief Retrieve the current value
     ///
-    /// @return the current value as a yyyymmdd decimal string.
+    /// @return the current date formatted as a yyyymmdd string.
     ///
     std::string current_value() const override { return std::to_string(value_); }
 
@@ -263,12 +265,12 @@ public:
     ///
     /// @return the zero-based index into the repeat sequence
     ///
-    long current_index() const override { return (value() - start()) / step(); };
+    long current_index() const override { return (value() - start()) / step(); }
 
     ///
     /// @brief Retrieve the current value
     ///
-    /// @return the current value as a yyyymmddTHHMMSS decimal string.
+    /// @return the current value formatted as a yyyymmddTHHMMSS string.
     ///
     std::string current_value() const override { return ecf::Instant::format(value_); }
 
@@ -364,7 +366,7 @@ public:
     long value_at(size_t i) const {
         assert(i < list_.size());
         return list_[i];
-    };
+    }
     long index_or_value() const override { return currentIndex_; }
     long last_valid_value() const override;
     long last_valid_value_minus(int value) const override;
@@ -375,12 +377,12 @@ public:
     ///
     /// @return the zero-based index into the repeat sequence
     ///
-    long current_index() const override { return currentIndex_; };
+    long current_index() const override { return currentIndex_; }
 
     ///
     /// @brief Retrieve the current value
     ///
-    /// @return the current value as a yyyymmddT decimal string, or "" if out of bounds.
+    /// @return the current value formatted as a yyyymmdd string, or "" if out of bounds.
     ///
     std::string current_value() const override {
         return currentIndex_ >= 0 && currentIndex_ < static_cast<int>(list_.size())
@@ -460,12 +462,12 @@ public:
     ///
     /// @return the zero-based index into the repeat sequence
     ///
-    long current_index() const override { return currentIndex_; };
+    long current_index() const override { return currentIndex_; }
 
     ///
     /// @brief Retrieve the current value
     ///
-    /// @return the current value as a yyyymmddTHHMMSS decimal string, or "" if out of bounds.
+    /// @return the current value fomratted as a yyyymmddTHHMMSS string, or "" if out of bounds.
     ///
     std::string current_value() const override {
         return currentIndex_ >= 0 && currentIndex_ < static_cast<int>(list_.size())
@@ -549,7 +551,7 @@ public:
     ///
     /// @return the zero-based index into the repeat sequence
     ///
-    long current_index() const override { return (value_ - start_) / delta_; };
+    long current_index() const override { return (value_ - start_) / delta_; }
 
     ///
     /// @brief Retrieve the current value
@@ -616,8 +618,12 @@ public:
     long index_or_value() const override { return currentIndex_; }
     long last_valid_value() const override;
 
-    long current_index() const override { return currentIndex_; };
-    ///< Returns the current enumeration index (0-based).
+    ///
+    /// @brief Retrieve the current zero-based index
+    ///
+    /// @return the zero-based index into the repeat sequence
+    ///
+    long current_index() const override { return currentIndex_; }
 
     ///
     /// @brief Retrieve the current value
@@ -686,7 +692,7 @@ public:
     ///
     /// @return the zero-based index into the repeat sequence
     ///
-    long current_index() const override { return currentIndex_; };
+    long current_index() const override { return currentIndex_; }
 
     ///
     /// @brief Retrieve the current value
@@ -784,7 +790,7 @@ public:
     ///
     /// @return the current index
     ///
-    long current_index() const override { return step_; };
+    long current_index() const override { return step_; }
 
     ///
     /// @brief Retrieve the current value
@@ -799,7 +805,7 @@ public:
     RepeatBase* clone() const override { return new RepeatDay(step_, valid_); }
     bool compare(RepeatBase*) const override;
     bool valid() const override { return valid_; }
-    std::string valueAsString() const override { return std::string{}; };
+    std::string valueAsString() const override { return std::string{}; }
     std::string value_as_string(int) const override { return std::string{}; }
     std::string next_value_as_string() const override { return std::string{}; }
     std::string prev_value_as_string() const override { return std::string{}; }
@@ -963,9 +969,33 @@ private:
     void serialize(Archive& ar, std::uint32_t const version);
 };
 
+namespace ecf {
+
+namespace repeat {
 template <typename Result, typename RepeatType>
 inline std::optional<Result> current_value_of(const RepeatType& repeat) {
-    return std::nullopt; // default implementation returns empty optional for all RepeatTypes
+    //
+    // This primary template is intentionally reached for combinations where the
+    // Result type does not match the native type of RepeatType — for example,
+    // current_value_of<std::string>(const RepeatDate&) has no specialisation and
+    // should return nullopt silently (RepeatDate yields int, not string).
+    //
+    // If RepeatType is a completely unknown type (e.g. a new RepeatBase subtype with no
+    // specialisations at all), that is a programming error caught here at compile time.
+    //
+    static_assert(
+        ecf::is_one_of_v<RepeatType,
+                         RepeatDate,
+                         RepeatDateTime,
+                         RepeatDateList,
+                         RepeatDateTimeList,
+                         RepeatInteger,
+                         RepeatEnumerated,
+                         RepeatString,
+                         RepeatDay>,
+        "current_value_of: RepeatType is an unknown Repeat subtype. "
+        "Add explicit specialisation of current_value_of<int/std::string>(const RepeatType&) in RepeatAttr.hpp.");
+    return std::nullopt;
 }
 
 template <>
@@ -1011,35 +1041,35 @@ inline std::optional<int> current_value_of(const RepeatDay& repeat) {
 template <typename Result>
 inline std::optional<Result> current_value_as(const RepeatBase& base) {
     if (base.isDate()) {
-        auto& repeat = dynamic_cast<const RepeatDate&>(base);
+        auto& repeat = static_cast<const RepeatDate&>(base);
         return current_value_of<Result>(repeat);
     }
     else if (base.isDateTime()) {
-        auto& repeat = dynamic_cast<const RepeatDateTime&>(base);
+        auto& repeat = static_cast<const RepeatDateTime&>(base);
         return current_value_of<Result>(repeat);
     }
     else if (base.isDateList()) {
-        auto& repeat = dynamic_cast<const RepeatDateList&>(base);
+        auto& repeat = static_cast<const RepeatDateList&>(base);
         return current_value_of<Result>(repeat);
     }
     else if (base.isDateTimeList()) {
-        auto& repeat = dynamic_cast<const RepeatDateTimeList&>(base);
+        auto& repeat = static_cast<const RepeatDateTimeList&>(base);
         return current_value_of<Result>(repeat);
     }
     else if (base.isInteger()) {
-        auto& repeat = dynamic_cast<const RepeatInteger&>(base);
+        auto& repeat = static_cast<const RepeatInteger&>(base);
         return current_value_of<Result>(repeat);
     }
     else if (base.isEnumerated()) {
-        auto& repeat = dynamic_cast<const RepeatEnumerated&>(base);
+        auto& repeat = static_cast<const RepeatEnumerated&>(base);
         return current_value_of<Result>(repeat);
     }
     else if (base.isString()) {
-        auto& repeat = dynamic_cast<const RepeatString&>(base);
+        auto& repeat = static_cast<const RepeatString&>(base);
         return current_value_of<Result>(repeat);
     }
     else if (base.isDay()) {
-        auto& repeat = dynamic_cast<const RepeatDay&>(base);
+        auto& repeat = static_cast<const RepeatDay&>(base);
         return current_value_of<Result>(repeat);
     }
     else {
@@ -1052,5 +1082,9 @@ std::optional<T> current_value_as(const Repeat& repeat) {
     auto base = repeat.repeatBase();
     return (base) ? current_value_as<T>(*base) : std::nullopt;
 }
+
+} // namespace repeat
+
+} // namespace ecf
 
 #endif /* ecflow_attribute_RepeatAttr_HPP */

--- a/libs/attribute/test/TestRepeat.cpp
+++ b/libs/attribute/test/TestRepeat.cpp
@@ -65,6 +65,10 @@ BOOST_AUTO_TEST_CASE(construction) {
 }
 
 BOOST_AUTO_TEST_CASE(current_index_current_value_delegates_to_concrete_type) {
+    ECF_NAME_THIS_TEST();
+
+    using namespace ecf::repeat;
+
     // Repeat is a type-erasing wrapper; current_index / current_value must
     // delegate correctly to each wrapped type.
     {
@@ -412,6 +416,10 @@ BOOST_AUTO_TEST_CASE(generated_variables) {
 }
 
 BOOST_AUTO_TEST_CASE(iterate_over_datelist_current_index_current_value) {
+    ECF_NAME_THIS_TEST();
+
+    using namespace ecf::repeat;
+
     RepeatDateList r("DL", {20100101, 20100201, 20100301});
     BOOST_CHECK_EQUAL(r.current_index(), 0L);
     BOOST_CHECK_EQUAL(r.current_value(), "20100101");
@@ -609,6 +617,10 @@ BOOST_AUTO_TEST_CASE(generated_variables) {
 }
 
 BOOST_AUTO_TEST_CASE(iterate_over_datetimelist_current_index_current_value) {
+    ECF_NAME_THIS_TEST();
+
+    using namespace ecf::repeat;
+
     RepeatDateTimeList r("DTL",
                          {ecf::Instant::parse("19700101T000000"),
                           ecf::Instant::parse("19700101T120000"),
@@ -1163,6 +1175,10 @@ BOOST_AUTO_TEST_CASE(more_generated_variables) {
 }
 
 BOOST_AUTO_TEST_CASE(iterate_over_date_current_index_current_value_within_month) {
+    ECF_NAME_THIS_TEST();
+
+    using namespace ecf::repeat;
+
     RepeatDate r("YMD", 20100101, 20100110, 3);
     BOOST_CHECK_EQUAL(r.current_index(), 0L);
     BOOST_CHECK_EQUAL(r.current_value(), "20100101");
@@ -1210,6 +1226,10 @@ BOOST_AUTO_TEST_CASE(iterate_over_date_current_index_current_value_within_month)
 }
 
 BOOST_AUTO_TEST_CASE(iterate_over_date_current_index_current_value_over_month_boundary) {
+    ECF_NAME_THIS_TEST();
+
+    using namespace ecf::repeat;
+
     RepeatDate r("YMD", 20241129, 20241207, 3);
     BOOST_CHECK_EQUAL(r.current_index(), 0L);
     BOOST_CHECK_EQUAL(r.current_value(), "20241129");
@@ -1234,6 +1254,10 @@ BOOST_AUTO_TEST_CASE(iterate_over_date_current_index_current_value_over_month_bo
 }
 
 BOOST_AUTO_TEST_CASE(iterate_over_date_current_index_current_value_over_year_boundary) {
+    ECF_NAME_THIS_TEST();
+
+    using namespace ecf::repeat;
+
     // Another cross-boundary regression: Jan 1st is 2 days after Dec 30th.
     RepeatDate r("YMD", 20231230, 20240103, 2);
     BOOST_CHECK_EQUAL(r.current_index(), 0L);
@@ -1258,37 +1282,63 @@ BOOST_AUTO_TEST_CASE(iterate_over_date_current_index_current_value_over_year_bou
     }
 }
 
-// BOOST_AUTO_TEST_CASE(convert_xref_to_boost_date) {
-//     ECF_NAME_THIS_TEST();
-//
-//     auto check_date = [](int start, int end, int delta) {
-//         auto bdate = boost::gregorian::from_undelimited_string(boost::lexical_cast<std::string>(start));
-//
-//         Repeat rep(RepeatDate("YMD", start, end, delta));
-//         Repeat rep2(RepeatDate("YMD", start, end, delta));
-//         while (rep.valid()) {
-//
-//             // xref repeat date with boost date, essentially checking bdate with rep
-//             std::string str_value = boost::lexical_cast<std::string>(rep.value());
-//             auto date2            = boost::gregorian::from_undelimited_string(str_value);
-//             BOOST_CHECK_MESSAGE(bdate == date2, "expected same value, but found " << bdate << "  " << date2);
-//
-//             // check change value
-//             rep2.change(str_value);
-//             BOOST_CHECK_MESSAGE(rep.value() == rep2.value(),
-//                                 "expected same value, but found " << rep.value() << "  " << rep2.value());
-//
-//             // increment repeat and boost date
-//             rep.increment();
-//             bdate += boost::gregorian::days(delta);
-//         }
-//     };
-//
-//     check_date(19800101, 20621231, 1);
-//     check_date(19800101, 20621231, 7);
-//     check_date(20621231, 19800101, -7);
-//     check_date(20150514, 20150730, 7);
-// }
+BOOST_AUTO_TEST_CASE(iterate_over_date_current_index_negative_delta) {
+    ECF_NAME_THIS_TEST();
+
+    RepeatDate r("YMD", 20240103, 20231230, -2);
+    BOOST_CHECK_EQUAL(r.current_index(), 0L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20240103");
+    {
+        auto value = ecf::repeat::current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 20240103);
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 1L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20240101");
+    {
+        auto value = ecf::repeat::current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 20240101);
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 2L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20231230");
+    {
+        auto value = ecf::repeat::current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 20231230);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(convert_xref_to_boost_date) {
+    ECF_NAME_THIS_TEST();
+
+    auto check_date = [](int start, int end, int delta) {
+        auto bdate = boost::gregorian::from_undelimited_string(boost::lexical_cast<std::string>(start));
+
+        Repeat rep(RepeatDate("YMD", start, end, delta));
+        Repeat rep2(RepeatDate("YMD", start, end, delta));
+        while (rep.valid()) {
+
+            // xref repeat date with boost date, essentially checking bdate with rep
+            std::string str_value = boost::lexical_cast<std::string>(rep.value());
+            auto date2            = boost::gregorian::from_undelimited_string(str_value);
+            BOOST_CHECK_MESSAGE(bdate == date2, "expected same value, but found " << bdate << "  " << date2);
+
+            // check change value
+            rep2.change(str_value);
+            BOOST_CHECK_MESSAGE(rep.value() == rep2.value(),
+                                "expected same value, but found " << rep.value() << "  " << rep2.value());
+
+            // increment repeat and boost date
+            rep.increment();
+            bdate += boost::gregorian::days(delta);
+        }
+    };
+
+    check_date(19800101, 20621231, 1);
+    check_date(19800101, 20621231, 7);
+    check_date(20621231, 19800101, -7);
+    check_date(20150514, 20150730, 7);
+}
 
 BOOST_AUTO_TEST_SUITE_END() // test_repeat_date
 
@@ -1556,6 +1606,10 @@ BOOST_AUTO_TEST_CASE(generated_variables) {
 }
 
 BOOST_AUTO_TEST_CASE(iterate_over_datetime_current_index_current_value) {
+    ECF_NAME_THIS_TEST();
+
+    using namespace ecf::repeat;
+
     RepeatDateTime r("DT", "19700101T000000", "19700102T000000", "12:00:00");
     BOOST_CHECK_EQUAL(r.current_index(), 0L);
     BOOST_CHECK_EQUAL(r.current_value(), "19700101T000000");
@@ -1775,6 +1829,10 @@ BOOST_AUTO_TEST_CASE(handling_errors) {
 }
 
 BOOST_AUTO_TEST_CASE(iterate_over_enumerated_current_index_current_value) {
+    ECF_NAME_THIS_TEST();
+
+    using namespace ecf::repeat;
+
     using namespace std::string_literals;
     RepeatEnumerated r("E", {"red"s, "green"s, "blue"s});
     BOOST_CHECK_EQUAL(r.current_index(), 0L);
@@ -1931,6 +1989,10 @@ BOOST_AUTO_TEST_CASE(increment) {
 }
 
 BOOST_AUTO_TEST_CASE(iterate_over_integer_current_index_current_value) {
+    ECF_NAME_THIS_TEST();
+
+    using namespace ecf::repeat;
+
     RepeatInteger r("N", 1, 6, 2);
     BOOST_CHECK_EQUAL(r.current_index(), 0L);
     BOOST_CHECK_EQUAL(r.current_value(), "1");
@@ -2001,6 +2063,10 @@ BOOST_AUTO_TEST_CASE(invariants) {
 }
 
 BOOST_AUTO_TEST_CASE(iterate_over_day_current_index_current_value) {
+    ECF_NAME_THIS_TEST();
+
+    using namespace ecf::repeat;
+
     // RepeatDay has no position concept: current_index() returns the step value.
     RepeatDay r(3);
     BOOST_CHECK_EQUAL(r.current_index(), 3L);
@@ -2111,7 +2177,11 @@ BOOST_AUTO_TEST_CASE(handling_errors) {
 }
 
 BOOST_AUTO_TEST_CASE(iterate_over_string_current_index_current_value) {
+    ECF_NAME_THIS_TEST();
+
+    using namespace ecf::repeat;
     using namespace std::string_literals;
+
     RepeatString r("S", {"a"s, "b"s, "c"s});
     BOOST_CHECK_EQUAL(r.current_index(), 0L);
     BOOST_CHECK_EQUAL(r.current_value(), "a");

--- a/libs/attribute/test/TestRepeat.cpp
+++ b/libs/attribute/test/TestRepeat.cpp
@@ -1705,6 +1705,201 @@ BOOST_AUTO_TEST_CASE(handling_errors) {
 
 BOOST_AUTO_TEST_SUITE_END() // test_repeat_string
 
+/*
+ * Test Suite: ::test_current_index_value
+ *
+ * Tests the current_index() and current_value() methods directly on each
+ * concrete RepeatBase subtype and on the Repeat wrapper.
+ *
+ * Note: Range<RepeatDate>::current_index() in RepeatRange.hpp already uses
+ * Julian-day arithmetic.  RepeatDate::current_index() previously used a naive
+ * yyyymmdd integer formula that gave incorrect results for sequences crossing
+ * month/year boundaries.  The implementation was corrected to match the Range
+ * specialisation; the cross-month cases below serve as regression tests.
+ * ************************************************************ */
+
+BOOST_AUTO_TEST_SUITE(test_current_index_value)
+
+BOOST_AUTO_TEST_CASE(repeat_date_within_month) {
+    // Simple same-month sequence: both the old integer formula and the new
+    // Julian-day formula agree, so this confirms no regression.
+    RepeatDate r("YMD", 20100101, 20100110, 3);
+    BOOST_CHECK_EQUAL(r.current_index(), 0L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20100101");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 1L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20100104");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 2L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20100107");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 3L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20100110");
+}
+
+BOOST_AUTO_TEST_CASE(repeat_date_cross_month_boundary) {
+    // Regression for the Julian-day fix:
+    // The old naive formula (yyyymmdd_diff / step) would give
+    // (20241202 - 20241129) / 3 = 73 / 3 = 24 (wrong).
+    // The corrected formula gives 1.
+    RepeatDate r("YMD", 20241129, 20241207, 3);
+    BOOST_CHECK_EQUAL(r.current_index(), 0L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20241129");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 1L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20241202");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 2L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20241205");
+}
+
+BOOST_AUTO_TEST_CASE(repeat_date_cross_year_boundary) {
+    // Another cross-boundary regression: Jan 1st is 2 days after Dec 30th.
+    RepeatDate r("YMD", 20231230, 20240103, 2);
+    BOOST_CHECK_EQUAL(r.current_index(), 0L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20231230");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 1L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20240101");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 2L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20240103");
+}
+
+BOOST_AUTO_TEST_CASE(repeat_datetime_index_and_value) {
+    RepeatDateTime r("DT", "19700101T000000", "19700102T000000", "12:00:00");
+    BOOST_CHECK_EQUAL(r.current_index(), 0L);
+    BOOST_CHECK_EQUAL(r.current_value(), "19700101T000000");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 1L);
+    BOOST_CHECK_EQUAL(r.current_value(), "19700101T120000");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 2L);
+    BOOST_CHECK_EQUAL(r.current_value(), "19700102T000000");
+}
+
+BOOST_AUTO_TEST_CASE(repeat_datelist_index_and_value) {
+    RepeatDateList r("DL", {20100101, 20100201, 20100301});
+    BOOST_CHECK_EQUAL(r.current_index(), 0L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20100101");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 1L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20100201");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 2L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20100301");
+}
+
+BOOST_AUTO_TEST_CASE(repeat_datetimelist_index_and_value) {
+    RepeatDateTimeList r("DTL",
+                         {ecf::Instant::parse("19700101T000000"),
+                          ecf::Instant::parse("19700101T120000"),
+                          ecf::Instant::parse("19700102T000000")});
+    BOOST_CHECK_EQUAL(r.current_index(), 0L);
+    BOOST_CHECK_EQUAL(r.current_value(), "19700101T000000");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 1L);
+    BOOST_CHECK_EQUAL(r.current_value(), "19700101T120000");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 2L);
+    BOOST_CHECK_EQUAL(r.current_value(), "19700102T000000");
+}
+
+BOOST_AUTO_TEST_CASE(repeat_integer_index_and_value) {
+    RepeatInteger r("N", 1, 6, 2);
+    BOOST_CHECK_EQUAL(r.current_index(), 0L);
+    BOOST_CHECK_EQUAL(r.current_value(), "1");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 1L);
+    BOOST_CHECK_EQUAL(r.current_value(), "3");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 2L);
+    BOOST_CHECK_EQUAL(r.current_value(), "5");
+}
+
+BOOST_AUTO_TEST_CASE(repeat_enumerated_index_and_value) {
+    using namespace std::string_literals;
+    RepeatEnumerated r("E", {"red"s, "green"s, "blue"s});
+    BOOST_CHECK_EQUAL(r.current_index(), 0L);
+    BOOST_CHECK_EQUAL(r.current_value(), "red");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 1L);
+    BOOST_CHECK_EQUAL(r.current_value(), "green");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 2L);
+    BOOST_CHECK_EQUAL(r.current_value(), "blue");
+}
+
+BOOST_AUTO_TEST_CASE(repeat_string_index_and_value) {
+    using namespace std::string_literals;
+    RepeatString r("S", {"a"s, "b"s, "c"s});
+    BOOST_CHECK_EQUAL(r.current_index(), 0L);
+    BOOST_CHECK_EQUAL(r.current_value(), "a");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 1L);
+    BOOST_CHECK_EQUAL(r.current_value(), "b");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 2L);
+    BOOST_CHECK_EQUAL(r.current_value(), "c");
+}
+
+BOOST_AUTO_TEST_CASE(repeat_day_index_and_value) {
+    // RepeatDay has no position concept: current_index() returns the step value.
+    RepeatDay r(3);
+    BOOST_CHECK_EQUAL(r.current_index(), 3L);
+    BOOST_CHECK_EQUAL(r.current_value(), "3");
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 3L);
+    BOOST_CHECK_EQUAL(r.current_value(), "3");
+}
+
+BOOST_AUTO_TEST_CASE(repeat_wrapper_delegates_to_concrete_type) {
+    // Repeat is a type-erasing wrapper; current_index / current_value must
+    // delegate correctly to each wrapped type.
+    {
+        // RepeatDate: index increments with Julian-day arithmetic
+        Repeat rep{RepeatDate("YMD", 20241129, 20241207, 3)};
+        BOOST_CHECK_EQUAL(rep.current_index(), 0L);
+        BOOST_CHECK_EQUAL(rep.current_value(), "20241129");
+        rep.increment();
+        BOOST_CHECK_EQUAL(rep.current_index(), 1L);
+        BOOST_CHECK_EQUAL(rep.current_value(), "20241202");
+    }
+    {
+        // RepeatInteger
+        Repeat rep{RepeatInteger("N", 0, 4, 2)};
+        BOOST_CHECK_EQUAL(rep.current_index(), 0L);
+        BOOST_CHECK_EQUAL(rep.current_value(), "0");
+        rep.increment();
+        BOOST_CHECK_EQUAL(rep.current_index(), 1L);
+        BOOST_CHECK_EQUAL(rep.current_value(), "2");
+    }
+    {
+        // RepeatString
+        using namespace std::string_literals;
+        Repeat rep{RepeatString("S", {"x"s, "y"s})};
+        BOOST_CHECK_EQUAL(rep.current_index(), 0L);
+        BOOST_CHECK_EQUAL(rep.current_value(), "x");
+        rep.increment();
+        BOOST_CHECK_EQUAL(rep.current_index(), 1L);
+        BOOST_CHECK_EQUAL(rep.current_value(), "y");
+    }
+    {
+        // RepeatDay: index == step
+        Repeat rep{RepeatDay(5)};
+        BOOST_CHECK_EQUAL(rep.current_index(), 5L);
+        BOOST_CHECK_EQUAL(rep.current_value(), "5");
+    }
+    {
+        // Empty Repeat: returns 0 / ""
+        Repeat empty_rep;
+        BOOST_CHECK_EQUAL(empty_rep.current_index(), 0L);
+        BOOST_CHECK_EQUAL(empty_rep.current_value(), "");
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // test_current_index_value
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/attribute/test/TestRepeat.cpp
+++ b/libs/attribute/test/TestRepeat.cpp
@@ -64,6 +64,107 @@ BOOST_AUTO_TEST_CASE(construction) {
     BOOST_CHECK_MESSAGE(empty.state_change_no() == 0, " empty  failed");
 }
 
+BOOST_AUTO_TEST_CASE(current_index_current_value_delegates_to_concrete_type) {
+    // Repeat is a type-erasing wrapper; current_index / current_value must
+    // delegate correctly to each wrapped type.
+    {
+        // RepeatDate: index increments with Julian-day arithmetic
+        Repeat r{RepeatDate("YMD", 20241129, 20241207, 3)};
+        BOOST_CHECK_EQUAL(r.current_index(), 0L);
+        BOOST_CHECK_EQUAL(r.current_value(), "20241129");
+        {
+            auto value = current_value_as<int>(r);
+            BOOST_CHECK(value.has_value() && value.value() == 20241129);
+        }
+        {
+            auto value = current_value_as<std::string>(r);
+            BOOST_CHECK(!value.has_value());
+        }
+        r.increment();
+        BOOST_CHECK_EQUAL(r.current_index(), 1L);
+        BOOST_CHECK_EQUAL(r.current_value(), "20241202");
+        {
+            auto value = current_value_as<int>(r);
+            BOOST_CHECK(value.has_value() && value.value() == 20241202);
+        }
+        {
+            auto value = current_value_as<std::string>(r);
+            BOOST_CHECK(!value.has_value());
+        }
+    }
+    {
+        // RepeatInteger
+        Repeat r{RepeatInteger("N", 0, 4, 2)};
+        BOOST_CHECK_EQUAL(r.current_index(), 0L);
+        BOOST_CHECK_EQUAL(r.current_value(), "0");
+        {
+            auto value = current_value_as<int>(r);
+            BOOST_CHECK(value.has_value() && value.value() == 0);
+        }
+        {
+            auto value = current_value_as<std::string>(r);
+            BOOST_CHECK(!value.has_value());
+        }
+        r.increment();
+        BOOST_CHECK_EQUAL(r.current_index(), 1L);
+        BOOST_CHECK_EQUAL(r.current_value(), "2");
+        {
+            auto value = current_value_as<int>(r);
+            BOOST_CHECK(value.has_value() && value.value() == 2);
+        }
+        {
+            auto value = current_value_as<std::string>(r);
+            BOOST_CHECK(!value.has_value());
+        }
+    }
+    {
+        // RepeatString
+        using namespace std::string_literals;
+        Repeat r{RepeatString("S", {"x"s, "y"s})};
+        BOOST_CHECK_EQUAL(r.current_index(), 0L);
+        BOOST_CHECK_EQUAL(r.current_value(), "x");
+        {
+            auto value = current_value_as<int>(r);
+            BOOST_CHECK(!value.has_value());
+        }
+        {
+            auto value = current_value_as<std::string>(r);
+            BOOST_CHECK(value.has_value() && value.value() == "x");
+        }
+        r.increment();
+        BOOST_CHECK_EQUAL(r.current_index(), 1L);
+        BOOST_CHECK_EQUAL(r.current_value(), "y");
+        {
+            auto value = current_value_as<int>(r);
+            BOOST_CHECK(!value.has_value());
+        }
+        {
+            auto value = current_value_as<std::string>(r);
+            BOOST_CHECK(value.has_value() && value.value() == "y");
+        }
+    }
+    {
+        // RepeatDay: index == step
+        Repeat r{RepeatDay(5)};
+        BOOST_CHECK_EQUAL(r.current_index(), 5L);
+        BOOST_CHECK_EQUAL(r.current_value(), "5");
+        {
+            auto value = current_value_as<int>(r);
+            BOOST_CHECK(value.has_value() && value.value() == 5);
+        }
+        {
+            auto value = current_value_as<std::string>(r);
+            BOOST_CHECK(!value.has_value());
+        }
+    }
+    {
+        // Empty Repeat: returns 0 / ""
+        Repeat empty;
+        BOOST_CHECK_EQUAL(empty.current_index(), 0L);
+        BOOST_CHECK_EQUAL(empty.current_value(), "");
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END() // test_repeat
 
 /*
@@ -310,6 +411,42 @@ BOOST_AUTO_TEST_CASE(generated_variables) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(iterate_over_datelist_current_index_current_value) {
+    RepeatDateList r("DL", {20100101, 20100201, 20100301});
+    BOOST_CHECK_EQUAL(r.current_index(), 0L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20100101");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 20100101);
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 1L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20100201");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 20100201);
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 2L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20100301");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 20100301);
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END() // test_repeat_datelist
 
 /*
@@ -468,6 +605,45 @@ BOOST_AUTO_TEST_CASE(generated_variables) {
         const Variable& var = rep.find_gen_variable("DT_SECONDS");
         BOOST_CHECK_MESSAGE(!var.empty(), "Did not find DT_SECONDS");
         BOOST_CHECK_MESSAGE(var.theValue() == "45", "expected '45' but found " << var.theValue());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(iterate_over_datetimelist_current_index_current_value) {
+    RepeatDateTimeList r("DTL",
+                         {ecf::Instant::parse("19700101T000000"),
+                          ecf::Instant::parse("19700101T120000"),
+                          ecf::Instant::parse("19700102T000000")});
+    BOOST_CHECK_EQUAL(r.current_index(), 0L);
+    BOOST_CHECK_EQUAL(r.current_value(), "19700101T000000");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(value.has_value() && value.value() == "19700101T000000");
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 1L);
+    BOOST_CHECK_EQUAL(r.current_value(), "19700101T120000");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(value.has_value() && value.value() == "19700101T120000");
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 2L);
+    BOOST_CHECK_EQUAL(r.current_value(), "19700102T000000");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(value.has_value() && value.value() == "19700102T000000");
     }
 }
 
@@ -986,37 +1162,133 @@ BOOST_AUTO_TEST_CASE(more_generated_variables) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(convert_xref_to_boost_date) {
-    ECF_NAME_THIS_TEST();
-
-    auto check_date = [](int start, int end, int delta) {
-        auto bdate = boost::gregorian::from_undelimited_string(boost::lexical_cast<std::string>(start));
-
-        Repeat rep(RepeatDate("YMD", start, end, delta));
-        Repeat rep2(RepeatDate("YMD", start, end, delta));
-        while (rep.valid()) {
-
-            // xref repeat date with boost date, essentially checking bdate with rep
-            std::string str_value = boost::lexical_cast<std::string>(rep.value());
-            auto date2            = boost::gregorian::from_undelimited_string(str_value);
-            BOOST_CHECK_MESSAGE(bdate == date2, "expected same value, but found " << bdate << "  " << date2);
-
-            // check change value
-            rep2.change(str_value);
-            BOOST_CHECK_MESSAGE(rep.value() == rep2.value(),
-                                "expected same value, but found " << rep.value() << "  " << rep2.value());
-
-            // increment repeat and boost date
-            rep.increment();
-            bdate += boost::gregorian::days(delta);
-        }
-    };
-
-    check_date(19800101, 20621231, 1);
-    check_date(19800101, 20621231, 7);
-    check_date(20621231, 19800101, -7);
-    check_date(20150514, 20150730, 7);
+BOOST_AUTO_TEST_CASE(iterate_over_date_current_index_current_value_within_month) {
+    RepeatDate r("YMD", 20100101, 20100110, 3);
+    BOOST_CHECK_EQUAL(r.current_index(), 0L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20100101");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 20100101);
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 1L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20100104");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 20100104);
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 2L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20100107");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 20100107);
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 3L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20100110");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 20100110);
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(!value.has_value());
+    }
 }
+
+BOOST_AUTO_TEST_CASE(iterate_over_date_current_index_current_value_over_month_boundary) {
+    RepeatDate r("YMD", 20241129, 20241207, 3);
+    BOOST_CHECK_EQUAL(r.current_index(), 0L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20241129");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 20241129);
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 1L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20241202");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 20241202);
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 2L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20241205");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 20241205);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(iterate_over_date_current_index_current_value_over_year_boundary) {
+    // Another cross-boundary regression: Jan 1st is 2 days after Dec 30th.
+    RepeatDate r("YMD", 20231230, 20240103, 2);
+    BOOST_CHECK_EQUAL(r.current_index(), 0L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20231230");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 20231230);
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 1L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20240101");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 20240101);
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 2L);
+    BOOST_CHECK_EQUAL(r.current_value(), "20240103");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 20240103);
+    }
+}
+
+// BOOST_AUTO_TEST_CASE(convert_xref_to_boost_date) {
+//     ECF_NAME_THIS_TEST();
+//
+//     auto check_date = [](int start, int end, int delta) {
+//         auto bdate = boost::gregorian::from_undelimited_string(boost::lexical_cast<std::string>(start));
+//
+//         Repeat rep(RepeatDate("YMD", start, end, delta));
+//         Repeat rep2(RepeatDate("YMD", start, end, delta));
+//         while (rep.valid()) {
+//
+//             // xref repeat date with boost date, essentially checking bdate with rep
+//             std::string str_value = boost::lexical_cast<std::string>(rep.value());
+//             auto date2            = boost::gregorian::from_undelimited_string(str_value);
+//             BOOST_CHECK_MESSAGE(bdate == date2, "expected same value, but found " << bdate << "  " << date2);
+//
+//             // check change value
+//             rep2.change(str_value);
+//             BOOST_CHECK_MESSAGE(rep.value() == rep2.value(),
+//                                 "expected same value, but found " << rep.value() << "  " << rep2.value());
+//
+//             // increment repeat and boost date
+//             rep.increment();
+//             bdate += boost::gregorian::days(delta);
+//         }
+//     };
+//
+//     check_date(19800101, 20621231, 1);
+//     check_date(19800101, 20621231, 7);
+//     check_date(20621231, 19800101, -7);
+//     check_date(20150514, 20150730, 7);
+// }
 
 BOOST_AUTO_TEST_SUITE_END() // test_repeat_date
 
@@ -1283,6 +1555,42 @@ BOOST_AUTO_TEST_CASE(generated_variables) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(iterate_over_datetime_current_index_current_value) {
+    RepeatDateTime r("DT", "19700101T000000", "19700102T000000", "12:00:00");
+    BOOST_CHECK_EQUAL(r.current_index(), 0L);
+    BOOST_CHECK_EQUAL(r.current_value(), "19700101T000000");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(value.has_value() && value.value() == "19700101T000000");
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 1L);
+    BOOST_CHECK_EQUAL(r.current_value(), "19700101T120000");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(value.has_value() && value.value() == "19700101T120000");
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 2L);
+    BOOST_CHECK_EQUAL(r.current_value(), "19700102T000000");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(value.has_value() && value.value() == "19700102T000000");
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END() // test_repeat_datetime
 
 /*
@@ -1466,6 +1774,43 @@ BOOST_AUTO_TEST_CASE(handling_errors) {
     BOOST_REQUIRE_THROW(RepeatEnumerated("AEnum", empty), std::runtime_error);  // empty enumerations
 }
 
+BOOST_AUTO_TEST_CASE(iterate_over_enumerated_current_index_current_value) {
+    using namespace std::string_literals;
+    RepeatEnumerated r("E", {"red"s, "green"s, "blue"s});
+    BOOST_CHECK_EQUAL(r.current_index(), 0L);
+    BOOST_CHECK_EQUAL(r.current_value(), "red");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(value.has_value() && value.value() == "red");
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 1L);
+    BOOST_CHECK_EQUAL(r.current_value(), "green");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(value.has_value() && value.value() == "green");
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 2L);
+    BOOST_CHECK_EQUAL(r.current_value(), "blue");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(value.has_value() && value.value() == "blue");
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END() // test_repeat_enumerated
 
 /*
@@ -1585,6 +1930,42 @@ BOOST_AUTO_TEST_CASE(increment) {
     BOOST_CHECK_MESSAGE(rep.last_valid_value() == 10, " Expected 10 but found " << rep.last_valid_value());
 }
 
+BOOST_AUTO_TEST_CASE(iterate_over_integer_current_index_current_value) {
+    RepeatInteger r("N", 1, 6, 2);
+    BOOST_CHECK_EQUAL(r.current_index(), 0L);
+    BOOST_CHECK_EQUAL(r.current_value(), "1");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 1);
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 1L);
+    BOOST_CHECK_EQUAL(r.current_value(), "3");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 3);
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 2L);
+    BOOST_CHECK_EQUAL(r.current_value(), "5");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 5);
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END() // test_repeat_integer
 
 /*
@@ -1616,6 +1997,32 @@ BOOST_AUTO_TEST_CASE(invariants) {
         BOOST_CHECK_MESSAGE(empty.valueAsString() == "", "not as expected");
         BOOST_CHECK_MESSAGE(empty.next_value_as_string() == "", "not as expected");
         BOOST_CHECK_MESSAGE(empty.prev_value_as_string() == "", "not as expected");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(iterate_over_day_current_index_current_value) {
+    // RepeatDay has no position concept: current_index() returns the step value.
+    RepeatDay r(3);
+    BOOST_CHECK_EQUAL(r.current_index(), 3L);
+    BOOST_CHECK_EQUAL(r.current_value(), "3");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 3);
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    r.increment();
+    BOOST_CHECK_EQUAL(r.current_index(), 3L);
+    BOOST_CHECK_EQUAL(r.current_value(), "3");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(value.has_value() && value.value() == 3);
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(!value.has_value());
     }
 }
 
@@ -1703,202 +2110,44 @@ BOOST_AUTO_TEST_CASE(handling_errors) {
     BOOST_REQUIRE_THROW(RepeatString("AEnum", empty), std::runtime_error);          // empty string list
 }
 
-BOOST_AUTO_TEST_SUITE_END() // test_repeat_string
-
-/*
- * Test Suite: ::test_current_index_value
- *
- * Tests the current_index() and current_value() methods directly on each
- * concrete RepeatBase subtype and on the Repeat wrapper.
- *
- * Note: Range<RepeatDate>::current_index() in RepeatRange.hpp already uses
- * Julian-day arithmetic.  RepeatDate::current_index() previously used a naive
- * yyyymmdd integer formula that gave incorrect results for sequences crossing
- * month/year boundaries.  The implementation was corrected to match the Range
- * specialisation; the cross-month cases below serve as regression tests.
- * ************************************************************ */
-
-BOOST_AUTO_TEST_SUITE(test_current_index_value)
-
-BOOST_AUTO_TEST_CASE(repeat_date_within_month) {
-    // Simple same-month sequence: both the old integer formula and the new
-    // Julian-day formula agree, so this confirms no regression.
-    RepeatDate r("YMD", 20100101, 20100110, 3);
-    BOOST_CHECK_EQUAL(r.current_index(), 0L);
-    BOOST_CHECK_EQUAL(r.current_value(), "20100101");
-    r.increment();
-    BOOST_CHECK_EQUAL(r.current_index(), 1L);
-    BOOST_CHECK_EQUAL(r.current_value(), "20100104");
-    r.increment();
-    BOOST_CHECK_EQUAL(r.current_index(), 2L);
-    BOOST_CHECK_EQUAL(r.current_value(), "20100107");
-    r.increment();
-    BOOST_CHECK_EQUAL(r.current_index(), 3L);
-    BOOST_CHECK_EQUAL(r.current_value(), "20100110");
-}
-
-BOOST_AUTO_TEST_CASE(repeat_date_cross_month_boundary) {
-    // Regression for the Julian-day fix:
-    // The old naive formula (yyyymmdd_diff / step) would give
-    // (20241202 - 20241129) / 3 = 73 / 3 = 24 (wrong).
-    // The corrected formula gives 1.
-    RepeatDate r("YMD", 20241129, 20241207, 3);
-    BOOST_CHECK_EQUAL(r.current_index(), 0L);
-    BOOST_CHECK_EQUAL(r.current_value(), "20241129");
-    r.increment();
-    BOOST_CHECK_EQUAL(r.current_index(), 1L);
-    BOOST_CHECK_EQUAL(r.current_value(), "20241202");
-    r.increment();
-    BOOST_CHECK_EQUAL(r.current_index(), 2L);
-    BOOST_CHECK_EQUAL(r.current_value(), "20241205");
-}
-
-BOOST_AUTO_TEST_CASE(repeat_date_cross_year_boundary) {
-    // Another cross-boundary regression: Jan 1st is 2 days after Dec 30th.
-    RepeatDate r("YMD", 20231230, 20240103, 2);
-    BOOST_CHECK_EQUAL(r.current_index(), 0L);
-    BOOST_CHECK_EQUAL(r.current_value(), "20231230");
-    r.increment();
-    BOOST_CHECK_EQUAL(r.current_index(), 1L);
-    BOOST_CHECK_EQUAL(r.current_value(), "20240101");
-    r.increment();
-    BOOST_CHECK_EQUAL(r.current_index(), 2L);
-    BOOST_CHECK_EQUAL(r.current_value(), "20240103");
-}
-
-BOOST_AUTO_TEST_CASE(repeat_datetime_index_and_value) {
-    RepeatDateTime r("DT", "19700101T000000", "19700102T000000", "12:00:00");
-    BOOST_CHECK_EQUAL(r.current_index(), 0L);
-    BOOST_CHECK_EQUAL(r.current_value(), "19700101T000000");
-    r.increment();
-    BOOST_CHECK_EQUAL(r.current_index(), 1L);
-    BOOST_CHECK_EQUAL(r.current_value(), "19700101T120000");
-    r.increment();
-    BOOST_CHECK_EQUAL(r.current_index(), 2L);
-    BOOST_CHECK_EQUAL(r.current_value(), "19700102T000000");
-}
-
-BOOST_AUTO_TEST_CASE(repeat_datelist_index_and_value) {
-    RepeatDateList r("DL", {20100101, 20100201, 20100301});
-    BOOST_CHECK_EQUAL(r.current_index(), 0L);
-    BOOST_CHECK_EQUAL(r.current_value(), "20100101");
-    r.increment();
-    BOOST_CHECK_EQUAL(r.current_index(), 1L);
-    BOOST_CHECK_EQUAL(r.current_value(), "20100201");
-    r.increment();
-    BOOST_CHECK_EQUAL(r.current_index(), 2L);
-    BOOST_CHECK_EQUAL(r.current_value(), "20100301");
-}
-
-BOOST_AUTO_TEST_CASE(repeat_datetimelist_index_and_value) {
-    RepeatDateTimeList r("DTL",
-                         {ecf::Instant::parse("19700101T000000"),
-                          ecf::Instant::parse("19700101T120000"),
-                          ecf::Instant::parse("19700102T000000")});
-    BOOST_CHECK_EQUAL(r.current_index(), 0L);
-    BOOST_CHECK_EQUAL(r.current_value(), "19700101T000000");
-    r.increment();
-    BOOST_CHECK_EQUAL(r.current_index(), 1L);
-    BOOST_CHECK_EQUAL(r.current_value(), "19700101T120000");
-    r.increment();
-    BOOST_CHECK_EQUAL(r.current_index(), 2L);
-    BOOST_CHECK_EQUAL(r.current_value(), "19700102T000000");
-}
-
-BOOST_AUTO_TEST_CASE(repeat_integer_index_and_value) {
-    RepeatInteger r("N", 1, 6, 2);
-    BOOST_CHECK_EQUAL(r.current_index(), 0L);
-    BOOST_CHECK_EQUAL(r.current_value(), "1");
-    r.increment();
-    BOOST_CHECK_EQUAL(r.current_index(), 1L);
-    BOOST_CHECK_EQUAL(r.current_value(), "3");
-    r.increment();
-    BOOST_CHECK_EQUAL(r.current_index(), 2L);
-    BOOST_CHECK_EQUAL(r.current_value(), "5");
-}
-
-BOOST_AUTO_TEST_CASE(repeat_enumerated_index_and_value) {
-    using namespace std::string_literals;
-    RepeatEnumerated r("E", {"red"s, "green"s, "blue"s});
-    BOOST_CHECK_EQUAL(r.current_index(), 0L);
-    BOOST_CHECK_EQUAL(r.current_value(), "red");
-    r.increment();
-    BOOST_CHECK_EQUAL(r.current_index(), 1L);
-    BOOST_CHECK_EQUAL(r.current_value(), "green");
-    r.increment();
-    BOOST_CHECK_EQUAL(r.current_index(), 2L);
-    BOOST_CHECK_EQUAL(r.current_value(), "blue");
-}
-
-BOOST_AUTO_TEST_CASE(repeat_string_index_and_value) {
+BOOST_AUTO_TEST_CASE(iterate_over_string_current_index_current_value) {
     using namespace std::string_literals;
     RepeatString r("S", {"a"s, "b"s, "c"s});
     BOOST_CHECK_EQUAL(r.current_index(), 0L);
     BOOST_CHECK_EQUAL(r.current_value(), "a");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(value.has_value() && value.value() == "a");
+    }
     r.increment();
     BOOST_CHECK_EQUAL(r.current_index(), 1L);
     BOOST_CHECK_EQUAL(r.current_value(), "b");
+    {
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(!value.has_value());
+    }
+    {
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(value.has_value() && value.value() == "b");
+    }
     r.increment();
     BOOST_CHECK_EQUAL(r.current_index(), 2L);
     BOOST_CHECK_EQUAL(r.current_value(), "c");
-}
-
-BOOST_AUTO_TEST_CASE(repeat_day_index_and_value) {
-    // RepeatDay has no position concept: current_index() returns the step value.
-    RepeatDay r(3);
-    BOOST_CHECK_EQUAL(r.current_index(), 3L);
-    BOOST_CHECK_EQUAL(r.current_value(), "3");
-    r.increment();
-    BOOST_CHECK_EQUAL(r.current_index(), 3L);
-    BOOST_CHECK_EQUAL(r.current_value(), "3");
-}
-
-BOOST_AUTO_TEST_CASE(repeat_wrapper_delegates_to_concrete_type) {
-    // Repeat is a type-erasing wrapper; current_index / current_value must
-    // delegate correctly to each wrapped type.
     {
-        // RepeatDate: index increments with Julian-day arithmetic
-        Repeat rep{RepeatDate("YMD", 20241129, 20241207, 3)};
-        BOOST_CHECK_EQUAL(rep.current_index(), 0L);
-        BOOST_CHECK_EQUAL(rep.current_value(), "20241129");
-        rep.increment();
-        BOOST_CHECK_EQUAL(rep.current_index(), 1L);
-        BOOST_CHECK_EQUAL(rep.current_value(), "20241202");
+        auto value = current_value_as<int>(r);
+        BOOST_CHECK(!value.has_value());
     }
     {
-        // RepeatInteger
-        Repeat rep{RepeatInteger("N", 0, 4, 2)};
-        BOOST_CHECK_EQUAL(rep.current_index(), 0L);
-        BOOST_CHECK_EQUAL(rep.current_value(), "0");
-        rep.increment();
-        BOOST_CHECK_EQUAL(rep.current_index(), 1L);
-        BOOST_CHECK_EQUAL(rep.current_value(), "2");
-    }
-    {
-        // RepeatString
-        using namespace std::string_literals;
-        Repeat rep{RepeatString("S", {"x"s, "y"s})};
-        BOOST_CHECK_EQUAL(rep.current_index(), 0L);
-        BOOST_CHECK_EQUAL(rep.current_value(), "x");
-        rep.increment();
-        BOOST_CHECK_EQUAL(rep.current_index(), 1L);
-        BOOST_CHECK_EQUAL(rep.current_value(), "y");
-    }
-    {
-        // RepeatDay: index == step
-        Repeat rep{RepeatDay(5)};
-        BOOST_CHECK_EQUAL(rep.current_index(), 5L);
-        BOOST_CHECK_EQUAL(rep.current_value(), "5");
-    }
-    {
-        // Empty Repeat: returns 0 / ""
-        Repeat empty_rep;
-        BOOST_CHECK_EQUAL(empty_rep.current_index(), 0L);
-        BOOST_CHECK_EQUAL(empty_rep.current_value(), "");
+        auto value = current_value_as<std::string>(r);
+        BOOST_CHECK(value.has_value() && value.value() == "c");
     }
 }
 
-BOOST_AUTO_TEST_SUITE_END() // test_current_index_value
+BOOST_AUTO_TEST_SUITE_END() // test_repeat_string
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/libs/core/src/ecflow/core/TypeTraits.hpp
+++ b/libs/core/src/ecflow/core/TypeTraits.hpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2009- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#ifndef ecflow_core_TypeTraits_HPP
+#define ecflow_core_TypeTraits_HPP
+
+#include <type_traits>
+
+namespace ecf {
+
+///
+/// @brief Check if a given reference type is one of the comparing types
+///
+/// The value data member is true when the refernce type is one of the comparing types, otherwise false.
+///
+/// @tparam T the reference type
+/// @tparam Xs the comparing types
+///
+template <typename T, typename... Xs>
+struct is_one_of
+{
+    static constexpr bool value = false;
+};
+
+///
+/// @brief Specialisation of is_one_of to handle the comparison between the reference type and the comparing types
+///
+/// @tparam T the reference type
+/// @tparam X the first of the comparing types
+/// @tparam Xs the remaining comparing types
+///
+template <typename T, typename X, typename... Xs>
+struct is_one_of<T, X, Xs...>
+{
+    static constexpr bool value = std::is_same_v<T, X> || is_one_of<T, Xs...>::value;
+};
+
+///
+/// @brief A convenience variable template to get the value of is_one_of without needing to access the value data member
+///
+/// @tparam T the reference type
+/// @tparam Xs the comparing types
+///
+template <typename T, typename... Xs>
+inline constexpr bool is_one_of_v = is_one_of<T, Xs...>::value;
+
+} // namespace ecf
+
+#endif /* ecflow_core_TypeTraits_HPP */

--- a/libs/pyext/src/ecflow/python/ExportNodeAttr.cpp
+++ b/libs/pyext/src/ecflow/python/ExportNodeAttr.cpp
@@ -1253,7 +1253,13 @@ void export_NodeAttr(py::module& m) {
         .def("end", &RepeatDate::end, "Return the end date as an integer in yyyymmdd format")
         .def("step",
              &RepeatDate::step,
-             "Return the step increment. This is used to update the repeat, until end date is reached");
+             "Return the step increment. This is used to update the repeat, until end date is reached")
+        .def("current_index",
+             &RepeatDate::current_index,
+             "Return the zero-based index of the current date position.\n"
+             "Uses calendar-day (Julian-day) arithmetic so the result is correct\n"
+             "even for sequences that cross month or year boundaries.")
+        .def("current_value", &RepeatDate::current_value, "Return the current date as a string in yyyymmdd format.");
 
     py::class_<RepeatDateTime>(m, "RepeatDateTime", NodeAttrDoc::repeat_datetime_doc())
 
@@ -1283,7 +1289,14 @@ void export_NodeAttr(py::module& m) {
         .def("step",
              &RepeatDateTime::step,
              "Return the step increment (in seconds). This is used to update the repeat, until end instant is "
-             "reached");
+             "reached")
+        .def("current_index",
+             &RepeatDateTime::current_index,
+             "Return the zero-based index of the current instant position:\n"
+             "(seconds(current) - seconds(start)) / seconds(step).")
+        .def("current_value",
+             &RepeatDateTime::current_value,
+             "Return the current instant as a string in yyyymmddTHHMMSS format.");
 
     py::class_<RepeatDateList>(m, "RepeatDateList", NodeAttrDoc::repeat_date_list_doc())
 
@@ -1295,7 +1308,13 @@ void export_NodeAttr(py::module& m) {
         .def("__copy__", pyutil_copy_object<RepeatDateList>)
         .def("name", &RepeatDateList::name, py::return_value_policy::reference, "Return the name of the repeat.")
         .def("start", &RepeatDateList::start, "Return the start date as an integer in yyyymmdd format")
-        .def("end", &RepeatDateList::end, "Return the end date as an integer in yyyymmdd format");
+        .def("end", &RepeatDateList::end, "Return the end date as an integer in yyyymmdd format")
+        .def("current_index",
+             &RepeatDateList::current_index,
+             "Return the zero-based index of the current date in the list.")
+        .def("current_value",
+             &RepeatDateList::current_value,
+             "Return the current date as a string in yyyymmdd format, or '' if out of bounds.");
 
     py::class_<RepeatDateTimeList>(m, "RepeatDateTimeList", NodeAttrDoc::repeat_datetimelist_doc())
         .def(py::init<>())
@@ -1306,7 +1325,13 @@ void export_NodeAttr(py::module& m) {
         .def("__copy__", pyutil_copy_object<RepeatDateTimeList>) // __copy__ uses copy constructor
         .def("name", &RepeatDateTimeList::name, py::return_value_policy::reference, "Return the name of the repeat.")
         .def("start", &RepeatDateTimeList::start, "Return the start instant as seconds since epoch")
-        .def("end", &RepeatDateTimeList::end, "Return the end instant as seconds since epoch");
+        .def("end", &RepeatDateTimeList::end, "Return the end instant as seconds since epoch")
+        .def("current_index",
+             &RepeatDateTimeList::current_index,
+             "Return the zero-based index of the current instant in the list.")
+        .def("current_value",
+             &RepeatDateTimeList::current_value,
+             "Return the current instant as a string in yyyymmddTHHMMSS format, or '' if out of bounds.");
 
     py::class_<RepeatInteger>(m, "RepeatInteger", NodeAttrDoc::repeat_integer_doc())
 
@@ -1322,7 +1347,11 @@ void export_NodeAttr(py::module& m) {
         .def("name", &RepeatInteger::name, py::return_value_policy::reference, "Return the name of the repeat.")
         .def("start", &RepeatInteger::start)
         .def("end", &RepeatInteger::end)
-        .def("step", &RepeatInteger::step);
+        .def("step", &RepeatInteger::step)
+        .def("current_index",
+             &RepeatInteger::current_index,
+             "Return the zero-based index of the current value: (value - start) / step.")
+        .def("current_value", &RepeatInteger::current_value, "Return the current integer value as a decimal string.");
 
     // Create as shared because: we want to pass a Python list as part of the constructor,
     // and the only way make_constructor works is with a pointer.
@@ -1338,7 +1367,13 @@ void export_NodeAttr(py::module& m) {
         .def("name", &RepeatEnumerated::name, py::return_value_policy::reference, "Return the name of the `repeat`_.")
         .def("start", &RepeatEnumerated::start)
         .def("end", &RepeatEnumerated::end)
-        .def("step", &RepeatEnumerated::step);
+        .def("step", &RepeatEnumerated::step)
+        .def("current_index",
+             &RepeatEnumerated::current_index,
+             "Return the zero-based index of the current enumeration value.")
+        .def("current_value",
+             &RepeatEnumerated::current_value,
+             "Return the enumeration string at the current index, or '' if out of bounds.");
 
     py::class_<RepeatString, std::shared_ptr<RepeatString>>(m, "RepeatString", NodeAttrDoc::repeat_string_doc())
 
@@ -1351,7 +1386,11 @@ void export_NodeAttr(py::module& m) {
         .def("name", &RepeatString::name, py::return_value_policy::reference, "Return the name of the `repeat`_.")
         .def("start", &RepeatString::start)
         .def("end", &RepeatString::end)
-        .def("step", &RepeatString::step);
+        .def("step", &RepeatString::step)
+        .def("current_index", &RepeatString::current_index, "Return the zero-based index into the string list.")
+        .def("current_value",
+             &RepeatString::current_value,
+             "Return the string at the current index, or '' if out of bounds.");
 
     py::class_<RepeatDay>(m, "RepeatDay", NodeAttrDoc::repeat_day_doc())
 
@@ -1359,7 +1398,11 @@ void export_NodeAttr(py::module& m) {
         .def(py::self == py::self)
         .def("__hash__", &py_hash)
         .def("__str__", &RepeatDay::toString)
-        .def("__copy__", pyutil_copy_object<RepeatDay>);
+        .def("__copy__", pyutil_copy_object<RepeatDay>)
+        .def("current_index",
+             &RepeatDay::current_index,
+             "Return the step value (RepeatDay has no position concept; the step is its only numeric attribute).")
+        .def("current_value", &RepeatDay::current_value, "Return the step value as a decimal string.");
 
     py::class_<Repeat>(m, "Repeat", NodeAttrDoc::repeat_doc())
 
@@ -1376,7 +1419,10 @@ void export_NodeAttr(py::module& m) {
         .def("start", &Repeat::start, "The start value of the repeat, as an integer")
         .def("end", &Repeat::end, "The last value of the repeat, as an integer")
         .def("step", &Repeat::step, "The increment for the repeat, as an integer")
-        .def("value", &Repeat::last_valid_value, "The current value of the repeat as an integer");
+        .def("value", &Repeat::last_valid_value, "The current value of the repeat as an integer")
+        .def("current_value", &Repeat::current_value, "The current value of the repeat (as a string)")
+        .def("current_index", &Repeat::current_index, "The current index of the repeat (as an integer)")
+        .def("increment", &Repeat::increment, "Increment the repeat to the next value");
 
     void (ecf::CronAttr::*CronAttr_set_time_series_timeseries)(const ecf::TimeSeries&) = &ecf::CronAttr::addTimeSeries;
     void (ecf::CronAttr::*CronAttr_set_time_series_timeslot_timeslot_timeslot)(

--- a/libs/pyext/src/ecflow/python/ExportNodeAttr.cpp
+++ b/libs/pyext/src/ecflow/python/ExportNodeAttr.cpp
@@ -1261,7 +1261,9 @@ void export_NodeAttr(py::module& m) {
              "even for sequences that cross month or year boundaries.")
         .def(
             "current_value",
-            [](const RepeatDate& self) -> py::object { return py::cast(current_value_of<int>(self).value()); },
+            [](const RepeatDate& self) -> py::object {
+                return py::cast(ecf::repeat::current_value_of<int>(self).value());
+            },
             "Return the current date as an integer in yyyymmdd format.");
 
     py::class_<RepeatDateTime>(m, "RepeatDateTime", NodeAttrDoc::repeat_datetime_doc())
@@ -1300,7 +1302,7 @@ void export_NodeAttr(py::module& m) {
         .def(
             "current_value",
             [](const RepeatDateTime& self) -> py::object {
-                return py::cast(current_value_of<std::string>(self).value());
+                return py::cast(ecf::repeat::current_value_of<std::string>(self).value());
             },
             "Return the current instant as a string in yyyymmddTHHMMSS format.");
 
@@ -1320,8 +1322,10 @@ void export_NodeAttr(py::module& m) {
              "Return the zero-based index of the current date in the list.")
         .def(
             "current_value",
-            [](const RepeatDateList& self) -> py::object { return py::cast(current_value_of<int>(self).value()); },
-            "Return the current date as a integer in yyyymmdd format.");
+            [](const RepeatDateList& self) -> py::object {
+                return py::cast(ecf::repeat::current_value_of<int>(self).value());
+            },
+            "Return the current date as an integer in yyyymmdd format.");
 
     py::class_<RepeatDateTimeList>(m, "RepeatDateTimeList", NodeAttrDoc::repeat_datetimelist_doc())
         .def(py::init<>())
@@ -1339,7 +1343,7 @@ void export_NodeAttr(py::module& m) {
         .def(
             "current_value",
             [](const RepeatDateTimeList& self) -> py::object {
-                return py::cast(current_value_of<std::string>(self).value());
+                return py::cast(ecf::repeat::current_value_of<std::string>(self).value());
             },
             "Return the current instant as a string in yyyymmddTHHMMSS format.");
 
@@ -1363,7 +1367,9 @@ void export_NodeAttr(py::module& m) {
              "Return the zero-based index of the current value: (value - start) / step.")
         .def(
             "current_value",
-            [](const RepeatInteger& self) -> py::object { return py::cast(current_value_of<int>(self).value()); },
+            [](const RepeatInteger& self) -> py::object {
+                return py::cast(ecf::repeat::current_value_of<int>(self).value());
+            },
             "Return the current integer value.");
 
     // Create as shared because: we want to pass a Python list as part of the constructor,
@@ -1387,7 +1393,7 @@ void export_NodeAttr(py::module& m) {
         .def(
             "current_value",
             [](const RepeatEnumerated& self) -> py::object {
-                return py::cast(current_value_of<std::string>(self).value());
+                return py::cast(ecf::repeat::current_value_of<std::string>(self).value());
             },
             "Return the enumeration string at the current index.");
 
@@ -1407,7 +1413,7 @@ void export_NodeAttr(py::module& m) {
         .def(
             "current_value",
             [](const RepeatString& self) -> py::object {
-                return py::cast(current_value_of<std::string>(self).value());
+                return py::cast(ecf::repeat::current_value_of<std::string>(self).value());
             },
             "Return the string at the current index.");
 
@@ -1424,7 +1430,9 @@ void export_NodeAttr(py::module& m) {
              "numeric attribute).")
         .def(
             "current_value",
-            [](const RepeatDay& self) -> py::object { return py::cast(current_value_of<int>(self).value()); },
+            [](const RepeatDay& self) -> py::object {
+                return py::cast(ecf::repeat::current_value_of<int>(self).value());
+            },
             "Return the step value as an integer value.");
 
     py::class_<Repeat>(m, "Repeat", NodeAttrDoc::repeat_doc())
@@ -1443,13 +1451,14 @@ void export_NodeAttr(py::module& m) {
         .def("end", &Repeat::end, "The last value of the repeat, as an integer")
         .def("step", &Repeat::step, "The increment for the repeat, as an integer")
         .def("value", &Repeat::last_valid_value, "The current value of the repeat as an integer")
+        .def("current_index", &Repeat::current_index, "The current index of the repeat (as an integer)")
         .def(
             "current_value",
             [](const Repeat& self) -> py::object {
-                if (auto found = current_value_as<int>(self); found.has_value()) {
+                if (auto found = ecf::repeat::current_value_as<int>(self); found.has_value()) {
                     return py::cast(found.value());
                 }
-                if (auto found = current_value_as<std::string>(self); found.has_value()) {
+                if (auto found = ecf::repeat::current_value_as<std::string>(self); found.has_value()) {
                     return py::cast(found.value());
                 }
                 else {
@@ -1458,9 +1467,10 @@ void export_NodeAttr(py::module& m) {
             },
             "The current value of the repeat (as a string for RepeatDateTime, RepeatDateTimeList, RepeatEnumerated, "
             "RepeatString; as an integer for RepeatDate, RepeatDateList, RepeatInteger and RepeatDay)")
-        .def("current_value", &Repeat::current_value, "The current value of the repeat (as a string)")
-        .def("current_index", &Repeat::current_index, "The current index of the repeat (as an integer)")
-        .def("increment", &Repeat::increment, "Increment the repeat to the next value");
+        .def("increment",
+             &Repeat::increment,
+             "Increment the repeat to the next value\n\n"
+             "n.b. this modifies the in-memory local object only --it does not update the ecFlow server.");
 
     void (ecf::CronAttr::*CronAttr_set_time_series_timeseries)(const ecf::TimeSeries&) = &ecf::CronAttr::addTimeSeries;
     void (ecf::CronAttr::*CronAttr_set_time_series_timeslot_timeslot_timeslot)(

--- a/libs/pyext/src/ecflow/python/ExportNodeAttr.cpp
+++ b/libs/pyext/src/ecflow/python/ExportNodeAttr.cpp
@@ -1259,7 +1259,10 @@ void export_NodeAttr(py::module& m) {
              "Return the zero-based index of the current date position.\n"
              "Uses calendar-day (Julian-day) arithmetic so the result is correct\n"
              "even for sequences that cross month or year boundaries.")
-        .def("current_value", &RepeatDate::current_value, "Return the current date as a string in yyyymmdd format.");
+        .def(
+            "current_value",
+            [](const RepeatDate& self) -> py::object { return py::cast(current_value_of<int>(self).value()); },
+            "Return the current date as an integer in yyyymmdd format.");
 
     py::class_<RepeatDateTime>(m, "RepeatDateTime", NodeAttrDoc::repeat_datetime_doc())
 
@@ -1294,9 +1297,12 @@ void export_NodeAttr(py::module& m) {
              &RepeatDateTime::current_index,
              "Return the zero-based index of the current instant position:\n"
              "(seconds(current) - seconds(start)) / seconds(step).")
-        .def("current_value",
-             &RepeatDateTime::current_value,
-             "Return the current instant as a string in yyyymmddTHHMMSS format.");
+        .def(
+            "current_value",
+            [](const RepeatDateTime& self) -> py::object {
+                return py::cast(current_value_of<std::string>(self).value());
+            },
+            "Return the current instant as a string in yyyymmddTHHMMSS format.");
 
     py::class_<RepeatDateList>(m, "RepeatDateList", NodeAttrDoc::repeat_date_list_doc())
 
@@ -1312,9 +1318,10 @@ void export_NodeAttr(py::module& m) {
         .def("current_index",
              &RepeatDateList::current_index,
              "Return the zero-based index of the current date in the list.")
-        .def("current_value",
-             &RepeatDateList::current_value,
-             "Return the current date as a string in yyyymmdd format, or '' if out of bounds.");
+        .def(
+            "current_value",
+            [](const RepeatDateList& self) -> py::object { return py::cast(current_value_of<int>(self).value()); },
+            "Return the current date as a integer in yyyymmdd format.");
 
     py::class_<RepeatDateTimeList>(m, "RepeatDateTimeList", NodeAttrDoc::repeat_datetimelist_doc())
         .def(py::init<>())
@@ -1329,9 +1336,12 @@ void export_NodeAttr(py::module& m) {
         .def("current_index",
              &RepeatDateTimeList::current_index,
              "Return the zero-based index of the current instant in the list.")
-        .def("current_value",
-             &RepeatDateTimeList::current_value,
-             "Return the current instant as a string in yyyymmddTHHMMSS format, or '' if out of bounds.");
+        .def(
+            "current_value",
+            [](const RepeatDateTimeList& self) -> py::object {
+                return py::cast(current_value_of<std::string>(self).value());
+            },
+            "Return the current instant as a string in yyyymmddTHHMMSS format.");
 
     py::class_<RepeatInteger>(m, "RepeatInteger", NodeAttrDoc::repeat_integer_doc())
 
@@ -1351,7 +1361,10 @@ void export_NodeAttr(py::module& m) {
         .def("current_index",
              &RepeatInteger::current_index,
              "Return the zero-based index of the current value: (value - start) / step.")
-        .def("current_value", &RepeatInteger::current_value, "Return the current integer value as a decimal string.");
+        .def(
+            "current_value",
+            [](const RepeatInteger& self) -> py::object { return py::cast(current_value_of<int>(self).value()); },
+            "Return the current integer value.");
 
     // Create as shared because: we want to pass a Python list as part of the constructor,
     // and the only way make_constructor works is with a pointer.
@@ -1371,9 +1384,12 @@ void export_NodeAttr(py::module& m) {
         .def("current_index",
              &RepeatEnumerated::current_index,
              "Return the zero-based index of the current enumeration value.")
-        .def("current_value",
-             &RepeatEnumerated::current_value,
-             "Return the enumeration string at the current index, or '' if out of bounds.");
+        .def(
+            "current_value",
+            [](const RepeatEnumerated& self) -> py::object {
+                return py::cast(current_value_of<std::string>(self).value());
+            },
+            "Return the enumeration string at the current index.");
 
     py::class_<RepeatString, std::shared_ptr<RepeatString>>(m, "RepeatString", NodeAttrDoc::repeat_string_doc())
 
@@ -1388,9 +1404,12 @@ void export_NodeAttr(py::module& m) {
         .def("end", &RepeatString::end)
         .def("step", &RepeatString::step)
         .def("current_index", &RepeatString::current_index, "Return the zero-based index into the string list.")
-        .def("current_value",
-             &RepeatString::current_value,
-             "Return the string at the current index, or '' if out of bounds.");
+        .def(
+            "current_value",
+            [](const RepeatString& self) -> py::object {
+                return py::cast(current_value_of<std::string>(self).value());
+            },
+            "Return the string at the current index.");
 
     py::class_<RepeatDay>(m, "RepeatDay", NodeAttrDoc::repeat_day_doc())
 
@@ -1401,8 +1420,12 @@ void export_NodeAttr(py::module& m) {
         .def("__copy__", pyutil_copy_object<RepeatDay>)
         .def("current_index",
              &RepeatDay::current_index,
-             "Return the step value (RepeatDay has no position concept; the step is its only numeric attribute).")
-        .def("current_value", &RepeatDay::current_value, "Return the step value as a decimal string.");
+             "Return the step as an integer value (n.b. RepeatDay has no position concept; the step is its only "
+             "numeric attribute).")
+        .def(
+            "current_value",
+            [](const RepeatDay& self) -> py::object { return py::cast(current_value_of<int>(self).value()); },
+            "Return the step value as an integer value.");
 
     py::class_<Repeat>(m, "Repeat", NodeAttrDoc::repeat_doc())
 
@@ -1420,6 +1443,21 @@ void export_NodeAttr(py::module& m) {
         .def("end", &Repeat::end, "The last value of the repeat, as an integer")
         .def("step", &Repeat::step, "The increment for the repeat, as an integer")
         .def("value", &Repeat::last_valid_value, "The current value of the repeat as an integer")
+        .def(
+            "current_value",
+            [](const Repeat& self) -> py::object {
+                if (auto found = current_value_as<int>(self); found.has_value()) {
+                    return py::cast(found.value());
+                }
+                if (auto found = current_value_as<std::string>(self); found.has_value()) {
+                    return py::cast(found.value());
+                }
+                else {
+                    return py::none();
+                }
+            },
+            "The current value of the repeat (as a string for RepeatDateTime, RepeatDateTimeList, RepeatEnumerated, "
+            "RepeatString; as an integer for RepeatDate, RepeatDateList, RepeatInteger and RepeatDay)")
         .def("current_value", &Repeat::current_value, "The current value of the repeat (as a string)")
         .def("current_index", &Repeat::current_index, "The current index of the repeat (as an integer)")
         .def("increment", &Repeat::increment, "Increment the repeat to the next value");

--- a/libs/pyext/src/ecflow/python/NodeAttrDoc.cpp
+++ b/libs/pyext/src/ecflow/python/NodeAttrDoc.cpp
@@ -554,11 +554,11 @@ const char* NodeAttrDoc::autorestore_doc() {
 
 const char* NodeAttrDoc::repeat_doc() {
     return "Represents one of RepeatString, RepeatEnumerated, RepeatInteger, RepeatDate,\n"
-           "RepeatDateTime, RepeatDateList, RepeatDateTimeList, or RepeatDay.\n\n"
-           "Accessor methods\n"
-           "-----------------\n"
-           "current_index() -> int    Zero-based position index of the repeat's current value.\n"
-           "current_value() -> str    Current value as a human-readable string.\n";
+           "RepeatDateTime, RepeatDateList, RepeatDateTimeList, or RepeatDay.\n"
+           "\nAccessor methods::\n\n"
+           "   current_value() -> None # if empty\n"
+           "   current_value() -> int  # if holding RepeatDate/DateList/Integer/Day\n"
+           "   current_value() -> str  # if holdind RepeatDateTime/DateTimeList/Enumerated/RepeatString\n";
 }
 
 const char* NodeAttrDoc::repeat_date_doc() {
@@ -588,9 +588,9 @@ const char* NodeAttrDoc::repeat_date_doc() {
            "      Zero-based position of the current date in the sequence.\n"
            "      Computed using calendar-day (Julian-day) arithmetic,\n"
            "      so it is correct even when the sequence crosses a month or year boundary.\n"
-           "      Returns 0 at construction / after reset.\n"
-           "   current_value() -> str\n"
-           "      The current date as a string in yyyymmdd format.\n";
+           "      Returns 0 at construction / after reset.\n\n"
+           "   current_value() -> int\n"
+           "      The current instant as an integer in yyyymmdd format.\n";
 }
 
 const char* NodeAttrDoc::repeat_datetime_doc() {
@@ -647,8 +647,8 @@ const char* NodeAttrDoc::repeat_date_list_doc() {
            "\nAccessor methods::\n\n"
            "   current_index() -> int\n"
            "      Zero-based index of the current date in the list.\n"
-           "   current_value() -> str\n"
-           "      The current date as a string in yyyymmdd format, or '' if out of bounds.\n";
+           "   current_value() -> int\n"
+           "      The current date as an integer in yyyymmdd format.\n";
 }
 
 const char* NodeAttrDoc::repeat_datetimelist_doc() {
@@ -692,8 +692,8 @@ const char* NodeAttrDoc::repeat_integer_doc() {
            "\nAccessor methods::\n\n"
            "   current_index() -> int\n"
            "      Zero-based position: (value - start) / step.\n"
-           "   current_value() -> str\n"
-           "      The current integer value as a decimal string.\n";
+           "   current_value() -> int\n"
+           "      The current integer value.\n";
 }
 
 const char* NodeAttrDoc::repeat_enumerated_doc() {
@@ -749,8 +749,8 @@ const char* NodeAttrDoc::repeat_day_doc() {
            "\nAccessor methods::\n\n"
            "   current_index() -> int\n"
            "      RepeatDay has no position concept; returns the step value.\n"
-           "   current_value() -> str\n"
-           "      The step value as a decimal string.\n";
+           "   current_value() -> int\n"
+           "      The step value as an integer.\n";
 }
 
 const char* NodeAttrDoc::cron_doc() {

--- a/libs/pyext/src/ecflow/python/NodeAttrDoc.cpp
+++ b/libs/pyext/src/ecflow/python/NodeAttrDoc.cpp
@@ -553,7 +553,12 @@ const char* NodeAttrDoc::autorestore_doc() {
 }
 
 const char* NodeAttrDoc::repeat_doc() {
-    return "Represents one of RepeatString,RepeatEnumerated,RepeatInteger,RepeatDate,RepeatDay\n\n";
+    return "Represents one of RepeatString, RepeatEnumerated, RepeatInteger, RepeatDate,\n"
+           "RepeatDateTime, RepeatDateList, RepeatDateTimeList, or RepeatDay.\n\n"
+           "Accessor methods\n"
+           "-----------------\n"
+           "current_index() -> int    Zero-based position index of the repeat's current value.\n"
+           "current_value() -> str    Current value as a human-readable string.\n";
 }
 
 const char* NodeAttrDoc::repeat_date_doc() {
@@ -577,7 +582,15 @@ const char* NodeAttrDoc::repeat_date_doc() {
            "   rep = RepeatDate('YMD', 20050130, 20050203 )\n"
            "   rep = RepeatDate('YMD', 20050130, 20050203, 2)\n"
            "   t = Task('t1',\n"
-           "            RepeatDate('YMD', 20050130, 20050203 ))\n";
+           "            RepeatDate('YMD', 20050130, 20050203 ))\n"
+           "\nAccessor methods::\n\n"
+           "   current_index() -> int\n"
+           "      Zero-based position of the current date in the sequence.\n"
+           "      Computed using calendar-day (Julian-day) arithmetic,\n"
+           "      so it is correct even when the sequence crosses a month or year boundary.\n"
+           "      Returns 0 at construction / after reset.\n"
+           "   current_value() -> str\n"
+           "      The current date as a string in yyyymmdd format.\n";
 }
 
 const char* NodeAttrDoc::repeat_datetime_doc() {
@@ -603,7 +616,12 @@ const char* NodeAttrDoc::repeat_datetime_doc() {
            "   rep = RepeatDateTime('DATETIME', '20050130T000000', '20050203T000000')\n"
            "   rep = RepeatDateTime('DATETIME', '20050130T000000', '20050203T000000', '48:00:00')\n"
            "   t = Task('t1',\n"
-           "            RepeatDateTime('DATETIME', '20050130T000000', '20050203T120000', '1:00:00'))\n";
+           "            RepeatDateTime('DATETIME', '20050130T000000', '20050203T120000', '1:00:00'))\n"
+           "\nAccessor methods::\n\n"
+           "   current_index() -> int\n"
+           "      Zero-based position: (seconds(current) - seconds(start)) / seconds(step).\n"
+           "   current_value() -> str\n"
+           "      The current instant as a string in yyyymmddTHHMMSS format.\n";
 }
 
 const char* NodeAttrDoc::repeat_date_list_doc() {
@@ -625,7 +643,12 @@ const char* NodeAttrDoc::repeat_date_list_doc() {
            ".. code-block:: python\n\n"
            "   rep = RepeatDateList('YMD', [20050130, 20050203] )\n"
            "   t = Task('t1',\n"
-           "            RepeatDateList('YMD',[20050130, 20050203] ))\n";
+           "            RepeatDateList('YMD',[20050130, 20050203] ))\n"
+           "\nAccessor methods::\n\n"
+           "   current_index() -> int\n"
+           "      Zero-based index of the current date in the list.\n"
+           "   current_value() -> str\n"
+           "      The current date as a string in yyyymmdd format, or '' if out of bounds.\n";
 }
 
 const char* NodeAttrDoc::repeat_datetimelist_doc() {
@@ -643,7 +666,12 @@ const char* NodeAttrDoc::repeat_datetimelist_doc() {
            ".. code-block:: python\n\n"
            "   rep = RepeatDateTimeList('DT', ['20240101T000000', '20240102T120000', '20240103T060000'])\n"
            "   t = Task('t1',\n"
-           "            RepeatDateTimeList('DT', ['20240101T000000', '20240102T120000']))\n";
+           "            RepeatDateTimeList('DT', ['20240101T000000', '20240102T120000']))\n"
+           "\nAccessor methods::\n\n"
+           "   current_index() -> int\n"
+           "      Zero-based index of the current instant in the list.\n"
+           "   current_value() -> str\n"
+           "      The current instant as a string in yyyymmddTHHMMSS format, or '' if out of bounds.\n";
 }
 
 const char* NodeAttrDoc::repeat_integer_doc() {
@@ -660,7 +688,12 @@ const char* NodeAttrDoc::repeat_integer_doc() {
            "\nUsage:\n\n"
            ".. code-block:: python\n\n"
            "   t = Task('t1',\n"
-           "            RepeatInteger('HOUR', 6, 24, 6 ))\n";
+           "            RepeatInteger('HOUR', 6, 24, 6 ))\n"
+           "\nAccessor methods::\n\n"
+           "   current_index() -> int\n"
+           "      Zero-based position: (value - start) / step.\n"
+           "   current_value() -> str\n"
+           "      The current integer value as a decimal string.\n";
 }
 
 const char* NodeAttrDoc::repeat_enumerated_doc() {
@@ -675,7 +708,12 @@ const char* NodeAttrDoc::repeat_enumerated_doc() {
            "\nUsage:\n\n"
            ".. code-block:: python\n\n"
            "   t = Task('t1',\n"
-           "            RepeatEnumerated('COLOR', [ 'red', 'green', 'blue' ] ))\n";
+           "            RepeatEnumerated('COLOR', [ 'red', 'green', 'blue' ] ))\n"
+           "\nAccessor methods::\n\n"
+           "   current_index() -> int\n"
+           "      Zero-based index of the current enumeration value.\n"
+           "   current_value() -> str\n"
+           "      The enumeration string at the current index, or '' if out of bounds.\n";
 }
 
 const char* NodeAttrDoc::repeat_string_doc() {
@@ -690,7 +728,12 @@ const char* NodeAttrDoc::repeat_string_doc() {
            "\nUsage:\n\n"
            ".. code-block:: python\n\n"
            "   t = Task('t1',\n"
-           "            RepeatString('COLOR', [ 'red', 'green', 'blue' ] ))\n";
+           "            RepeatString('COLOR', [ 'red', 'green', 'blue' ] ))\n"
+           "\nAccessor methods::\n\n"
+           "   current_index() -> int\n"
+           "      Zero-based index into the string list.\n"
+           "   current_value() -> str\n"
+           "      The string at the current index, or '' if out of bounds.\n";
 }
 
 const char* NodeAttrDoc::repeat_day_doc() {
@@ -702,7 +745,12 @@ const char* NodeAttrDoc::repeat_day_doc() {
            "\nUsage:\n\n"
            ".. code-block:: python\n\n"
            "   t = Task('t1',\n"
-           "             RepeatDay( 1 ))\n";
+           "             RepeatDay( 1 ))\n"
+           "\nAccessor methods::\n\n"
+           "   current_index() -> int\n"
+           "      RepeatDay has no position concept; returns the step value.\n"
+           "   current_value() -> str\n"
+           "      The step value as a decimal string.\n";
 }
 
 const char* NodeAttrDoc::cron_doc() {

--- a/libs/pyext/test/py_u_TestExportNodeAttr.py
+++ b/libs/pyext/test/py_u_TestExportNodeAttr.py
@@ -10700,11 +10700,11 @@ class TestRepeatDate(unittest.TestCase):
 
     def test_current_value_initial_is_start(self):
         """current_value() is the start date string at construction."""
-        self.assertEqual(ecf.RepeatDate("YMD", 20100101, 20100110).current_value(), "20100101")
+        self.assertEqual(ecf.RepeatDate("YMD", 20100101, 20100110).current_value(), 20100101)
 
-    def test_current_value_returns_str(self):
-        """current_value() returns a Python str."""
-        self.assertIsInstance(ecf.RepeatDate("YMD", 20100101, 20100110).current_value(), str)
+    def test_current_value_returns_int(self):
+        """current_value() returns a Python int."""
+        self.assertIsInstance(ecf.RepeatDate("YMD", 20100101, 20100110).current_value(), int)
 
     def test_current_index_via_node_after_advance(self):
         """current_index() on get_repeat() advances correctly via the node."""
@@ -10714,15 +10714,15 @@ class TestRepeatDate(unittest.TestCase):
         # Advance the repeat
         r = t.get_repeat()
         self.assertEqual(r.current_index(), 0)
-        self.assertEqual(r.current_value(), "20241129")
+        self.assertEqual(r.current_value(), 20241129)
         r.increment()
         r = t.get_repeat()
         self.assertEqual(r.current_index(), 1)
-        self.assertEqual(r.current_value(), "20241202")
+        self.assertEqual(r.current_value(), 20241202)
         t.get_repeat().increment()
         r2 = t.get_repeat()
         self.assertEqual(r2.current_index(), 2)
-        self.assertEqual(r2.current_value(), "20241205")
+        self.assertEqual(r2.current_value(), 20241205)
 
 
 class TestRepeatDateTime(unittest.TestCase):
@@ -11424,11 +11424,11 @@ class TestRepeatDateList(unittest.TestCase):
 
     def test_current_value_initial_is_first_entry(self):
         """current_value() is the first list entry at construction."""
-        self.assertEqual(ecf.RepeatDateList("DL", [20100101, 20100115]).current_value(), "20100101")
+        self.assertEqual(ecf.RepeatDateList("DL", [20100101, 20100115]).current_value(), 20100101)
 
-    def test_current_value_returns_str(self):
-        """current_value() returns a Python str."""
-        self.assertIsInstance(ecf.RepeatDateList("DL", [20100101]).current_value(), str)
+    def test_current_value_returns_int(self):
+        """current_value() returns a Python int."""
+        self.assertIsInstance(ecf.RepeatDateList("DL", [20100101]).current_value(), int)
 
     def test_current_index_via_node_after_advance(self):
         """current_index() on get_repeat() advances correctly via the node."""
@@ -11438,15 +11438,15 @@ class TestRepeatDateList(unittest.TestCase):
         # Advance the repeat
         r = t.get_repeat()
         self.assertEqual(r.current_index(), 0)
-        self.assertEqual(r.current_value(), "19700101")
+        self.assertEqual(r.current_value(), 19700101)
         r.increment()
         r2 = t.get_repeat()
         self.assertEqual(r, r2)
         self.assertEqual(r2.current_index(), 1)
-        self.assertEqual(r2.current_value(), "19700103")
+        self.assertEqual(r2.current_value(), 19700103)
         r2.increment()
         self.assertEqual(r2.current_index(), 2)
-        self.assertEqual(r2.current_value(), "19700104")
+        self.assertEqual(r2.current_value(), 19700104)
 
 class TestRepeatDateTimeList(unittest.TestCase):
     """Tests for py::class_<RepeatDateTimeList> exposed as ecf.RepeatDateTimeList in ExportNodeAttr.cpp.
@@ -12126,12 +12126,12 @@ class TestRepeatInteger(unittest.TestCase):
         self.assertIsInstance(ecf.RepeatInteger("N", 0, 10).current_index(), int)
 
     def test_current_value_initial_is_start(self):
-        """current_value() is the start value string at construction."""
-        self.assertEqual(ecf.RepeatInteger("N", 5, 10).current_value(), "5")
+        """current_value() is the start value integer at construction."""
+        self.assertEqual(ecf.RepeatInteger("N", 5, 10).current_value(), 5)
 
-    def test_current_value_returns_str(self):
-        """current_value() returns a Python str."""
-        self.assertIsInstance(ecf.RepeatInteger("N", 0, 10).current_value(), str)
+    def test_current_value_returns_int(self):
+        """current_value() returns a Python int."""
+        self.assertIsInstance(ecf.RepeatInteger("N", 0, 10).current_value(), int)
 
     def test_current_index_via_node_after_advance(self):
         """current_index() on get_repeat() advances correctly via the node."""
@@ -12141,15 +12141,15 @@ class TestRepeatInteger(unittest.TestCase):
         # Advance the repeat
         r = t.get_repeat()
         self.assertEqual(r.current_index(), 0)
-        self.assertEqual(r.current_value(), "100")
+        self.assertEqual(r.current_value(), 100)
         r.increment()
         r2 = t.get_repeat()
         self.assertEqual(r, r2)
         self.assertEqual(r2.current_index(), 1)
-        self.assertEqual(r2.current_value(), "105")
+        self.assertEqual(r2.current_value(), 105)
         r2.increment()
         self.assertEqual(r2.current_index(), 2)
-        self.assertEqual(r2.current_value(), "110")
+        self.assertEqual(r2.current_value(), 110)
 
 
 class TestRepeatEnumerated(unittest.TestCase):
@@ -12934,13 +12934,13 @@ class TestRepeatDay(unittest.TestCase):
         """current_index() returns a Python int."""
         self.assertIsInstance(ecf.RepeatDay(1).current_index(), int)
 
-    def test_current_value_is_step_string(self):
-        """current_value() returns the step as a decimal string."""
-        self.assertEqual(ecf.RepeatDay(5).current_value(), "5")
+    def test_current_value_is_step_integer(self):
+        """current_value() returns the step as an integer."""
+        self.assertEqual(ecf.RepeatDay(5).current_value(), 5)
 
-    def test_current_value_returns_str(self):
-        """current_value() returns a Python str."""
-        self.assertIsInstance(ecf.RepeatDay(2).current_value(), str)
+    def test_current_value_returns_int(self):
+        """current_value() returns a Python int."""
+        self.assertIsInstance(ecf.RepeatDay(2).current_value(), int)
 
     def test_current_index_via_node_after_advance(self):
         """
@@ -12954,15 +12954,15 @@ class TestRepeatDay(unittest.TestCase):
         # Advance the repeat
         r = t.get_repeat()
         self.assertEqual(r.current_index(), 31)
-        self.assertEqual(r.current_value(), "31")
+        self.assertEqual(r.current_value(), 31)
         r.increment()
         r2 = t.get_repeat()
         self.assertEqual(r, r2)
         self.assertEqual(r2.current_index(), 31)
-        self.assertEqual(r2.current_value(), "31")
+        self.assertEqual(r2.current_value(), 31)
         r2.increment()
         self.assertEqual(r2.current_index(), 31)
-        self.assertEqual(r2.current_value(), "31")
+        self.assertEqual(r2.current_value(), 31)
 
 
 class TestRepeat(unittest.TestCase):
@@ -12974,8 +12974,8 @@ class TestRepeat(unittest.TestCase):
     In practice, Repeat instances are most commonly obtained from node.get_repeat(),
     which returns whatever concrete repeat is attached to the node.
 
-    The Python binding exposes a single constructor accepting an int.  Boost.Python
-    resolves this via the implicit-conversion chain
+    The Python binding exposes a single constructor accepting an int.
+    This is resolved via the implicit-conversion chain:
         int -> RepeatDay(int) -> Repeat(const RepeatDay&)
     so all tests here exercise the RepeatDay-backed specialisation.  All accessor
     methods delegate to the wrapped type and return 0 / empty string when the Repeat
@@ -12985,7 +12985,6 @@ class TestRepeat(unittest.TestCase):
     -----------
     Constructors
         Repeat(step)   -- step (int); creates a Repeat wrapping RepeatDay(step)
-                          via Boost.Python implicit conversion
 
     Instance methods
         empty()   -> bool   -- True when no concrete type is held (e.g. obtained
@@ -13248,13 +13247,13 @@ class TestRepeat(unittest.TestCase):
         """For Repeat(N), current_index() equals N (RepeatDay semantics)."""
         self.assertEqual(ecf.Repeat(4).current_index(), 4)
 
-    def test_current_value_returns_str(self):
-        """current_value() returns a Python str."""
-        self.assertIsInstance(ecf.Repeat(1).current_value(), str)
+    def test_current_value_returns_int(self):
+        """current_value() returns a Python int."""
+        self.assertIsInstance(ecf.Repeat(1).current_value(), int)
 
-    def test_current_value_is_step_string_for_repeat_day(self):
-        """For Repeat(N), current_value() is str(N)."""
-        self.assertEqual(ecf.Repeat(7).current_value(), "7")
+    def test_current_value_is_step_integer_for_repeat_day(self):
+        """For Repeat(N), current_value() is int(N)."""
+        self.assertEqual(ecf.Repeat(7).current_value(), 7)
 
     def test_current_index_via_repeat_date_node(self):
         """current_index() advances correctly for a RepeatDate-backed Repeat obtained from a node."""
@@ -13263,16 +13262,16 @@ class TestRepeat(unittest.TestCase):
         t.add_repeat(ecf.RepeatDate("YMD", 20100101, 20100110, 1))
         r = t.get_repeat()
         self.assertEqual(r.current_index(), 0)
-        self.assertEqual(r.current_value(), "20100101")
+        self.assertEqual(r.current_value(), 20100101)
 
     def test_current_index_via_repeat_integer_node(self):
         """current_index() and current_value() for a RepeatInteger-backed Repeat."""
         defs = ecf.Defs()
         t = defs.add_suite("s").add_family("f").add_task("t")
-        t.add_repeat(ecf.RepeatInteger("N", 0, 10, 2))
+        t.add_repeat(ecf.RepeatInteger("N", 3, 10, 2))
         r = t.get_repeat()
         self.assertEqual(r.current_index(), 0)
-        self.assertEqual(r.current_value(), "0")
+        self.assertEqual(r.current_value(), 3)
 
     def test_current_index_via_repeat_string_node(self):
         """current_index() and current_value() for a RepeatString-backed Repeat."""

--- a/libs/pyext/test/py_u_TestExportNodeAttr.py
+++ b/libs/pyext/test/py_u_TestExportNodeAttr.py
@@ -10685,6 +10685,45 @@ class TestRepeatDate(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             ecf.RepeatDate("YMD", 20100101, -20100101)
 
+    # ------------------------------------------------------------------
+    # current_index() / current_value()
+    # ------------------------------------------------------------------
+
+    def test_current_index_initial_is_zero(self):
+        """current_index() is 0 on a freshly constructed RepeatDate."""
+        rd = ecf.RepeatDate("YMD", 20100101, 20100110, 1)
+        self.assertEqual(rd.current_index(), 0)
+
+    def test_current_index_returns_int(self):
+        """current_index() returns a Python int."""
+        self.assertIsInstance(ecf.RepeatDate("YMD", 20100101, 20100110).current_index(), int)
+
+    def test_current_value_initial_is_start(self):
+        """current_value() is the start date string at construction."""
+        self.assertEqual(ecf.RepeatDate("YMD", 20100101, 20100110).current_value(), "20100101")
+
+    def test_current_value_returns_str(self):
+        """current_value() returns a Python str."""
+        self.assertIsInstance(ecf.RepeatDate("YMD", 20100101, 20100110).current_value(), str)
+
+    def test_current_index_via_node_after_advance(self):
+        """current_index() on get_repeat() advances correctly via the node."""
+        defs = ecf.Defs()
+        t = defs.add_suite("s").add_family("f").add_task("t")
+        t.add_repeat(ecf.RepeatDate("YMD", 20241129, 20241207, 3))
+        # Advance the repeat
+        r = t.get_repeat()
+        self.assertEqual(r.current_index(), 0)
+        self.assertEqual(r.current_value(), "20241129")
+        r.increment()
+        r = t.get_repeat()
+        self.assertEqual(r.current_index(), 1)
+        self.assertEqual(r.current_value(), "20241202")
+        t.get_repeat().increment()
+        r2 = t.get_repeat()
+        self.assertEqual(r2.current_index(), 2)
+        self.assertEqual(r2.current_value(), "20241205")
+
 
 class TestRepeatDateTime(unittest.TestCase):
     """Tests for py::class_<RepeatDateTime> exposed as ecf.RepeatDateTime in ExportNodeAttr.cpp.
@@ -11054,6 +11093,48 @@ class TestRepeatDateTime(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             ecf.RepeatDateTime("DT", "20100101T000000", "-0100101T000000")
 
+    # ------------------------------------------------------------------
+    # current_index() / current_value()
+    # ------------------------------------------------------------------
+
+    def test_current_index_initial_is_zero(self):
+        """current_index() is 0 on a freshly constructed RepeatDateTime."""
+        r = ecf.RepeatDateTime("DT", "19700101T000000", "19700103T000000", "24:00:00")
+        self.assertEqual(r.current_index(), 0)
+
+    def test_current_index_returns_int(self):
+        """current_index() returns a Python int."""
+        self.assertIsInstance(
+            ecf.RepeatDateTime("DT", "19700101T000000", "19700103T000000").current_index(), int)
+
+    def test_current_value_initial_is_start(self):
+        """current_value() is the start instant string at construction."""
+        r = ecf.RepeatDateTime("DT", "19700101T000000", "19700103T000000", "24:00:00")
+        self.assertEqual(r.current_value(), "19700101T000000")
+
+    def test_current_value_returns_str(self):
+        """current_value() returns a Python str."""
+        self.assertIsInstance(
+            ecf.RepeatDateTime("DT", "19700101T000000", "19700103T000000").current_value(), str)
+
+    def test_current_index_via_node_after_advance(self):
+        """current_index() on get_repeat() advances correctly via the node."""
+        defs = ecf.Defs()
+        t = defs.add_suite("s").add_family("f").add_task("t")
+        t.add_repeat(ecf.RepeatDateTime("DT", "19700101T000000", "19700103T000000", "24:00:00"))
+        # Advance the repeat twice (simulates two steps)
+        r = t.get_repeat()
+        self.assertEqual(r.current_index(), 0)
+        self.assertEqual(r.current_value(), "19700101T000000")
+        r.increment()
+        r2 = t.get_repeat()
+        self.assertEqual(r, r2)
+        self.assertEqual(r2.current_index(), 1)
+        self.assertEqual(r2.current_value(), "19700102T000000")
+        r2.increment()
+        self.assertEqual(r2.current_index(), 2)
+        self.assertEqual(r2.current_value(), "19700103T000000")
+
 
 class TestRepeatDateList(unittest.TestCase):
     """Tests for py::class_<RepeatDateList> exposed as ecf.RepeatDateList in ExportNodeAttr.cpp.
@@ -11329,6 +11410,43 @@ class TestRepeatDateList(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             ecf.RepeatDateList("DL", [20100101, 20101301, 20100110])
 
+    # ------------------------------------------------------------------
+    # current_index() / current_value()
+    # ------------------------------------------------------------------
+
+    def test_current_index_initial_is_zero(self):
+        """current_index() is 0 on a freshly constructed RepeatDateList."""
+        self.assertEqual(ecf.RepeatDateList("DL", [20100101, 20100115]).current_index(), 0)
+
+    def test_current_index_returns_int(self):
+        """current_index() returns a Python int."""
+        self.assertIsInstance(ecf.RepeatDateList("DL", [20100101, 20100115]).current_index(), int)
+
+    def test_current_value_initial_is_first_entry(self):
+        """current_value() is the first list entry at construction."""
+        self.assertEqual(ecf.RepeatDateList("DL", [20100101, 20100115]).current_value(), "20100101")
+
+    def test_current_value_returns_str(self):
+        """current_value() returns a Python str."""
+        self.assertIsInstance(ecf.RepeatDateList("DL", [20100101]).current_value(), str)
+
+    def test_current_index_via_node_after_advance(self):
+        """current_index() on get_repeat() advances correctly via the node."""
+        defs = ecf.Defs()
+        t = defs.add_suite("s").add_family("f").add_task("t")
+        t.add_repeat(ecf.RepeatDateList("DL", [19700101, 19700103, 19700104]))
+        # Advance the repeat
+        r = t.get_repeat()
+        self.assertEqual(r.current_index(), 0)
+        self.assertEqual(r.current_value(), "19700101")
+        r.increment()
+        r2 = t.get_repeat()
+        self.assertEqual(r, r2)
+        self.assertEqual(r2.current_index(), 1)
+        self.assertEqual(r2.current_value(), "19700103")
+        r2.increment()
+        self.assertEqual(r2.current_index(), 2)
+        self.assertEqual(r2.current_value(), "19700104")
 
 class TestRepeatDateTimeList(unittest.TestCase):
     """Tests for py::class_<RepeatDateTimeList> exposed as ecf.RepeatDateTimeList in ExportNodeAttr.cpp.
@@ -11625,6 +11743,48 @@ class TestRepeatDateTimeList(unittest.TestCase):
             ecf.RepeatDateTimeList(
                 "DTL", ["20100101T000000", "20101301T000000", "20100110T000000"]
             )
+
+    # ------------------------------------------------------------------
+    # current_index() / current_value()
+    # ------------------------------------------------------------------
+
+    def test_current_index_initial_is_zero(self):
+        """current_index() is 0 on a freshly constructed RepeatDateTimeList."""
+        r = ecf.RepeatDateTimeList("DTL", ["19700101T000000", "19700102T000000"])
+        self.assertEqual(r.current_index(), 0)
+
+    def test_current_index_returns_int(self):
+        """current_index() returns a Python int."""
+        self.assertIsInstance(
+            ecf.RepeatDateTimeList("DTL", ["19700101T000000"]).current_index(), int)
+
+    def test_current_value_initial_is_first_entry(self):
+        """current_value() is the first instant string at construction."""
+        r = ecf.RepeatDateTimeList("DTL", ["19700101T000000", "19700102T000000"])
+        self.assertEqual(r.current_value(), "19700101T000000")
+
+    def test_current_value_returns_str(self):
+        """current_value() returns a Python str."""
+        self.assertIsInstance(
+            ecf.RepeatDateTimeList("DTL", ["19700101T000000"]).current_value(), str)
+
+    def test_current_index_via_node_after_advance(self):
+        """current_index() on get_repeat() advances correctly via the node."""
+        defs = ecf.Defs()
+        t = defs.add_suite("s").add_family("f").add_task("t")
+        t.add_repeat(ecf.RepeatDateTimeList("DL", ["19700101T000001", "19700103T000003", "19700104T000004"]))
+        # Advance the repeat
+        r = t.get_repeat()
+        self.assertEqual(r.current_index(), 0)
+        self.assertEqual(r.current_value(), "19700101T000001")
+        r.increment()
+        r2 = t.get_repeat()
+        self.assertEqual(r, r2)
+        self.assertEqual(r2.current_index(), 1)
+        self.assertEqual(r2.current_value(), "19700103T000003")
+        r2.increment()
+        self.assertEqual(r2.current_index(), 2)
+        self.assertEqual(r2.current_value(), "19700104T000004")
 
 
 class TestRepeatInteger(unittest.TestCase):
@@ -11953,6 +12113,44 @@ class TestRepeatInteger(unittest.TestCase):
         with self.assertRaises((TypeError, RuntimeError)):
             ecf.RepeatInteger("VAR", "0", 10)
 
+    # ------------------------------------------------------------------
+    # current_index() / current_value()
+    # ------------------------------------------------------------------
+
+    def test_current_index_initial_is_zero(self):
+        """current_index() is 0 on a freshly constructed RepeatInteger."""
+        self.assertEqual(ecf.RepeatInteger("N", 0, 10, 2).current_index(), 0)
+
+    def test_current_index_returns_int(self):
+        """current_index() returns a Python int."""
+        self.assertIsInstance(ecf.RepeatInteger("N", 0, 10).current_index(), int)
+
+    def test_current_value_initial_is_start(self):
+        """current_value() is the start value string at construction."""
+        self.assertEqual(ecf.RepeatInteger("N", 5, 10).current_value(), "5")
+
+    def test_current_value_returns_str(self):
+        """current_value() returns a Python str."""
+        self.assertIsInstance(ecf.RepeatInteger("N", 0, 10).current_value(), str)
+
+    def test_current_index_via_node_after_advance(self):
+        """current_index() on get_repeat() advances correctly via the node."""
+        defs = ecf.Defs()
+        t = defs.add_suite("s").add_family("f").add_task("t")
+        t.add_repeat(ecf.RepeatInteger("N", 100, 110, 5))
+        # Advance the repeat
+        r = t.get_repeat()
+        self.assertEqual(r.current_index(), 0)
+        self.assertEqual(r.current_value(), "100")
+        r.increment()
+        r2 = t.get_repeat()
+        self.assertEqual(r, r2)
+        self.assertEqual(r2.current_index(), 1)
+        self.assertEqual(r2.current_value(), "105")
+        r2.increment()
+        self.assertEqual(r2.current_index(), 2)
+        self.assertEqual(r2.current_value(), "110")
+
 
 class TestRepeatEnumerated(unittest.TestCase):
     """Tests for py::class_<RepeatEnumerated> exposed as ecf.RepeatEnumerated in ExportNodeAttr.cpp.
@@ -12206,6 +12404,44 @@ class TestRepeatEnumerated(unittest.TestCase):
         """A list containing integers instead of strings raises TypeError."""
         with self.assertRaises((TypeError, RuntimeError)):
             ecf.RepeatEnumerated("E", [1, 2, 3])
+
+    # ------------------------------------------------------------------
+    # current_index() / current_value()
+    # ------------------------------------------------------------------
+
+    def test_current_index_initial_is_zero(self):
+        """current_index() is 0 on a freshly constructed RepeatEnumerated."""
+        self.assertEqual(ecf.RepeatEnumerated("E", ["red", "green", "blue"]).current_index(), 0)
+
+    def test_current_index_returns_int(self):
+        """current_index() returns a Python int."""
+        self.assertIsInstance(ecf.RepeatEnumerated("E", ["a"]).current_index(), int)
+
+    def test_current_value_initial_is_first_entry(self):
+        """current_value() is the first enumeration string at construction."""
+        self.assertEqual(ecf.RepeatEnumerated("E", ["red", "green"]).current_value(), "red")
+
+    def test_current_value_returns_str(self):
+        """current_value() returns a Python str."""
+        self.assertIsInstance(ecf.RepeatEnumerated("E", ["x"]).current_value(), str)
+
+    def test_current_index_via_node_after_advance(self):
+        """current_index() on get_repeat() advances correctly via the node."""
+        defs = ecf.Defs()
+        t = defs.add_suite("s").add_family("f").add_task("t")
+        t.add_repeat(ecf.RepeatEnumerated("E", ["r", "g", "b"]))
+        # Advance the repeat
+        r = t.get_repeat()
+        self.assertEqual(r.current_index(), 0)
+        self.assertEqual(r.current_value(), "r")
+        r.increment()
+        r2 = t.get_repeat()
+        self.assertEqual(r, r2)
+        self.assertEqual(r2.current_index(), 1)
+        self.assertEqual(r2.current_value(), "g")
+        r2.increment()
+        self.assertEqual(r2.current_index(), 2)
+        self.assertEqual(r2.current_value(), "b")
 
 
 class TestRepeatString(unittest.TestCase):
@@ -12461,6 +12697,44 @@ class TestRepeatString(unittest.TestCase):
         with self.assertRaises((TypeError, RuntimeError)):
             ecf.RepeatString("S", [1, 2])
 
+    # ------------------------------------------------------------------
+    # current_index() / current_value()
+    # ------------------------------------------------------------------
+
+    def test_current_index_initial_is_zero(self):
+        """current_index() is 0 on a freshly constructed RepeatString."""
+        self.assertEqual(ecf.RepeatString("S", ["a", "b", "c"]).current_index(), 0)
+
+    def test_current_index_returns_int(self):
+        """current_index() returns a Python int."""
+        self.assertIsInstance(ecf.RepeatString("S", ["x"]).current_index(), int)
+
+    def test_current_value_initial_is_first_entry(self):
+        """current_value() is the first string at construction."""
+        self.assertEqual(ecf.RepeatString("S", ["alpha", "beta"]).current_value(), "alpha")
+
+    def test_current_value_returns_str(self):
+        """current_value() returns a Python str."""
+        self.assertIsInstance(ecf.RepeatString("S", ["x"]).current_value(), str)
+
+    def test_current_index_via_node_after_advance(self):
+        """current_index() on get_repeat() advances correctly via the node."""
+        defs = ecf.Defs()
+        t = defs.add_suite("s").add_family("f").add_task("t")
+        t.add_repeat(ecf.RepeatString("S", ["x", "y", "z"]))
+        # Advance the repeat
+        r = t.get_repeat()
+        self.assertEqual(r.current_index(), 0)
+        self.assertEqual(r.current_value(), "x")
+        r.increment()
+        r2 = t.get_repeat()
+        self.assertEqual(r, r2)
+        self.assertEqual(r2.current_index(), 1)
+        self.assertEqual(r2.current_value(), "y")
+        r2.increment()
+        self.assertEqual(r2.current_index(), 2)
+        self.assertEqual(r2.current_value(), "z")
+
 
 class TestRepeatDay(unittest.TestCase):
     """Tests for py::class_<RepeatDay> exposed as ecf.RepeatDay in ExportNodeAttr.cpp.
@@ -12647,6 +12921,48 @@ class TestRepeatDay(unittest.TestCase):
         """RepeatDay(-1) is accepted without error; step is stored as given."""
         rd = ecf.RepeatDay(-1)
         self.assertEqual(str(rd), "  repeat day -1\n")
+
+    # ------------------------------------------------------------------
+    # current_index() / current_value()
+    # ------------------------------------------------------------------
+
+    def test_current_index_is_step(self):
+        """current_index() returns the step value (RepeatDay has no position concept)."""
+        self.assertEqual(ecf.RepeatDay(3).current_index(), 3)
+
+    def test_current_index_returns_int(self):
+        """current_index() returns a Python int."""
+        self.assertIsInstance(ecf.RepeatDay(1).current_index(), int)
+
+    def test_current_value_is_step_string(self):
+        """current_value() returns the step as a decimal string."""
+        self.assertEqual(ecf.RepeatDay(5).current_value(), "5")
+
+    def test_current_value_returns_str(self):
+        """current_value() returns a Python str."""
+        self.assertIsInstance(ecf.RepeatDay(2).current_value(), str)
+
+    def test_current_index_via_node_after_advance(self):
+        """
+        current_index() on get_repeat() advances correctly via the node.
+        For RepeatDay, increment is currently a no-op!
+        Neither the value nor the index actually advance!!
+        """
+        defs = ecf.Defs()
+        t = defs.add_suite("s").add_family("f").add_task("t")
+        t.add_repeat(ecf.RepeatDay(31))
+        # Advance the repeat
+        r = t.get_repeat()
+        self.assertEqual(r.current_index(), 31)
+        self.assertEqual(r.current_value(), "31")
+        r.increment()
+        r2 = t.get_repeat()
+        self.assertEqual(r, r2)
+        self.assertEqual(r2.current_index(), 31)
+        self.assertEqual(r2.current_value(), "31")
+        r2.increment()
+        self.assertEqual(r2.current_index(), 31)
+        self.assertEqual(r2.current_value(), "31")
 
 
 class TestRepeat(unittest.TestCase):
@@ -12920,6 +13236,52 @@ class TestRepeat(unittest.TestCase):
         """Passing a float raises TypeError."""
         with self.assertRaises((TypeError, RuntimeError)):
             ecf.Repeat(1.5)
+
+    # ------------------------------------------------------------------
+    # current_index() / current_value()
+    # ------------------------------------------------------------------
+    def test_current_index_returns_int(self):
+        """current_index() returns a Python int."""
+        self.assertIsInstance(ecf.Repeat(1).current_index(), int)
+
+    def test_current_index_is_step_for_repeat_day(self):
+        """For Repeat(N), current_index() equals N (RepeatDay semantics)."""
+        self.assertEqual(ecf.Repeat(4).current_index(), 4)
+
+    def test_current_value_returns_str(self):
+        """current_value() returns a Python str."""
+        self.assertIsInstance(ecf.Repeat(1).current_value(), str)
+
+    def test_current_value_is_step_string_for_repeat_day(self):
+        """For Repeat(N), current_value() is str(N)."""
+        self.assertEqual(ecf.Repeat(7).current_value(), "7")
+
+    def test_current_index_via_repeat_date_node(self):
+        """current_index() advances correctly for a RepeatDate-backed Repeat obtained from a node."""
+        defs = ecf.Defs()
+        t = defs.add_suite("s").add_family("f").add_task("t")
+        t.add_repeat(ecf.RepeatDate("YMD", 20100101, 20100110, 1))
+        r = t.get_repeat()
+        self.assertEqual(r.current_index(), 0)
+        self.assertEqual(r.current_value(), "20100101")
+
+    def test_current_index_via_repeat_integer_node(self):
+        """current_index() and current_value() for a RepeatInteger-backed Repeat."""
+        defs = ecf.Defs()
+        t = defs.add_suite("s").add_family("f").add_task("t")
+        t.add_repeat(ecf.RepeatInteger("N", 0, 10, 2))
+        r = t.get_repeat()
+        self.assertEqual(r.current_index(), 0)
+        self.assertEqual(r.current_value(), "0")
+
+    def test_current_index_via_repeat_string_node(self):
+        """current_index() and current_value() for a RepeatString-backed Repeat."""
+        defs = ecf.Defs()
+        t = defs.add_suite("s").add_family("f").add_task("t")
+        t.add_repeat(ecf.RepeatString("S", ["alpha", "beta", "gamma"]))
+        r = t.get_repeat()
+        self.assertEqual(r.current_index(), 0)
+        self.assertEqual(r.current_value(), "alpha")
 
 
 class TestCron(unittest.TestCase):


### PR DESCRIPTION
### Description

As per PR title.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-343
<!-- PREVIEW-URL_END -->