### PR TITLE
Add new .../info endpoint ECFLOW-2105

### DIFF
--- a/docs/python_api/reference/MirrorAttr.rst
+++ b/docs/python_api/reference/MirrorAttr.rst
@@ -22,6 +22,7 @@ Constructor::
       string polling: The polling interval used to contact the remote ecFlow server
       Bool ssl: `true`, when using SSL to contact the remote ecFlow server; `false`, otherwise
       string auth: The path to the Mirror Authentication credentials
+      Bool propagate: `true`, to propagate the node state up local tree; `false`, otherwise (default)
 
 
 Usage:
@@ -31,10 +32,10 @@ Usage:
    t1 = Task('t1',
              MirrorAttr('name', '/remote/task', 'remote-ecflow', '3141', '60', True, '/path/to/auth'))
 
-   t2 = Task('t2')
-   t2.add_aviso('name', '/remote/task', 'remote-ecflow', '3141', '60', True, '/path/to/auth')
+   t2 = Task('t2',
+             MirrorAttr('name', '/remote/task', 'remote-ecflow', '3141', '60', True, '/path/to/auth', True))
 
-The parameters `remote_host`, `remote_port`, `polling`, `ssl`, and `auth` are optional
+The parameters `remote_host`, `remote_port`, `polling`, `ssl`, `auth`, and `propagate` are optional
 
 
 .. py:method:: MirrorAttr.auth(self: ecflow.MirrorAttr) -> str
@@ -52,7 +53,7 @@ Returns the name of the Mirror attribute
 .. py:method:: MirrorAttr.polling(self: ecflow.MirrorAttr) -> str
    :module: ecflow
 
-Returns the polling interval used to contact the remote ecFlow server
+Returns the polling interval used to contact the remove ecFlow server
 
 
 .. py:method:: MirrorAttr.propagate(self: ecflow.MirrorAttr) -> bool

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -284,11 +284,12 @@ API v1 Documentation
 
 The API supports operations using GET, POST, PUT and DELETE methods.
 Generally the last word of the URL defines the target of the query. For
-example, https://localhost/v1/suites. There are seven different
+example, https://localhost/v1/suites. There are eight different
 supported targets:
 
 -  attributes
 -  definition
+-  info
 -  output
 -  ping
 -  script
@@ -312,6 +313,14 @@ definition
 
 Definition is the definition of an ecflow suite or a part of it in the
 ecflow domain specific language. Supported REST methods are: GET, PUT.
+
+info
+~~~~
+
+Info provides a compact summary of one or more nodes: absolute path, current runtime state,
+and the timestamp of the last state change. Supports query parameters to traverse the node
+subtree recursively, restrict results to specific node kinds (suite, family, task, alias), and
+filter by state. Supported REST methods are: GET.
 
 output
 ~~~~~~
@@ -363,6 +372,9 @@ API v1 supports the following endpoints -- specification for each endpoing can b
    * - /v1/suites/tree
      - GET
      - Operations related to Suite trees
+   * - /v1/suites/info
+     - GET
+     - Obtain compact info aggregated across all suites
    * - /v1/suites/{path}
      - DELETE
      - Operations related to Nodes
@@ -375,6 +387,9 @@ API v1 supports the following endpoints -- specification for each endpoing can b
    * - /v1/suites/{path}/status
      - GET, PUT
      - Operations related to Node status
+   * - /v1/suites/{path}/info
+     - GET
+     - Obtain compact Node info (path, state, state change time)
    * - /v1/suites/{path}/attributes
      - POST, GET, PUT, DELETE
      - Operations related to Node attributes
@@ -651,6 +666,49 @@ When query parameters :code:`content=full&with_id=true` are used, the full Suite
 
 When using the query parameter :code:`gen_vars=true` the generated variables are included in the :code:`attributes` section.
 Generated variables can be identified by a :code:`generate` attribute set to :code:`true`.
+
+Endpoint :code:`/v1/suites/info`
+--------------------------------
+
+Obtain Node information (across Suites)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :stub-columns: 1
+   :width: 100%
+   :widths: 20 80
+
+   * - Endpoint
+     - :code:`/v1/suites/info`
+   * - Method
+     - :code:`GET`
+   * - Description
+     - **Read** compact Node information aggregated across *all* suites. Without :code:`recursive=1`, only the
+       root node of each suite is included. With :code:`recursive=1`, all nodes in all suites
+       are collected. See more details of query parameters provided with :code:`/v1/suites/{path}/info`.
+   * - Parameters
+     - :code:`recursive`, (optional), possible values: :code:`1` (only the value :code:`1` activates recursive traversal; any other value is treated as non-recursive)
+
+       :code:`type`, (optional), possible values: comma-separated list of node kinds
+
+       :code:`state`, (optional), possible values: comma-separated list of state names
+
+       :code:`sortby`, (optional), possible values: :code:`[+|-]{path|state|state_change_time}`
+
+       :code:`count`, (optional), possible values: non-negative integer
+
+   * - Payload
+     - *empty*
+   * - Response
+     - See :ref:`below <response with node info>` for response format details.
+   * - Example
+     - :code:`curl https://localhost:8080/v1/suites/info`
+
+       :code:`curl https://localhost:8080/v1/suites/info?recursive=1`
+
+       :code:`curl "https://localhost:8080/v1/suites/info?recursive=1&type=task&state=aborted"`
+
+       :code:`curl "https://localhost:8080/v1/suites/info?recursive=1&type=task&state=aborted&sortby=-state_change_time&count=10"`
 
 Endpoint :code:`/v1/suites/{path}`
 ----------------------------------
@@ -1275,6 +1333,187 @@ Obtain the Node job output
      - :code:`{"job_output": "..."}`
    * - Example
      - :code:`curl https://localhost:8080/v1/suites/path/to/node/output`
