### PR TITLE
Update the pybind11 version used to build with Python 3.8

### DIFF
--- a/.github/cd-config.yml
+++ b/.github/cd-config.yml
@@ -261,7 +261,7 @@ builds:
             -DENABLE_UI: OFF
             -DBoost_ROOT: /usr/local/apps/boost/1.87.0/GNU/8.5
             -DBoost_INCLUDE_DIR: /usr/local/apps/boost/1.87.0/GNU/8.5/include
-            -DCMAKE_PREFIX_PATH: /usr/local/apps/python3/3.8.8-01/lib/python3.8/site-packages/pybind11/share/cmake/
+            -DCMAKE_PREFIX_PATH: /usr/local/apps/python3/3.10.10-01/lib/python3.10/site-packages/pybind11/share/cmake/pybind11
             -DPython3_ROOT_DIR: /usr/local/apps/python3/3.8.8-01
             -DPython3_EXECUTABLE: /usr/local/apps/python3/3.8.8-01/bin/python3
             -DPython3_INCLUDE_DIRS: /usr/local/apps/python3/3.8.8-01/include/python3.8


### PR DESCRIPTION
### Description

This purposely points to Python3.10 on the HPC, which includes an installation of pybind11 2.10.3. Since pybind11 is a header-only library there is no need to have a match between the Python version for which it was installed, and the Python version used to build the ecflow python extension.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-346
<!-- PREVIEW-URL_END -->