### PR TITLE
Suppress Mirror poll messages ECFLOW-2098

### DIFF
--- a/libs/node/src/ecflow/node/MirrorAttr.cpp
+++ b/libs/node/src/ecflow/node/MirrorAttr.cpp
@@ -88,7 +88,7 @@ void MirrorAttr::finish() {
 }
 
 void MirrorAttr::mirror() {
-    SLOG(D, "MirrorAttr: poll Mirror attribute '" << absolute_name() << "'");
+    SLOG(T, "MirrorAttr: poll Mirror attribute '" << absolute_name() << "'");
 
     start_controller();
     if (!controller_) {
@@ -163,7 +163,7 @@ void MirrorAttr::mirror() {
         }
     }
     else {
-        SLOG(D, "MirrorAttr: No notifications found for Mirror attribute (name: " << name_ << ")");
+        SLOG(T, "MirrorAttr: No notifications found for Mirror attribute (name: " << name_ << ")");
     }
 
     // No notifications, nothing to do...

--- a/libs/service/src/ecflow/service/Log.hpp
+++ b/libs/service/src/ecflow/service/Log.hpp
@@ -18,11 +18,13 @@
 #include "ecflow/core/Log.hpp"
 
 // NOLINTBEGIN(bugprone-macro-parentheses)
-#define SLOG(LEVEL, MESSAGE)                                                      \
-    [&]() {                                                                       \
-        using namespace ecf::service::log;                                        \
-        LOG(LevelTraits<Level::LEVEL>::mapping_type,                              \
-            MESSAGE << " {" << LevelTraits<Level::LEVEL>::name << "}" << Meta{}); \
+#define SLOG(LEVEL, MESSAGE)                                                          \
+    [&]() {                                                                           \
+        using namespace ecf::service::log;                                            \
+        if constexpr (LevelTraits<Level::LEVEL>::permitted) {                         \
+            LOG(LevelTraits<Level::LEVEL>::mapping_type,                              \
+                MESSAGE << " {" << LevelTraits<Level::LEVEL>::name << "}" << Meta{}); \
+        }                                                                             \
     }()
 // NOLINTEND(bugprone-macro-parentheses)
 
@@ -30,14 +32,27 @@ namespace ecf::service {
 
 namespace log {
 
-enum class Level { D /*ebug*/, I /*nformation*/, W /*arning*/, E /*rror*/, F /*atal*/ };
+enum class Level { T /*race*/, D /*ebug*/, I /*nformation*/, W /*arning*/, E /*rror*/, F /*atal*/ };
 
 template <Level L>
 struct LevelTraits;
 
 template <>
+struct LevelTraits<Level::T>
+{
+#if defined(NDEBUG)
+    static constexpr bool permitted = false;
+#else
+    static constexpr bool permitted = true; // Only Debug builds log "Trace messages
+#endif
+    static constexpr const char* name               = "T";
+    static constexpr ecf::Log::LogType mapping_type = ecf::Log::LogType::DBG;
+};
+
+template <>
 struct LevelTraits<Level::D>
 {
+    static constexpr bool permitted                 = true;
     static constexpr const char* name               = "D";
     static constexpr ecf::Log::LogType mapping_type = ecf::Log::LogType::DBG;
 };
@@ -45,6 +60,7 @@ struct LevelTraits<Level::D>
 template <>
 struct LevelTraits<Level::I>
 {
+    static constexpr bool permitted                 = true;
     static constexpr const char* name               = "I";
     static constexpr ecf::Log::LogType mapping_type = ecf::Log::LogType::LOG;
 };
@@ -52,6 +68,7 @@ struct LevelTraits<Level::I>
 template <>
 struct LevelTraits<Level::W>
 {
+    static constexpr bool permitted                 = true;
     static constexpr const char* name               = "W";
     static constexpr ecf::Log::LogType mapping_type = ecf::Log::LogType::WAR;
 };
@@ -59,6 +76,7 @@ struct LevelTraits<Level::W>
 template <>
 struct LevelTraits<Level::E>
 {
+    static constexpr bool permitted                 = true;
     static constexpr const char* name               = "E";
     static constexpr ecf::Log::LogType mapping_type = ecf::Log::LogType::ERR;
 };
@@ -66,6 +84,7 @@ struct LevelTraits<Level::E>
 template <>
 struct LevelTraits<Level::F>
 {
+    static constexpr bool permitted                 = true;
     static constexpr const char* name               = "F";
     static constexpr ecf::Log::LogType mapping_type = ecf::Log::LogType::ERR;
 };


### PR DESCRIPTION
### Description

As per PR title.

These debug messages happen every second, within the ecflow server internal loop, and are considered too noisy.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-364
<!-- PREVIEW-URL_END -->