+
+Endpoint :code:`/v1/suites/{path}/info`
+----------------------------------------
+
+Obtain Node information
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :stub-columns: 1
+   :width: 100%
+   :widths: 20 80
+
+   * - Endpoint
+     - :code:`/v1/suites/{path}/info`
+   * - Method
+     - :code:`GET`
+   * - Description
+     - **Read** compact info for the node at :code:`/{path}`: absolute path, current runtime state, and the
+       ISO 8601 timestamp of the last state change. Returns a JSON array; each element describes one node.
+       The array always contains at least the requested node, unless a filter excludes it.
+   * - Parameters
+     - :code:`recursive`, (optional), possible values: :code:`1` (only the value :code:`1` activates recursive traversal; any other value is treated as non-recursive)
+
+       :code:`type`, (optional), possible values: comma-separated list of node kinds
+
+       :code:`state`, (optional), possible values: comma-separated list of state names
+
+       :code:`sortby`, (optional), possible values: :code:`[+|-]{path|state|state_change_time}`
+
+       :code:`count`, (optional), possible values: non-negative integer
+
+   * - Payload
+     - *empty*
+   * - Response
+     - See :ref:`below <response with node info>` for details.
+   * - Example
+     - :code:`curl https://localhost:8080/v1/suites/my_suite/info`
+
+       :code:`curl https://localhost:8080/v1/suites/my_suite/info?recursive=1`
+
+       :code:`curl "https://localhost:8080/v1/suites/my_suite/info?recursive=1&type=task,alias"`
+
+       :code:`curl "https://localhost:8080/v1/suites/my_suite/info?recursive=1&state=active,queued"`
+
+       :code:`curl "https://localhost:8080/v1/suites/my_suite/info?recursive=1&sortby=-state_change_time"`
+
+       :code:`curl "https://localhost:8080/v1/suites/my_suite/info?recursive=1&state=aborted&sortby=path&count=10"`
+
+.. _response with node info:
+
+Response with Node info
+"""""""""""""""""""""""
+
+The response is a JSON array. The following is an example of the fields for each element of the array:
+
+.. code-block:: json
+
+  [
+    {
+      "path": "/suite1/family/task1",
+      "state": "active",
+      "state_change_time": "2024-06-22T10:30:00"
+    },
+    {
+      "path": "/suite1/family/task2",
+      "state": "submitted",
+      "state_change_time": "2024-06-22T09:21:10"
+    },
+    {
+      "path": "/suite2/family",
+      "state": "unknown",
+      "state_change_time": null
+    }
+  ]
+
+where
+
+- :code:`path` is the absolute path of the node in the ecFlow node tree
+- :code:`state` is the current runtime state of the node (see valid state values below)
+- :code:`state_change_time` is the ISO 8601 timestamp (YYYY-MM-DDTHH:MM:SS) of the last state change, or :code:`null`
+  if the suite containing the node has not been started yet (i.e. :code:`begin` has not been called)
+
+Query Parameters
+""""""""""""""""
+
+.. list-table::
+   :header-rows: 1
+
+   * - Parameter
+     - Value
+     - Description
+   * - :code:`recursive`
+     - :code:`1`
+     - Traverse the node subtree depth-first and include all descendant nodes in the response.
+       Without this parameter, or when set to any value other than :code:`1`, only the node at
+       :code:`/{path}` itself is included.
+   * - :code:`type`
+     - comma-separated list of node kinds
+     - Restrict the result to nodes whose kind matches one of the listed values.
+       Valid kinds are :code:`suite`, :code:`family`, :code:`task`, :code:`alias`.
+       Multiple kinds are combined as a union. When :code:`recursive=1`, container nodes are still
+       traversed even when they are excluded by the filter, so descendant tasks or aliases remain
+       reachable. Any other value, including uppercase variants, results in an HTTP :code:`400 Bad Request` error.
+   * - :code:`state`
+     - comma-separated list of state names
+     - Restrict the result to nodes whose current runtime state matches one of the listed states.
+       Multiple states are combined as a union (a node is included if it matches *any* of them).
+       Duplicate state names are accepted. Only the following lowercase values are valid:
+       :code:`unknown`, :code:`complete`, :code:`queued`, :code:`aborted`, :code:`submitted`, :code:`active`.
+       Any other value, including uppercase variants, results in an HTTP :code:`400 Bad Request` error.
+   * - :code:`sortby`
+     - :code:`[+|-]{path|state|state_change_time}`
+     - Sort the response array. An optional leading :code:`+` (or no prefix) means ascending order;
+       :code:`-` means descending order. The sort field must be one of :code:`path` (lexicographic),
+       :code:`state` (lexicographic), or :code:`state_change_time` (ISO 8601 string comparison;
+       :code:`null` values sort first in ascending order, last in descending order).
+       Sorting is stable. Any other value results in an HTTP :code:`400 Bad Request` error.
+
+       .. note::
+
+          In URL query strings the :code:`+` character is reserved and is often decoded as a
+          space by HTTP clients and servers.
+          When specifying ascending order explicitly, consider using the percent-encoded form
+          :code:`%2B` instead (e.g. :code:`sortby=%2Bpath`) to avoid ambiguity.
+
+          The :code:`-` prefix for descending order requires no encoding.
+
+   * - :code:`count`
+     - non-negative integer
+     - Limit the number of items in the response array. Applied after filtering and sorting.
+       Omitting this parameter returns all matching entries. A negative value results in an
+       HTTP :code:`400 Bad Request` error.
+
+All parameters are fully composable: when used together a node is included in the response
+only if it satisfies all active filters simultaneously, after which the result is sorted
+and truncated to the requested count.
+
+Usage examples
+""""""""""""""
+
+Return info for a single node:
+
+.. code-block:: bash
+
+  curl https://localhost:8080/v1/suites/my_suite/info
+
+Return info for all nodes in the subtree rooted at :code:`/my_suite/my_family`:
+
+.. code-block:: bash
+
+  curl https://localhost:8080/v1/suites/my_suite/my_family/info?recursive=1
+
+Return only tasks and aliases across an entire suite:
+
+.. code-block:: bash
+
+  curl "https://localhost:8080/v1/suites/my_suite/info?recursive=1&type=task,alias"
+
+Return only active or queued tasks across an entire suite:
+
+.. code-block:: bash
+
+  curl "https://localhost:8080/v1/suites/my_suite/info?recursive=1&type=task,alias&state=active,queued"
+
+Return only aborted tasks across an entire suite (useful for monitoring):
+
+.. code-block:: bash
+
+  curl "https://localhost:8080/v1/suites/my_suite/info?recursive=1&type=task,alias&state=aborted"
+
+Return all nodes sorted by most recently changed first:
+
+.. code-block:: bash
+
+  curl "https://localhost:8080/v1/suites/my_suite/info?recursive=1&sortby=-state_change_time"
+
+Return the 10 most recently changed aborted tasks:
+
+.. code-block:: bash
+
+  curl "https://localhost:8080/v1/suites/my_suite/info?recursive=1&type=task&state=aborted&sortby=-state_change_time&count=10"
 
 Endpoint :code:`/v1/server/status`
 ----------------------------------

--- a/libs/rest/src/ecflow/http/ApiV1.cpp
+++ b/libs/rest/src/ecflow/http/ApiV1.cpp
@@ -206,6 +206,14 @@ ojson filter_json(const ojson& j, const httplib::Request& r) {
     return dive(j, path_elems);
 }
 
