### PR TITLE
ecflow_ui: add Suspended option to Defstatus menu

### DIFF
--- a/share/ecflow/etc/ecflowview_menus.json
+++ b/share/ecflow/etc/ecflowview_menus.json
@@ -865,6 +865,13 @@
             "status_tip"     : "__cmd__"
         },
         {
+            "menu"           : "Defstatus",
+            "name"           : "Suspended",
+            "visible_for"    : "node",
+            "command"        : "ecflow_client --alter change defstatus suspended <full_name>",
+            "status_tip"     : "__cmd__"
+        },
+        {
             "menu"           : "Node",
             "name"           : "-"
         },


### PR DESCRIPTION
## Summary
- add Suspended entry in ecflow_ui Defstatus context menu
- keep existing Defstatus options (Complete, Queued) unchanged
- wire command to ecflow_client --alter change defstatus suspended <full_name>

## Files
- share/ecflow/etc/ecflowview_menus.json

## Notes
- source-only commit, no build artifacts included