+static InfoQueryContext make_info_context(const httplib::Request& request) {
+    return {request.get_param_value("recursive") == "1",
+            request.get_param_value("type"),
+            request.get_param_value("state"),
+            request.get_param_value("sortby"),
+            request.get_param_value("count")};
+}
+
 static std::string get_tree_content_kind(const httplib::Request& request) {
     constexpr const char* parameter = "content";
     return request.has_param(parameter) ? request.get_param_value(parameter) : "basic";
@@ -251,6 +259,25 @@ void suites_read(const httplib::Request& request, httplib::Response& response) {
     trycatch(request, response, [&]() {
         num_cached_requests++;
         ojson j = filter_json(ecf::http::get_suites(), request);
+
+        response.status = HttpStatusCode::success_ok;
+        response.set_content(j.dump(), "application/json");
+        set_cors(response);
+    });
+}
+
+void suites_info_options(const httplib::Request& request, httplib::Response& response) {
+    trycatch(request, response, [&]() {
+        response.status = HttpStatusCode::success_no_content;
+        set_allowed_methods(response, "GET, HEAD");
+        set_cors(response);
+    });
+}
+
+void suites_info_read(const httplib::Request& request, httplib::Response& response) {
+    trycatch(request, response, [&]() {
+        num_cached_requests++;
+        ojson j = filter_json(get_suites_info(make_info_context(request)), request);
 
         response.status = HttpStatusCode::success_ok;
         response.set_content(j.dump(), "application/json");
@@ -348,6 +375,26 @@ void node_status_read(const httplib::Request& request, httplib::Response& respon
 void node_status_update(const httplib::Request& request, httplib::Response& response) {
     trycatch(request, response, [&]() {
         ojson j         = update_node_status(request);
+        response.status = HttpStatusCode::success_ok;
+        response.set_content(j.dump(), "application/json");
+        set_cors(response);
+    });
+}
+
+void node_info_options(const httplib::Request& request, httplib::Response& response) {
+    trycatch(request, response, [&]() {
+        response.status = HttpStatusCode::success_no_content;
+        set_allowed_methods(response, "GET, HEAD");
+        set_cors(response);
+    });
+}
+
+void node_info_read(const httplib::Request& request, httplib::Response& response) {
+    trycatch(request, response, [&]() {
+        num_cached_requests++;
+        const std::string path = request.matches[1];
+        ojson j                = filter_json(get_node_info(path, make_info_context(request)), request);
+
         response.status = HttpStatusCode::success_ok;
         response.set_content(j.dump(), "application/json");
         set_cors(response);
@@ -660,6 +707,28 @@ void routing(httplib::Server& http_server) {
         http_server.Get(resource_path, v1::node_status_read);        // Read
         http_server.Put(resource_path, v1::node_status_update);      // Update
         http_server.Delete(resource_path, v1::not_implemented);      // Delete
+    }
+
+    /* /v1/suites/info */
+    {
+        std::string resource_path = R"(/v1/suites/info$)";
+
+        http_server.Options(resource_path, v1::suites_info_options); // Options
+        http_server.Post(resource_path, v1::not_implemented);        // Create
+        http_server.Get(resource_path, v1::suites_info_read);        // Read
+        http_server.Put(resource_path, v1::not_implemented);         // Update
+        http_server.Delete(resource_path, v1::not_implemented);      // Delete
+    }
+
+    /* .../suites/<path>/info */
+    {
+        std::string resource_path = R"(/v1/suites([A-Za-z0-9_\/\.]+)/info$)";
+
+        http_server.Options(resource_path, v1::node_info_options); // Options
+        http_server.Post(resource_path, v1::not_implemented);      // Create
+        http_server.Get(resource_path, v1::node_info_read);        // Read
+        http_server.Put(resource_path, v1::not_implemented);       // Update
+        http_server.Delete(resource_path, v1::not_implemented);    // Delete
     }
 
     /* .../suites/<path>/attributes */

--- a/libs/rest/src/ecflow/http/ApiV1.hpp
+++ b/libs/rest/src/ecflow/http/ApiV1.hpp
@@ -26,6 +26,9 @@ void suites_options(const httplib::Request& request, httplib::Response& response
 void suites_create(const httplib::Request& request, httplib::Response& response);
 void suites_read(const httplib::Request& request, httplib::Response& response);
 
+void suites_info_options(const httplib::Request& request, httplib::Response& response);
+void suites_info_read(const httplib::Request& request, httplib::Response& response);
+
 void node_tree_options(const httplib::Request& request, httplib::Response& response);
 void node_tree_read(const httplib::Request& request, httplib::Response& response);
 
@@ -37,6 +40,9 @@ void node_definition_delete(const httplib::Request& request, httplib::Response& 
 void node_status_options(const httplib::Request& request, httplib::Response& response);
 void node_status_read(const httplib::Request& request, httplib::Response& response);
 void node_status_update(const httplib::Request& request, httplib::Response& response);
+
+void node_info_options(const httplib::Request& request, httplib::Response& response);
+void node_info_read(const httplib::Request& request, httplib::Response& response);
 
 void node_attributes_options(const httplib::Request& request, httplib::Response& response);
 void node_attributes_create(const httplib::Request& request, httplib::Response& response);

--- a/libs/rest/src/ecflow/http/ApiV1Impl.cpp
+++ b/libs/rest/src/ecflow/http/ApiV1Impl.cpp
@@ -10,6 +10,7 @@
 
 #include "ecflow/http/ApiV1Impl.hpp"
 
+#include <algorithm>
 #include <optional>
 #include <string>
 
@@ -117,6 +118,252 @@ ojson get_node_status(const httplib::Request& request) {
     return j;
 }
 
+static ojson make_node_info_entry(const node_ptr& node) {
+    ojson entry;
+    entry["path"]  = node->absNodePath();
+    entry["state"] = NState::toString(node->state());
+
+    const boost::posix_time::ptime t = node->state_change_time();
+    if (t.is_not_a_date_time()) {
+        entry["state_change_time"] = nullptr;
+    }
+    else {
+        entry["state_change_time"] = boost::posix_time::to_iso_extended_string(t);
+    }
+
+    return entry;
+}
+
+static std::vector<std::string> parse_type_filter(const std::string& param) {
+    if (param.empty()) {
+        return {};
+    }
+
+    static const std::string_view suite_type  = "suite";
+    static const std::string_view family_type = "family";
+    static const std::string_view task_type   = "task";
+    static const std::string_view alias_type  = "alias";
+
+    std::vector<std::string> tokens;
+    ecf::algorithm::split_at(tokens, param, ",");
+
+    // A non-empty parameter that yields no tokens (e.g. only separators, such as ',' or ',,') is invalid
+    if (tokens.empty()) {
+        throw HttpServerException(HttpStatusCode::client_error_bad_request, "Invalid node type: '" + param + "'");
+    }
+
+    std::vector<std::string> result;
+    for (const auto& token : tokens) {
+        if (token != suite_type && token != family_type && token != task_type && token != alias_type) {
+            throw HttpServerException(HttpStatusCode::client_error_bad_request, "Invalid node type: '" + token + "'");
+        }
+        result.push_back(token);
+    }
+
+    // Deduplicate the options (in case of the same type is defined multiple times e.g. "task,task,alias")
+    std::sort(result.begin(), result.end());
+    result.erase(std::unique(result.begin(), result.end()), result.end());
+
+    return result;
+}
+
+static bool is_node_with_type(const node_ptr& node, const std::vector<std::string>& filter) {
+    if (filter.empty()) {
+        return true;
+    }
+    const std::string type = ecf::algorithm::tolower(node->debugType());
+    for (const auto& f : filter) {
+        if (f == type) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static std::vector<NState::State> parse_state_filter(const std::string& param) {
+    if (param.empty()) {
+        return {};
+    }
+
+    std::vector<std::string> tokens;
+    ecf::algorithm::split_at(tokens, param, ",");
+
+    // A non-empty parameter that yields no tokens (e.g. only separators, such as ',' or ',,') is invalid
+    if (tokens.empty()) {
+        throw HttpServerException(HttpStatusCode::client_error_bad_request, "Invalid state value: '" + param + "'");
+    }
+
+    std::vector<NState::State> result;
+    for (const auto& token : tokens) {
+        const auto [state, valid] = NState::to_state(token);
+        if (!valid) {
+            throw HttpServerException(HttpStatusCode::client_error_bad_request, "Invalid state value: '" + token + "'");
+        }
+        result.push_back(state);
+    }
+
+    // Deduplicate the options (in case of the same type is defined multiple times e.g. "task,task,alias")
+    std::sort(result.begin(), result.end());
+    result.erase(std::unique(result.begin(), result.end()), result.end());
+
+    return result;
+}
+
+static bool is_node_with_state(const node_ptr& node, const std::vector<NState::State>& filter) {
+    if (filter.empty()) {
+        return true;
+    }
+    const NState::State s = node->state();
+    for (const auto& f : filter) {
+        if (f == s) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void collect_single_node_info(const node_ptr& node,
+                                     ojson& result,
+                                     const std::vector<std::string>& selected_types,
+                                     const std::vector<NState::State>& selected_states) {
+    if (is_node_with_type(node, selected_types) && is_node_with_state(node, selected_states)) {
+        result.push_back(make_node_info_entry(node));
+    }
+}
+
+static void collect_node_info(const node_ptr& node,
+                              ojson& result,
+                              const std::vector<std::string>& type_filter,
+                              const std::vector<NState::State>& state_filter) {
+    // Collect node (if it passes the filters)
+    collect_single_node_info(node, result, type_filter, state_filter);
+
+    // Collect node children
+    if (auto container = std::dynamic_pointer_cast<NodeContainer>(node)) {
+        for (const auto& child : container->children()) {
+            collect_node_info(child, result, type_filter, state_filter);
+        }
+    }
+    // Collect task aliases (Task is not a NodeContainer, so its aliases are not covered above)
+    else if (auto task = std::dynamic_pointer_cast<Task>(node)) {
+        for (const auto& alias : task->aliases()) {
+            collect_single_node_info(alias, result, type_filter, state_filter);
+        }
+    }
+}
+
+namespace {
+
+struct InfoSortSpecification
+{
+    enum class Field { path, state, state_change_time };
+    Field field;
+    bool ascending;
+};
+
+} // anonymous namespace
+
+static InfoSortSpecification parse_sortby(const std::string& param) {
+    bool ascending    = true;
+    std::string field = param;
+    if (!param.empty() && (param[0] == '+' || param[0] == '-')) {
+        ascending = (param[0] == '+');
+        field     = param.substr(1);
+    }
+    if (field == "path") {
+        return {InfoSortSpecification::Field::path, ascending};
+    }
+    if (field == "state") {
+        return {InfoSortSpecification::Field::state, ascending};
+    }
+    if (field == "state_change_time") {
+        return {InfoSortSpecification::Field::state_change_time, ascending};
+    }
+    throw HttpServerException(HttpStatusCode::client_error_bad_request, "Invalid sortby value: '" + param + "'");
+}
+
+static size_t parse_count(const std::string& param) {
+    int n;
+    try {
+        n = std::stoi(param);
+    }
+    catch (const std::exception&) {
+        throw HttpServerException(HttpStatusCode::client_error_bad_request, "Invalid count value: '" + param + "'");
+    }
+    if (n < 0) {
+        throw HttpServerException(HttpStatusCode::client_error_bad_request, "count must not be negative");
+    }
+    return static_cast<size_t>(n);
+}
+
+static void apply_sortby(ojson& result, const InfoSortSpecification& spec) {
+    auto& arr = result.get_ref<ojson::array_t&>();
+    std::stable_sort(arr.begin(), arr.end(), [&](const ojson& a, const ojson& b) {
+        using Field = InfoSortSpecification::Field;
+        switch (spec.field) {
+            case Field::path: {
+                auto pa = a["path"].get<std::string>();
+                auto pb = b["path"].get<std::string>();
+                return spec.ascending ? (pa < pb) : (pa > pb);
+            }
+            case Field::state: {
+                auto sa = a["state"].get<std::string>();
+                auto sb = b["state"].get<std::string>();
+                return spec.ascending ? (sa < sb) : (sa > sb);
+            }
+            case Field::state_change_time: {
+                bool a_null = a["state_change_time"].is_null();
+                bool b_null = b["state_change_time"].is_null();
+                if (a_null && b_null) {
+                    return false;
+                }
+                if (a_null) {
+                    return spec.ascending; // null < non-null when ascending
+                }
+                if (b_null) {
+                    return !spec.ascending;
+                }
+                auto ta = a["state_change_time"].get<std::string>();
+                auto tb = b["state_change_time"].get<std::string>();
+                return spec.ascending ? (ta < tb) : (ta > tb);
+            }
+        }
+        return false;
+    });
+}
+
+ojson get_node_info(const std::string& path, const InfoQueryContext& ctx) {
+    node_ptr node = get_node(path);
+
+    const auto type_filter  = parse_type_filter(ctx.node_types);
+    const auto state_filter = parse_state_filter(ctx.node_states);
+
+    ojson result = ojson::array();
+    // Collect all node information
+    if (ctx.recursive) {
+        collect_node_info(node, result, type_filter, state_filter);
+    }
+    else {
+        collect_single_node_info(node, result, type_filter, state_filter);
+    }
+
+    // Apply sorting
+    if (!ctx.sortby.empty()) {
+        apply_sortby(result, parse_sortby(ctx.sortby));
+    }
+
+    // Apply count limit
+    if (!ctx.count.empty()) {
+        const size_t limit = parse_count(ctx.count);
+        auto& arr          = result.get_ref<ojson::array_t&>();
+        if (limit < arr.size()) {
+            arr.resize(limit);
+        }
+    }
+
+    return result;
+}
+
 template <typename F>
 void apply_to_parents(const Node* node, F f) {
     for (const Node* up = node; up != nullptr; up = up->parent()) {
@@ -210,6 +457,38 @@ ojson get_suites() {
         j.push_back(s->name());
     }
     return j;
+}
+
+ojson get_suites_info(const InfoQueryContext& ctx) {
+    const auto type_filter  = parse_type_filter(ctx.node_types);
+    const auto state_filter = parse_state_filter(ctx.node_states);
+
+    ojson result = ojson::array();
+    // Collect all node information
+    for (const auto& suite : get_defs()->suites()) {
+        if (ctx.recursive) {
+            collect_node_info(suite, result, type_filter, state_filter);
+        }
+        else {
+            collect_single_node_info(suite, result, type_filter, state_filter);
+        }
+    }
+
+    // Apply sorting
+    if (!ctx.sortby.empty()) {
+        apply_sortby(result, parse_sortby(ctx.sortby));
+    }
+
+    // Apply count limit
+    if (!ctx.count.empty()) {
+        const size_t limit = parse_count(ctx.count);
+        auto& arr          = result.get_ref<ojson::array_t&>();
+        if (limit < arr.size()) {
+            arr.resize(limit);
+        }
+    }
+
+    return result;
 }
 
 ojson get_server_attributes() {

--- a/libs/rest/src/ecflow/http/ApiV1Impl.hpp
+++ b/libs/rest/src/ecflow/http/ApiV1Impl.hpp
@@ -17,6 +17,15 @@
 
 namespace ecf::http {
 
+struct InfoQueryContext
+{
+    bool recursive;
+    std::string node_types;
+    std::string node_states;
+    std::string sortby;
+    std::string count;
+};
+
 ojson get_basic_node_tree(const std::string& path);
 ojson get_full_node_tree(const std::string& path, bool with_id, bool with_gen_vars);
 ojson get_sparser_node_tree(const std::string& path);
@@ -24,6 +33,8 @@ ojson get_sparser_node_tree(const std::string& path);
 void add_suite(const httplib::Request& request, httplib::Response& response);
 
 ojson get_suites();
+
+ojson get_suites_info(const InfoQueryContext& ctx);
 
 ojson get_server_attributes();
 ojson add_server_attribute(const httplib::Request& request);
@@ -40,6 +51,8 @@ ojson delete_node_attribute(const httplib::Request& request);
 
 ojson get_node_status(const httplib::Request& request);
 ojson update_node_status(const httplib::Request& request);
+
+ojson get_node_info(const std::string& path, const InfoQueryContext& ctx);
 
 ojson get_node_output(const httplib::Request& request);
 

--- a/libs/rest/test/TestApiV1.cpp
+++ b/libs/rest/test/TestApiV1.cpp
@@ -468,18 +468,18 @@ BOOST_AUTO_TEST_CASE(test_suite) {
 BOOST_AUTO_TEST_CASE(test_node_basic_tree) {
     ECF_NAME_THIS_TEST();
 
-    // (0) Clean up -- in case there is any left-over from passed/failed tests
+    // Clean up -- in case there is any left-over from passed/failed tests
     request("delete", "/v1/suites/basic_suite/definition", "", API_KEY);
     wait_until([] { return false == check_for_path("/v1/suites/basic_suite/definition"); });
 
-    // (1) Publish 'basic_suite' suite
+    // Publish 'basic_suite' suite
 
     std::string suite_definition =
         R"({"definition" : "suite basic_suite\n  family f\n    task t\n      label l \"value\"\n      meter m 0 100 50\n      event e\n  endfamily\nendsuite\n# comment"})";
     handle_response(request("post", "/v1/suites", suite_definition, API_KEY), HttpStatusCode::success_created);
     wait_until([] { return check_for_path("/v1/suites/basic_suite/definition"); });
 
-    // (2) Retrieve 'basic_suite' suite tree
+    // Retrieve 'basic_suite' suite tree
     {
         auto result  = handle_response(request("get", "/v1/suites/tree"));
         auto content = ojson::parse(result.body);
@@ -489,7 +489,7 @@ BOOST_AUTO_TEST_CASE(test_node_basic_tree) {
         BOOST_REQUIRE(content["basic_suite"]["f"].contains("t"));
     }
 
-    // (3) Retrieve 'basic_suite' suite tree, explicitly specifying basic content
+    // Retrieve 'basic_suite' suite tree, explicitly specifying basic content
     {
         auto result  = handle_response(request("get", "/v1/suites/tree?content=basic"));
         auto content = ojson::parse(result.body);
@@ -499,7 +499,7 @@ BOOST_AUTO_TEST_CASE(test_node_basic_tree) {
         BOOST_REQUIRE(content["basic_suite"]["f"].contains("t"));
     }
 
-    // (4) Retrieve specific node tree
+    // Retrieve specific node tree
     {
         auto result  = handle_response(request("get", "/v1/suites/basic_suite/f/tree?content=basic"));
         auto content = ojson::parse(result.body);
@@ -508,7 +508,7 @@ BOOST_AUTO_TEST_CASE(test_node_basic_tree) {
         BOOST_REQUIRE(content["f"].contains("t"));
     }
 
-    // (5) Clean up
+    // Clean up
     request("delete", "/v1/suites/basic_suite/definition", "", API_KEY);
     wait_until([] { return false == check_for_path("/v1/suites/basic_suite/definition"); });
 }
@@ -516,18 +516,18 @@ BOOST_AUTO_TEST_CASE(test_node_basic_tree) {
 BOOST_AUTO_TEST_CASE(test_node_full_tree) {
     ECF_NAME_THIS_TEST();
 
-    // (0) Clean up -- in case there is any left-over from passed/failed tests
+    // Clean up -- in case there is any left-over from passed/failed tests
     request("delete", "/v1/suites/full_suite/definition", "", API_KEY);
     wait_until([] { return false == check_for_path("/v1/suites/full_suite/definition"); });
 
-    // (1) Publish 'full_tree' suite
+    // Publish 'full_tree' suite
 
     std::string suite_definition =
         R"({"definition" : "suite full_suite\n  family f\n    task t\n      label l \"value\"\n      meter m 0 100 50\n      event e\n  endfamily\nendsuite\n# comment"})";
     handle_response(request("post", "/v1/suites", suite_definition, API_KEY), HttpStatusCode::success_created);
     wait_until([] { return check_for_path("/v1/suites/full_suite/definition"); });
 
-    // (2) Retrieve 'full_suite' suite tree, explicitly specifying full content
+    // Retrieve 'full_suite' suite tree, explicitly specifying full content
     {
         auto result  = handle_response(request("get", "/v1/suites/tree?content=full"));
         auto content = ojson::parse(result.body);
@@ -560,7 +560,7 @@ BOOST_AUTO_TEST_CASE(test_node_full_tree) {
         BOOST_REQUIRE(content["full_suite"]["children"]["f"]["children"]["t"]["aliases"].size() == 0);
     }
 
-    // (2) Retrieve 'full_suite' suite tree, explicitly specifying full content
+    // Retrieve 'full_suite' suite tree, explicitly specifying full content
     {
         auto result  = handle_response(request("get", "/v1/suites/full_suite/f/tree?content=full"));
         auto content = ojson::parse(result.body);
@@ -581,7 +581,7 @@ BOOST_AUTO_TEST_CASE(test_node_full_tree) {
         BOOST_REQUIRE(content["f"]["children"]["t"]["aliases"].size() == 0);
     }
 
-    // (4) Clean up
+    // Clean up
     request("delete", "/v1/suites/full_suite/definition", "", API_KEY);
     wait_until([] { return false == check_for_path("/v1/suites/full_suite/definition"); });
 }
@@ -589,18 +589,18 @@ BOOST_AUTO_TEST_CASE(test_node_full_tree) {
 BOOST_AUTO_TEST_CASE(test_node_full_tree_with_generated_variables) {
     std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " =========" << std::endl;
 
-    // (0) Clean up -- in case there is any left-over from passed/failed tests
+    // Clean up -- in case there is any left-over from passed/failed tests
     request("delete", "/v1/suites/full_suite/definition", "", API_KEY);
     wait_until([] { return false == check_for_path("/v1/suites/full_suite/definition"); });
 
-    // (1) Publish 'full_tree' suite
+    // Publish 'full_tree' suite
 
     std::string suite_definition =
         R"({"definition" : "suite full_suite\n  family f\n    task t\n      label l \"value\"\n      meter m 0 100 50\n      event e\n  endfamily\nendsuite\n# comment"})";
     handle_response(request("post", "/v1/suites", suite_definition, API_KEY), HttpStatusCode::success_created);
     wait_until([] { return check_for_path("/v1/suites/full_suite/definition"); });
 
-    // (2) Retrieve 'full_suite' suite tree, explicitly requesting generated variables
+    // Retrieve 'full_suite' suite tree, explicitly requesting generated variables
     {
         auto result  = handle_response(request("get", "/v1/suites/full_suite/f/tree?content=full&gen_vars=true"));
         auto content = ojson::parse(result.body);
@@ -646,9 +646,675 @@ BOOST_AUTO_TEST_CASE(test_node_full_tree_with_generated_variables) {
         }
     }
 
-    // (4) Clean up
+    // Clean up
     request("delete", "/v1/suites/full_suite/definition", "", API_KEY);
     wait_until([] { return false == check_for_path("/v1/suites/full_suite/definition"); });
+}
+
+BOOST_AUTO_TEST_CASE(test_node_info) {
+    ECF_NAME_THIS_TEST();
+
+    // Clean up
+    request("delete", "/v1/suites/suiteX/definition", "", API_KEY);
+    wait_until([] { return false == check_for_path("/v1/suites/suiteX/definition"); });
+
+    // Create suite 'suiteX'
+    //       `-- suiteX
+    //         `-- f
+    //           `-- t
+    handle_response(request("post",
+                            "/v1/suites",
+                            R"({"definition" : "suite suiteX\n  family f\n    task t\n  endfamily\nendsuite"})",
+                            API_KEY),
+                    HttpStatusCode::success_created);
+    wait_until([] { return check_for_path("/v1/suites/suiteX/definition"); });
+
+    // Check single-element array with correct path, "unknown" state, null time change
+    //     This is done before beginning to ensure we handle the "unknown" state, and null time change correctly
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info"));
+        auto content = ojson::parse(result.body);
+
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 1);
+        const auto& entry = content[0];
+        BOOST_REQUIRE(entry.contains("path"));
+        BOOST_REQUIRE(entry["path"] == "/suiteX");
+        BOOST_REQUIRE(entry.contains("state"));
+        BOOST_REQUIRE(entry["state"] == "unknown");
+        BOOST_REQUIRE(entry.contains("state_change_time"));
+        BOOST_REQUIRE(entry["state_change_time"].is_null());
+    }
+
+    // Check single-element array with correct full path
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/f/t/info"));
+        auto content = ojson::parse(result.body);
+
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 1);
+        BOOST_REQUIRE(content[0]["path"] == "/suiteX/f/t");
+        BOOST_REQUIRE(content[0]["state"] == "unknown");
+    }
+
+    // Check recursive=1, must include all nodes in the tree (suite + family + task = 3)
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?recursive=1"));
+        auto content = ojson::parse(result.body);
+
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 3); // suiteX, f, t
+
+        BOOST_REQUIRE(content[0]["path"] == "/suiteX");
+        BOOST_REQUIRE(content[1]["path"] == "/suiteX/f");
+        BOOST_REQUIRE(content[2]["path"] == "/suiteX/f/t");
+    }
+
+    // Check recursive=1 + type=task, must return only the task
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?recursive=1&type=task"));
+        auto content = ojson::parse(result.body);
+
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 1);
+        BOOST_REQUIRE(content[0]["path"] == "/suiteX/f/t");
+    }
+
+    // Check recursive=1 + type=family,task, must return family and task (2 nodes)
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?recursive=1&type=family,task"));
+        auto content = ojson::parse(result.body);
+
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 2);
+        BOOST_REQUIRE(content[0]["path"] == "/suiteX/f");
+        BOOST_REQUIRE(content[1]["path"] == "/suiteX/f/t");
+    }
+
+    // Check type=task without recursive on a suite node, must return empty array since suite is not a task
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?type=task"));
+        auto content = ojson::parse(result.body);
+
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.empty());
+    }
+
+    // Check type=task directly on the task node, must return the task itself
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/f/t/info?type=task"));
+        auto content = ojson::parse(result.body);
+
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 1);
+        BOOST_REQUIRE(content[0]["path"] == "/suiteX/f/t");
+    }
+
+    // Check type=suite on the suite node, must return the suite itself
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?type=suite"));
+        auto content = ojson::parse(result.body);
+
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 1);
+        BOOST_REQUIRE(content[0]["path"] == "/suiteX");
+    }
+
+    // Check that can handle invalid type value (invalid) → 400
+    handle_response(request("get", "/v1/suites/suiteX/info?type=invalid"), HttpStatusCode::client_error_bad_request);
+
+    // Check that can handle invalid type value (uppercase type not accepted) → 400
+    handle_response(request("get", "/v1/suites/suiteX/info?type=Task"), HttpStatusCode::client_error_bad_request);
+
+    // Check that a separator-only type value (no actual tokens) → 400
+    handle_response(request("get", "/v1/suites/suiteX/info?type=,"), HttpStatusCode::client_error_bad_request);
+    handle_response(request("get", "/v1/suites/suiteX/info?type=,,"), HttpStatusCode::client_error_bad_request);
+
+    // Check state=unknown, must return suite (n.b. no recursive)
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?state=unknown"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 1);
+        BOOST_REQUIRE(content[0]["path"] == "/suiteX");
+    }
+
+    // Check recursive=1&state=unknown, must return all 3 nodes
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?recursive=1&state=unknown"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 3);
+    }
+
+    // Check recursive=1&state=complete, must return empty array as all nodes are in unknown state before begin
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?recursive=1&state=complete"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.empty());
+    }
+
+    // Check state=queued,unknown, must consider both valid states (OR)
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?state=queued,unknown"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 1); // suite is unknown, matches first term
+    }
+
+    // Check that can handle invalid state value (uppercase state name) → 400
+    handle_response(request("get", "/v1/suites/suiteX/info?state=Active"), HttpStatusCode::client_error_bad_request);
+
+    // Check that can handle invalid state value (invalid state name) → 400
+    handle_response(request("get", "/v1/suites/suiteX/info?state=invalid"), HttpStatusCode::client_error_bad_request);
+
+    // Check that a separator-only state value (no actual tokens) → 400
+    handle_response(request("get", "/v1/suites/suiteX/info?state=,"), HttpStatusCode::client_error_bad_request);
+    handle_response(request("get", "/v1/suites/suiteX/info?state=,,"), HttpStatusCode::client_error_bad_request);
+
+    // Check combined type+state (AND semantics): type=suite AND state=unknown
+    //      must return exactly the suite root (1 result, non-recursive)
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?type=suite&state=unknown"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 1);
+        BOOST_REQUIRE(content[0]["path"] == "/suiteX");
+    }
+
+    // Check combined type+state: type=task AND state=unknown AND recursive=1
+    //      must return only the task (not the suite or family)
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?recursive=1&type=task&state=unknown"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 1);
+        BOOST_REQUIRE(content[0]["path"] == "/suiteX/f/t");
+    }
+
+    // Check combined type+state: type=task AND state=complete AND recursive=1
+    //      must return empty (no completed tasks before begin)
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?recursive=1&type=task&state=complete"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.empty());
+    }
+
+    // Check combined type+state: type=suite,family AND state=unknown AND recursive=1
+    //      must return suite + family (2 results), not the task
+    {
+        auto result =
+            handle_response(request("get", "/v1/suites/suiteX/info?recursive=1&type=suite,family&state=unknown"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 2);
+        BOOST_REQUIRE(content[0]["path"] == "/suiteX");
+        BOOST_REQUIRE(content[1]["path"] == "/suiteX/f");
+    }
+
+    // Check combined type+state: type=task AND state=queued AND recursive=1
+    //      must return empty before begin (task is unknown, not queued)
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?recursive=1&type=task&state=queued"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.empty());
+    }
+
+    // Begin the suite
+    handle_response(request("put", "/v1/suites/suiteX/status", R"({"action":"begin"})", API_KEY));
+
+    // Check that state_change_time is populated and state is no longer "unknown"
+    wait_until([] {
+        try {
+            auto r       = handle_response(request("get", "/v1/suites/suiteX/info"), HttpStatusCode::success_ok, true);
+            auto content = ojson::parse(r.body);
+            return content.is_array() && !content[0]["state_change_time"].is_null() &&
+                   content[0]["state"].get<std::string>() != "unknown";
+        }
+        catch (...) {
+            return false;
+        }
+    });
+
+    // Check that can handle non-existent node returns 404
+    handle_response(request("get", "/v1/suites/suiteX/nonexistent/info"), HttpStatusCode::client_error_not_found);
+
+    // Check that filter=[0] returns the first element as an object
+    //      n.b. the filter query parameter is a generic functionality, applied to all endpoints
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?filter=[0]"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_object());
+        BOOST_REQUIRE(content.contains("path"));
+        BOOST_REQUIRE(content.contains("state"));
+        BOOST_REQUIRE(content.contains("state_change_time"));
+    }
+
+    // Check sortby=+path, must return output in ascending lexicographic order of the path
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?recursive=1&sortby=%2Bpath"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 3);
+        BOOST_REQUIRE(content[0]["path"] == "/suiteX");
+        BOOST_REQUIRE(content[1]["path"] == "/suiteX/f");
+        BOOST_REQUIRE(content[2]["path"] == "/suiteX/f/t");
+    }
+
+    // Check sortby=-path, must return output in descending lexicographic order of the path
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?recursive=1&sortby=-path"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 3);
+        BOOST_REQUIRE(content[0]["path"] == "/suiteX/f/t");
+        BOOST_REQUIRE(content[1]["path"] == "/suiteX/f");
+        BOOST_REQUIRE(content[2]["path"] == "/suiteX");
+    }
+
+    // Check sortby=path, must return output (by default) in ascending lexicographic order of the path
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?recursive=1&sortby=path"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 3);
+        BOOST_REQUIRE(content[0]["path"] == "/suiteX");
+        BOOST_REQUIRE(content[1]["path"] == "/suiteX/f");
+        BOOST_REQUIRE(content[2]["path"] == "/suiteX/f/t");
+    }
+
+    // Check sortby=state, must return output (by default) in ascending alphabetical order of the state
+    //
+    // Note: The check verifies only that the order is correct, but not the values themselves because at this
+    // point the suite is running and the states change as the suite progresses, so the exact values are not known.
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?recursive=1&sortby=state"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 3);
+        for (size_t i = 1; i < content.size(); ++i) {
+            BOOST_REQUIRE(content[i - 1]["state"].get<std::string>() <= content[i]["state"].get<std::string>());
+        }
+    }
+
+    // Check sortby=-state, must return output in descending alphabetical order of the state
+    //
+    // Note: The check verifies only that the order is correct, but not the values themselves because at this
+    // point the suite is running and the states change as the suite progresses, so the exact values are not known.
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?recursive=1&sortby=-state"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 3);
+        for (size_t i = 1; i < content.size(); ++i) {
+            BOOST_REQUIRE(content[i - 1]["state"].get<std::string>() >= content[i]["state"].get<std::string>());
+        }
+    }
+
+    // Check sortby=state_change_time, must return output in ascending order of the time (nulls first, then ISO
+    // strings)
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?recursive=1&sortby=state_change_time"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 3);
+        for (size_t i = 1; i < content.size(); ++i) {
+            const bool a_null = content[i - 1]["state_change_time"].is_null();
+            const bool b_null = content[i]["state_change_time"].is_null();
+            if (!a_null && !b_null) {
+                BOOST_REQUIRE(content[i - 1]["state_change_time"].get<std::string>() <=
+                              content[i]["state_change_time"].get<std::string>());
+            }
+            else {
+                BOOST_REQUIRE(!b_null || a_null); // null must not follow a non-null (null comes first)
+            }
+        }
+    }
+
+    // Check that can handle invalid sortby value → 400
+    handle_response(request("get", "/v1/suites/suiteX/info?sortby=invalid_field"),
+                    HttpStatusCode::client_error_bad_request);
+
+    // Check count=2, must return only 2 items
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?recursive=1&count=2"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 2);
+    }
+
+    // Check count=0, must return empty array
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?recursive=1&count=0"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.empty());
+    }
+
+    // Check count=10, must return all 3 items, since N is larger than the result set
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?recursive=1&count=10"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 3);
+    }
+
+    // Check that can handle invalid count values (negative values) → 400
+    handle_response(request("get", "/v1/suites/suiteX/info?count=-1"), HttpStatusCode::client_error_bad_request);
+
+    // Check that can handle invalid count values (alphanumerical values) → 400
+    handle_response(request("get", "/v1/suites/suiteX/info?count=abc1"), HttpStatusCode::client_error_bad_request);
+
+    // Check sortby=-path&count=2, must sort by descending path, and then truncate output to 2
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteX/info?recursive=1&sortby=-path&count=2"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 2);
+        BOOST_REQUIRE(content[0]["path"] == "/suiteX/f/t");
+        BOOST_REQUIRE(content[1]["path"] == "/suiteX/f");
+    }
+
+    // Check HEAD requests: must return 200 with an empty body on both /info endpoints
+    //       HEAD is declared as an allowed method in the OPTIONS handler; cpp-httplib automatically
+    //       serves HEAD by running the GET handler and stripping the response body.
+    {
+        httplib::SSLClient c(API_HOST, ECF_TEST_HTTP_PORT_NR);
+        c.enable_server_certificate_verification(false);
+        c.set_connection_timeout(3);
+        c.set_read_timeout(5);
+        c.set_write_timeout(5);
+        c.set_default_headers(httplib::Headers{{"Content-type", "application/json"}});
+
+        // HEAD /v1/suites/suiteX/info
+        auto r1 = c.Head("/v1/suites/suiteX/info");
+        BOOST_REQUIRE(r1);
+        BOOST_REQUIRE_EQUAL(r1->status, HttpStatusCode::success_ok);
+        BOOST_REQUIRE(r1->body.empty());
+
+        // HEAD /v1/suites/info
+        auto r2 = c.Head("/v1/suites/info");
+        BOOST_REQUIRE(r2);
+        BOOST_REQUIRE_EQUAL(r2->status, HttpStatusCode::success_ok);
+        BOOST_REQUIRE(r2->body.empty());
+    }
+
+    // Clean up
+    request("delete", "/v1/suites/suiteX/definition", "", API_KEY);
+    wait_until([] { return false == check_for_path("/v1/suites/suiteX/definition"); });
+}
+
+BOOST_AUTO_TEST_CASE(test_suites_info) {
+    ECF_NAME_THIS_TEST();
+
+    // Clean up
+    //       |-- suite1
+    //       | `-- fa
+    //       |   `-- ta
+    //       `-- suite2
+    //         `-- fb
+    //           `-- tb
+    request("delete", "/v1/suites/suite1/definition", "", API_KEY);
+    request("delete", "/v1/suites/suite2/definition", "", API_KEY);
+    wait_until([] {
+        return !check_for_path("/v1/suites/suite1/definition") && !check_for_path("/v1/suites/suite2/definition");
+    });
+
+    // Create two suites: suite1 (family fa, task ta) and suite2 (family fb, task tb)
+    handle_response(request("post",
+                            "/v1/suites",
+                            R"({"definition" : "suite suite1\n  family fa\n    task ta\n  endfamily\nendsuite"})",
+                            API_KEY),
+                    HttpStatusCode::success_created);
+    handle_response(request("post",
+                            "/v1/suites",
+                            R"({"definition" : "suite suite2\n  family fb\n    task tb\n  endfamily\nendsuite"})",
+                            API_KEY),
+                    HttpStatusCode::success_created);
+    wait_until([] {
+        return check_for_path("/v1/suites/suite1/definition") && check_for_path("/v1/suites/suite2/definition");
+    });
+
+    // Check without recursive, must return both suite roots
+    {
+        auto result  = handle_response(request("get", "/v1/suites/info"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() >= 2);
+        bool has_a = false, has_b = false;
+        for (const auto& entry : content) {
+            if (entry["path"] == "/suite1") {
+                has_a = true;
+            }
+            if (entry["path"] == "/suite2") {
+                has_b = true;
+            }
+        }
+        BOOST_REQUIRE(has_a);
+        BOOST_REQUIRE(has_b);
+    }
+
+    // Check with recursive=1: must return suite1 and suite2 (each with 3 nodes)
+    {
+        auto result  = handle_response(request("get", "/v1/suites/info?recursive=1"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        size_t count_a = 0, count_b = 0;
+        for (const auto& entry : content) {
+            const auto path = entry["path"].get<std::string>();
+            if (path == "/suite1" || path.rfind("/suite1/", 0) == 0) {
+                ++count_a;
+            }
+            if (path == "/suite2" || path.rfind("/suite2/", 0) == 0) {
+                ++count_b;
+            }
+        }
+        BOOST_REQUIRE(count_a == 3); // suite + family + task
+        BOOST_REQUIRE(count_b == 3); // suite + family + task
+    }
+
+    // Check recursive=1 + type=task, must return 2 tasks, one from each suite
+    {
+        auto result  = handle_response(request("get", "/v1/suites/info?recursive=1&type=task"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        bool has_ta = false, has_tb = false;
+        for (const auto& entry : content) {
+            const auto path = entry["path"].get<std::string>();
+            if (path == "/suite1/fa/ta") {
+                has_ta = true;
+                BOOST_REQUIRE(entry["state"] == "unknown");
+            }
+            if (path == "/suite2/fb/tb") {
+                has_tb = true;
+                BOOST_REQUIRE(entry["state"] == "unknown");
+            }
+        }
+        BOOST_REQUIRE(has_ta);
+        BOOST_REQUIRE(has_tb);
+    }
+
+    // Check sortby=-path with recursive=1, must return entries in descending path order
+    {
+        auto result  = handle_response(request("get", "/v1/suites/info?recursive=1&sortby=-path"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() >= 2);
+        std::string first = content[0]["path"].get<std::string>();
+        std::string last  = content[content.size() - 1]["path"].get<std::string>();
+        BOOST_REQUIRE(first > last);
+    }
+
+    // Check count=3, must truncate the result to exactly 3 entries
+    {
+        auto result  = handle_response(request("get", "/v1/suites/info?recursive=1&count=3"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 3);
+    }
+
+    // Check state=unknown without recursive, must return both suite1 and suite2
+    {
+        auto result  = handle_response(request("get", "/v1/suites/info?state=unknown"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        bool has_a = false, has_b = false;
+        for (const auto& entry : content) {
+            if (entry["path"] == "/suite1") {
+                has_a = true;
+            }
+            if (entry["path"] == "/suite2") {
+                has_b = true;
+            }
+        }
+        BOOST_REQUIRE(has_a);
+        BOOST_REQUIRE(has_b);
+    }
+
+    // Check state=active without recursive, must return an empty array since neither suite is active
+    {
+        auto result  = handle_response(request("get", "/v1/suites/info?state=active"));
+        auto content = ojson::parse(result.body);
+        BOOST_REQUIRE(content.is_array());
+        for (const auto& entry : content) {
+            // Neither of our test suites should appear as active
+            BOOST_REQUIRE(entry["path"] != "/suite1");
+            BOOST_REQUIRE(entry["path"] != "/suite2");
+        }
+    }
+
+    // Clean up
+    request("delete", "/v1/suites/suite1/definition", "", API_KEY);
+    request("delete", "/v1/suites/suite2/definition", "", API_KEY);
+    wait_until([] {
+        return !check_for_path("/v1/suites/suite1/definition") && !check_for_path("/v1/suites/suite2/definition");
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_node_info_aliases) {
+    ECF_NAME_THIS_TEST();
+
+    // Aliases are 'special' children of a Task.
+    //
+    // This test ensures that the traversal of the .../info endpoint reaches aliases, when using 'type=alias' filter
+
+    // Clean up
+    request("delete", "/v1/suites/suiteY/definition", "", API_KEY);
+    wait_until([] { return false == check_for_path("/v1/suites/suiteY/definition"); });
+
+    // Create suite 'suiteY'
+    //       `-- suiteY
+    //         `-- f
+    //           `-- t
+    handle_response(request("post",
+                            "/v1/suites",
+                            R"({"definition" : "suite suiteY\n  family f\n    task t\n  endfamily\nendsuite"})",
+                            API_KEY),
+                    HttpStatusCode::success_created);
+    wait_until([] { return check_for_path("/v1/suites/suiteY/definition"); });
+
+    // Create an alias under the task '/suiteY/f/t' directly on the ecFlow server.
+    //     Note: we use ecFlow Python API to create aliases.
+    {
+        std::string port = ecf::environment::get("ECF_PORT");
+        ClientInvoker client("localhost", port);
+#if defined(ECF_TEST_HTTP_BACKEND)
+        client.enable_http();
+#endif
+        std::vector<std::string> user_file_contents = {"%comment", "%end", "echo \"alias body\""};
+        BOOST_REQUIRE_NO_THROW(client.edit_script_submit(
+            "/suiteY/f/t", NameValueVec{}, user_file_contents, true /* create_alias */, false /* run */));
+    }
+
+    // Wait for the REST server to pick up the newly created alias '/suiteY/f/t/alias0'
+    wait_until([] {
+        try {
+            auto r = handle_response(
+                request("get", "/v1/suites/suiteY/info?recursive=1&type=alias"), HttpStatusCode::success_ok, true);
+            auto content = ojson::parse(r.body);
+            return content.is_array() && !content.empty() && content[0]["path"] == "/suiteY/f/t/alias0";
+        }
+        catch (...) {
+            return false;
+        }
+    });
+
+    // Check recursive=1, must return 4 nodes, including suite + family + task + alias
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteY/info?recursive=1"));
+        auto content = ojson::parse(result.body);
+
+        BOOST_REQUIRE(content.is_array());
+        bool has_alias = false;
+        for (const auto& entry : content) {
+            if (entry["path"] == "/suiteY/f/t/alias0") {
+                has_alias = true;
+            }
+        }
+        BOOST_REQUIRE(has_alias);
+    }
+
+    // Check recursive=1 + type=alias, must return exactly only the alias
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteY/info?recursive=1&type=alias"));
+        auto content = ojson::parse(result.body);
+
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 1);
+        BOOST_REQUIRE(content[0]["path"] == "/suiteY/f/t/alias0");
+    }
+
+    // Check recursive=1 + type=task,alias, must return both the task and its alias
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteY/info?recursive=1&type=task,alias"));
+        auto content = ojson::parse(result.body);
+
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 2);
+        bool has_task = false, has_alias = false;
+        for (const auto& entry : content) {
+            if (entry["path"] == "/suiteY/f/t") {
+                has_task = true;
+            }
+            if (entry["path"] == "/suiteY/f/t/alias0") {
+                has_alias = true;
+            }
+        }
+        BOOST_REQUIRE(has_task);
+        BOOST_REQUIRE(has_alias);
+    }
+
+    // Check that querying the alias node directly (without recursive) returns the alias itself
+    {
+        auto result  = handle_response(request("get", "/v1/suites/suiteY/f/t/alias0/info"));
+        auto content = ojson::parse(result.body);
+
+        BOOST_REQUIRE(content.is_array());
+        BOOST_REQUIRE(content.size() == 1);
+        BOOST_REQUIRE(content[0]["path"] == "/suiteY/f/t/alias0");
+    }
+
+    // Check that aliases are accessible through /v1/suites/info endpoint
+    {
+        auto result  = handle_response(request("get", "/v1/suites/info?recursive=1&type=alias"));
+        auto content = ojson::parse(result.body);
+
+        BOOST_REQUIRE(content.is_array());
+        bool has_alias = false;
+        for (const auto& entry : content) {
+            if (entry["path"] == "/suiteY/f/t/alias0") {
+                has_alias = true;
+            }
+        }
+        BOOST_REQUIRE(has_alias);
+    }
+
+    // Clean up
+    request("delete", "/v1/suites/suiteY/definition", "", API_KEY);
+    wait_until([] { return false == check_for_path("/v1/suites/suiteY/definition"); });
 }
 
 BOOST_AUTO_TEST_CASE(test_token_authentication) {


### PR DESCRIPTION
### Description

As per PR title.

The new endpoint has been requested to allow an optimisation in the implementation of the NEXHub backend, which will be able to access, for example, `.../v1/suites/info?type=family,alias&sort=+state_change_time&count=1` to retrieve the family or alias that have been updated last in the entire server.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-361
<!-- PREVIEW-URL_END -->