### PR TITLE
Enable propagation of Mirror'ed node state

### DIFF
--- a/Viewer/ecflowUI/src/VMirrorAttr.cpp
+++ b/Viewer/ecflowUI/src/VMirrorAttr.cpp
@@ -20,7 +20,7 @@
 
 VMirrorAttrType::VMirrorAttrType()
     : VAttributeType("mirror") {
-    dataCount_                             = 9;
+    dataCount_                             = 10;
     searchKeyToData_["mirror_name"]        = NameIndex;
     searchKeyToData_["mirror_remote_path"] = RemotePathIndex;
     searchKeyToData_["mirror_remote_host"] = RemoteHostIndex;
@@ -38,10 +38,11 @@ QString VMirrorAttrType::toolTip(QStringList d) const {
         t += "<b>Remote Port:</b> " + d[RemotePortIndex] + "<br>";
         t += "<b>Polling:</b> " + d[PollingIndex] + "<br>";
         t += "<b>SSL:</b> " + d[SslIndex] + "<br>";
-        t += "<b>Auth:</b> " + d[AuthIndex];
+        t += "<b>Auth:</b> " + d[AuthIndex] + "<br>";
         if (const auto& reason = d[ReasonIndex]; !reason.isEmpty()) {
-            t += "<br><b>Reason:</b> <span style=\"color:red\">" + d[ReasonIndex] + "</span>";
+            t += "<br><b>Reason:</b> <span style=\"color:red\">" + d[ReasonIndex] + "</span><br>";
         }
+        t += "<b>Propagate:</b> " + d[PropagateIndex];
     }
     return t;
 }
@@ -57,15 +58,16 @@ QString VMirrorAttrType::definition(QStringList d) const {
 
 void VMirrorAttrType::encode(const ecf::MirrorAttr& mirror, QStringList& data, bool firstLine) const {
 
-    data << qName_                                                  // TypeIndex
-         << QString::fromStdString(mirror.name())                   // NameIndex
-         << QString::fromStdString(mirror.remote_path())            // RemotePathIndex
-         << QString::fromStdString(mirror.remote_host())            // RemoteHostIndex
-         << QString::fromStdString(mirror.remote_port())            // RemotePortIndex
-         << QString::fromStdString(mirror.polling())                // PollingIndex
-         << QString::fromStdString(mirror.ssl() ? "true" : "false") // SslIndex
-         << QString::fromStdString(mirror.auth())                   // AuthIndex
-         << QString::fromStdString(mirror.reason());                // ReasonIndex
+    data << qName_                                                         // TypeIndex
+         << QString::fromStdString(mirror.name())                          // NameIndex
+         << QString::fromStdString(mirror.remote_path())                   // RemotePathIndex
+         << QString::fromStdString(mirror.remote_host())                   // RemoteHostIndex
+         << QString::fromStdString(mirror.remote_port())                   // RemotePortIndex
+         << QString::fromStdString(mirror.polling())                       // PollingIndex
+         << QString::fromStdString(mirror.ssl() ? "true" : "false")        // SslIndex
+         << QString::fromStdString(mirror.auth())                          // AuthIndex
+         << QString::fromStdString(mirror.reason())                        // ReasonIndex
+         << QString::fromStdString(mirror.propagate() ? "true" : "false"); // PropagateIndex
 }
 
 void VMirrorAttrType::encode_empty(QStringList& data) const {

--- a/Viewer/ecflowUI/src/VMirrorAttr.hpp
+++ b/Viewer/ecflowUI/src/VMirrorAttr.hpp
@@ -45,7 +45,8 @@ private:
         PollingIndex    = 5,
         SslIndex        = 6,
         AuthIndex       = 7,
-        ReasonIndex     = 8
+        ReasonIndex     = 8,
+        PropagateIndex  = 9
     };
 };
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -1689,7 +1689,7 @@ Glossary
         as this may lead to undesired behaviour, including deadlocks.
 
       `Only one mirror attribute is allowed per node`, and each attribute is
-      defined by the following properties:
+      defined by the following options:
 
         - :code:`name`, an identifier
         - :code:`remote_path`, the path of the node on the remote ecFlow server
@@ -1698,6 +1698,7 @@ Glossary
         - :code:`ssl`, to connect to the ecFlow server using SSL
         - :code:`polling`, the value (in seconds) used to periodically contact the remote ecFlow server
         - :code:`auth`, the location to the Mirror authentication credentials file
+        - :code:`propagate`, to enable the propagation of the remote node state up the tree of local nodes
 
       .. warning::
 

--- a/docs/python_api/reference/MirrorAttr.rst
+++ b/docs/python_api/reference/MirrorAttr.rst
@@ -52,7 +52,7 @@ Returns the name of the Mirror attribute
 .. py:method:: MirrorAttr.polling(self: ecflow.MirrorAttr) -> str
    :module: ecflow
 
-Returns the polling interval used to contact the remove ecFlow server
+Returns the polling interval used to contact the remote ecFlow server
 
 
 .. py:method:: MirrorAttr.propagate(self: ecflow.MirrorAttr) -> bool

--- a/docs/python_api/reference/MirrorAttr.rst
+++ b/docs/python_api/reference/MirrorAttr.rst
@@ -55,6 +55,12 @@ Returns the name of the Mirror attribute
 Returns the polling interval used to contact the remove ecFlow server
 
 
+.. py:method:: MirrorAttr.propagate(self: ecflow.MirrorAttr) -> bool
+   :module: ecflow
+
+Returns a boolean, where true means the Node state is propagated up the Node tree
+
+
 .. py:method:: MirrorAttr.remote_host(self: ecflow.MirrorAttr) -> str
    :module: ecflow
 

--- a/docs/ug/cookbook/how_to_mirror_a_remote_task.rst
+++ b/docs/ug/cookbook/how_to_mirror_a_remote_task.rst
@@ -68,6 +68,17 @@ at :term:`suite` level:
      Variables that are referred in trigger expressions *must* be defined, as a placeholder
      for variables that eventually get synchronised.
 
+  .. note::
+
+     By default, only the mirrored task's own state is updated; parent families and triggers
+     are unaffected. To propagate the mirrored state up the local node tree and cause dependent
+     triggers to fire, add the ``--propagate`` option::
+
+         mirror --name A --remote_path /s1/f1/t1 ... --ssl --propagate
+
+     Use ``--propagate`` only when you explicitly want state changes on the mirrored task to
+     drive the evaluation of triggers on its parent families.
+
 Deploy the Suite with a `mirrored` Task
 =======================================
 

--- a/docs/ug/user_manual/text_based_suite_definition/external/mirror.rst
+++ b/docs/ug/user_manual/text_based_suite_definition/external/mirror.rst
@@ -7,10 +7,15 @@ This defines a :term:`mirror` attribute, which synchronizes the status of a
 :term:`node` between a local and a remote ecFlow server. The options defining
 the attribute can be provided in any order.
 
+The :term:`mirror` attribute is defined by the coordinates to the remote :term:`node` to be mirrored, including the
+remote :term:`node` path, the remote host name, the remote port number; and the polling interval in seconds.
+Furthermore, the option :code:`--ssl` enables the use of a Secure connection and the option :code:`--auth` can be used
+to provide the authentication credentials for the remote ecFlow server.
+
 .. code-block:: shell
 
     task t1
-      mirror --name A --remote_path /s/f/tA --remote_host host --remote_port 3141 --polling 20 --ssl --auth /path/to/auth.json
+      mirror --name A --remote_path /s/f/tA --remote_host host --remote_port 3141 --polling 300 --ssl --auth /path/to/auth.json
 
     task t2
       aviso --name B --remote_path /s/f/tB
@@ -19,6 +24,25 @@ the attribute can be provided in any order.
         #     --remote_port %ECF_MIRROR_REMOTE_PORT%
         #     --polling %ECF_MIRROR_POLLING%
         #     --auth %ECF_MIRROR_AUTH%
+
+
+By default, the :term:`mirror` attribute will not propagate the state of the remote :term:`node` to the local node tree,
+and only the actual associated local :term:`node` will see its state updated.
+The option :code:`--propagate` can be used to enable the propagation of the remote :term:`node` state to the local node
+tree.
+
+.. code-block:: shell
+
+    task t1
+      mirror --name A --remote_path /s/f/tA --remote_host host --remote_port 3141 --polling 300 --propagate
+
+
+.. note::
+   The ``--polling`` value (in seconds) controls how often the local ecFlow
+   server contacts the remote server. Lower values reduce latency but
+   have impact on the remote server as the network traffic increases.
+   A value of 300 seconds is considered suitable for most cases, and a minimum
+   of 60 seconds being imposed to avoid overloading the remote server.
 
 The Authentication credentials, provided via option :code:`--auth`, are
 provided in a `JSON` file with the following content:

--- a/libs/node/CMakeLists.txt
+++ b/libs/node/CMakeLists.txt
@@ -36,6 +36,7 @@ set(test_srcs
   test/TestJobProfiler.cpp
   test/TestLimit.cpp
   test/TestMigration.cpp
+  test/TestMirrorAttr.cpp
   test/TestMissNextTimeSlot.cpp
   test/TestMovePeer.cpp
   test/TestNodeAlgorithms.cpp

--- a/libs/node/src/ecflow/node/MirrorAttr.cpp
+++ b/libs/node/src/ecflow/node/MirrorAttr.cpp
@@ -115,7 +115,7 @@ void MirrorAttr::mirror() {
 
                                      SLOG(T,
                                           "MirrorAttr: Sync Mirror '"
-                                              << absolute_name() << "' to {path: '" << remote_path_ << "', host: '"
+                                              << absolute_name() << "' with {path: '" << remote_path_ << "', host: '"
                                               << remote_host_ << "', port: '" << remote_port_ << "', ssl: '" << ssl_
                                               << "'} to state '" << latest_state_name << "'");
 

--- a/libs/node/src/ecflow/node/MirrorAttr.cpp
+++ b/libs/node/src/ecflow/node/MirrorAttr.cpp
@@ -61,7 +61,12 @@ MirrorAttr::~MirrorAttr() {
 }
 
 std::string MirrorAttr::absolute_name() const {
-    return parent_->absNodePath() + ':' + name_;
+    if (parent_) {
+        return parent_->absNodePath() + ':' + name_;
+    }
+    else {
+        return "<undetermined>:" + name_;
+    }
 }
 
 bool MirrorAttr::why(std::string& theReasonWhy) const {
@@ -103,11 +108,14 @@ void MirrorAttr::mirror() {
 
         // Notifications found -- Node state to be updated or error to be reported
         std::visit(ecf::overload{[this](const service::mirror::MirrorNotification& notification) {
-                                     auto latest_state = static_cast<NState::State>(notification.data().state);
+                                     auto latest_state      = static_cast<NState::State>(notification.data().state);
+                                     auto latest_state_name = NState::toString(latest_state);
 
-                                     SLOG(D,
-                                          "MirrorAttr: Updating Mirror attribute (name: " << name_ << ") to state "
-                                                                                          << latest_state);
+                                     SLOG(T,
+                                          "MirrorAttr: Sync Mirror '"
+                                              << absolute_name() << "' to {path: '" << remote_path_ << "', host: '"
+                                              << remote_host_ << "', port: '" << remote_port_ << "', ssl: '" << ssl_
+                                              << "'} to state '" << latest_state_name << "'");
 
                                      // ** Node State
                                      reason_ = "";
@@ -134,7 +142,7 @@ void MirrorAttr::mirror() {
                                      parent_->replace_events(notification.data().events);
                                  },
                                  [this](const service::mirror::MirrorError& error) {
-                                     SLOG(D,
+                                     SLOG(T,
                                           "MirrorAttr: Failure detected on Mirror attribute (name: "
                                               << name_ << ") due to " << error.reason());
                                      reason_ = error.reason();
@@ -227,7 +235,7 @@ void MirrorAttr::start_controller() {
         auto polling     = resolve_cfg(polling_, default_polling, fallback_polling);
         auto auth        = resolve_cfg(auth_, default_remote_auth, fallback_remote_auth);
 
-        SLOG(D,
+        SLOG(T,
              "MirrorAttr: start polling Mirror attribute '" << absolute_name() << "', from " << remote_path_ << " @ "
                                                             << remote_host << ':' << remote_port
                                                             << ") using polling: " << polling << " s");
@@ -251,8 +259,8 @@ void MirrorAttr::start_controller() {
 
         // Controller -- start up the Mirror controller, and configure the Mirror request
         controller_ = std::make_shared<controller_t>();
-        controller_->subscribe(
-            ecf::service::mirror::MirrorRequest{remote_path_, remote_host, remote_port, polling_value, ssl_, auth});
+        controller_->subscribe(ecf::service::mirror::MirrorRequest{
+            absolute_name(), remote_path_, remote_host, remote_port, polling_value, ssl_, auth});
         // Controller -- effectively start the Mirror process
         // n.b. this must be done after subscribing in the controller, so that the polling interval is set
         controller_->start();
@@ -261,7 +269,7 @@ void MirrorAttr::start_controller() {
 
 void MirrorAttr::stop_controller() {
     if (controller_) {
-        SLOG(D,
+        SLOG(T,
              "MirrorAttr: finishing polling for Mirror attribute \"" << parent_->absNodePath() << ":" << name_
                                                                      << "\", from host: " << remote_host_
                                                                      << ", port: " << remote_port_ << ")");

--- a/libs/node/src/ecflow/node/MirrorAttr.cpp
+++ b/libs/node/src/ecflow/node/MirrorAttr.cpp
@@ -33,7 +33,8 @@ MirrorAttr::MirrorAttr(Node* parent,
                        polling_t polling,
                        flag_t ssl,
                        auth_t auth,
-                       reason_t reason)
+                       reason_t reason,
+                       flag_t propagate)
     : parent_{parent},
       name_{std::move(name)},
       remote_path_{std::move(remote_path)},
@@ -43,6 +44,7 @@ MirrorAttr::MirrorAttr(Node* parent,
       ssl_{ssl},
       auth_{std::move(auth)},
       reason_{std::move(reason)},
+      propagate_{propagate},
       controller_{nullptr} {
     if (!is_valid_name(name_)) {
         throw ecf::InvalidArgument(ecf::Message("Invalid MirrorAttr name :", name_));
@@ -65,7 +67,7 @@ std::string MirrorAttr::absolute_name() const {
         return parent_->absNodePath() + ':' + name_;
     }
     else {
-        return "<undetermined>:" + name_;
+        return "(detached):" + name_;
     }
 }
 
@@ -122,6 +124,9 @@ void MirrorAttr::mirror() {
                                      parent_->get_flag().clear(Flag::REMOTE_ERROR);
                                      parent_->get_flag().set_state_change_no(state_change_no_);
                                      parent_->setStateOnly(latest_state, true);
+                                     if (propagate_) {
+                                         parent_->set_most_significant_state_up_node_tree();
+                                     }
 
                                      // ** Node Variables
                                      std::vector<Variable> all_variables = notification.data().regular_variables;
@@ -270,9 +275,8 @@ void MirrorAttr::start_controller() {
 void MirrorAttr::stop_controller() {
     if (controller_) {
         SLOG(T,
-             "MirrorAttr: finishing polling for Mirror attribute \"" << parent_->absNodePath() << ":" << name_
-                                                                     << "\", from host: " << remote_host_
-                                                                     << ", port: " << remote_port_ << ")");
+             "MirrorAttr: finishing polling for Mirror attribute \""
+                 << absolute_name() << "\", from host: " << remote_host_ << ", port: " << remote_port_ << ")");
 
         controller_->stop();
         controller_.reset();
@@ -283,7 +287,7 @@ bool operator==(const MirrorAttr& lhs, const MirrorAttr& rhs) {
     return lhs.name() == rhs.name() && lhs.remote_path() == rhs.remote_path() &&
            lhs.remote_host() == rhs.remote_host() && lhs.remote_port() == rhs.remote_port() &&
            lhs.polling() == rhs.polling() && lhs.ssl() == rhs.ssl() && lhs.auth() == rhs.auth() &&
-           lhs.reason() == rhs.reason();
+           lhs.reason() == rhs.reason() && lhs.propagate() == rhs.propagate();
 }
 
 std::string to_python_string(const MirrorAttr& mirror) {
@@ -300,7 +304,9 @@ std::string to_python_string(const MirrorAttr& mirror) {
     s += ", polling=";
     s += mirror.polling();
     s += ", ssl=";
-    s += mirror.ssl();
+    s += mirror.ssl() ? "1" : "0";
+    s += ", propagate=";
+    s += mirror.propagate() ? "1" : "0";
     s += ", auth=";
     s += mirror.auth();
     s += ", reason=";

--- a/libs/node/src/ecflow/node/MirrorAttr.hpp
+++ b/libs/node/src/ecflow/node/MirrorAttr.hpp
@@ -52,6 +52,7 @@ public:
     static constexpr const char* default_remote_auth = "%ECF_MIRROR_REMOTE_AUTH%";
 
     // Fallback option values, used when the variables providing default values are not defined
+    static constexpr const char* fallback_remote_host = "localhost";
     static constexpr const char* fallback_remote_port = "3141";
     static constexpr const char* fallback_polling     = "120";
     static constexpr const char* fallback_remote_auth = "";
@@ -98,7 +99,7 @@ public:
     [[nodiscard]] inline flag_t propagate() const { return propagate_; }
 
     [[nodiscard]] inline std::string resolved_remote_host() const {
-        return resolve_cfg(remote_host_, default_remote_host, fallback_remote_port);
+        return resolve_cfg(remote_host_, default_remote_host, fallback_remote_host);
     }
     [[nodiscard]] inline std::string resolved_remote_port() const {
         return resolve_cfg(remote_port_, default_remote_port, fallback_remote_port);

--- a/libs/node/src/ecflow/node/MirrorAttr.hpp
+++ b/libs/node/src/ecflow/node/MirrorAttr.hpp
@@ -17,12 +17,9 @@
 #include <string>
 
 #include "ecflow/core/Log.hpp"
+#include "ecflow/core/Serialization.hpp"
 #include "ecflow/core/Str.hpp"
 #include "ecflow/service/mirror/MirrorService.hpp"
-
-namespace cereal {
-class access;
-}
 
 class Node;
 
@@ -78,7 +75,8 @@ public:
                polling_t polling,
                flag_t ssl,
                auth_t auth,
-               reason_t reason);
+               reason_t reason,
+               flag_t propagate);
 
     MirrorAttr(const MirrorAttr& rhs) = default;
     ~MirrorAttr();
@@ -97,6 +95,7 @@ public:
     [[nodiscard]] inline flag_t ssl() const { return ssl_; }
     [[nodiscard]] inline const std::string& auth() const { return auth_; }
     [[nodiscard]] inline const std::string& reason() const { return reason_; }
+    [[nodiscard]] inline flag_t propagate() const { return propagate_; }
 
     [[nodiscard]] inline std::string resolved_remote_host() const {
         return resolve_cfg(remote_host_, default_remote_host, fallback_remote_port);
@@ -146,9 +145,10 @@ private:
     remote_host_t remote_host_;
     remote_port_t remote_port_;
     polling_t polling_;
-    flag_t ssl_;
+    flag_t ssl_ = false;
     auth_t auth_;
     reason_t reason_;
+    flag_t propagate_ = false;
 
     unsigned int state_change_no_{0}; // *not* persisted, only used on the server side
 
@@ -171,8 +171,13 @@ void serialize(Archive& ar, MirrorAttr& mirror, [[maybe_unused]] std::uint32_t v
     ar & mirror.ssl_;
     ar & mirror.auth_;
     ar & mirror.reason_;
+    if (version >= 1) {
+        ar & mirror.propagate_;
+    }
 }
 
 } // namespace ecf
+
+CEREAL_CLASS_VERSION(ecf::MirrorAttr, 1);
 
 #endif /* ecflow_node_MirrorAttr_HPP */

--- a/libs/node/src/ecflow/node/formatter/MirrorFormatter.hpp
+++ b/libs/node/src/ecflow/node/formatter/MirrorFormatter.hpp
@@ -50,6 +50,9 @@ struct Formatter<MirrorAttr, Stream>
             output << " --reason ";
             output << item.reason();
         }
+        if (item.propagate()) {
+            output << " --propagate";
+        }
     }
 };
 

--- a/libs/node/src/ecflow/node/parser/MirrorParser.cpp
+++ b/libs/node/src/ecflow/node/parser/MirrorParser.cpp
@@ -79,6 +79,7 @@ ecf::MirrorAttr MirrorParser::parse_mirror_line(const std::string& line, Node* p
     description.add_options()(option_remote_auth,
                               po::value<std::string>()->default_value(ecf::MirrorAttr::default_remote_auth));
     description.add_options()(option_reason, po::value<std::string>()->default_value(""));
+    description.add_options()(option_propagate, "Propagate State up the node tree");
 
     po::parsed_options parsed_options = po::command_line_parser(tokens).options(description).run();
 
@@ -94,8 +95,9 @@ ecf::MirrorAttr MirrorParser::parse_mirror_line(const std::string& line, Node* p
     auto ssl         = get_option_value<ecf::MirrorAttr::flag_t>(vm, option_ssl, line);
     auto auth        = get_option_value<ecf::MirrorAttr::auth_t>(vm, option_remote_auth, line);
     auto reason      = get_option_value<ecf::MirrorAttr::reason_t>(vm, option_reason, line);
+    auto propagate   = get_option_value<ecf::MirrorAttr::flag_t>(vm, option_propagate, line);
 
-    return ecf::MirrorAttr{parent, name, ecflow_path, ecflow_host, ecflow_port, polling, ssl, auth, reason};
+    return ecf::MirrorAttr{parent, name, ecflow_path, ecflow_host, ecflow_port, polling, ssl, auth, reason, propagate};
 }
 
 bool MirrorParser::doParse(const std::string& line, std::vector<std::string>& lineTokens) {

--- a/libs/node/src/ecflow/node/parser/MirrorParser.hpp
+++ b/libs/node/src/ecflow/node/parser/MirrorParser.hpp
@@ -45,6 +45,7 @@ public:
     static constexpr const char* option_ssl         = "ssl";
     static constexpr const char* option_remote_auth = "remote_auth";
     static constexpr const char* option_reason      = "reason";
+    static constexpr const char* option_propagate   = "propagate";
 
     static ecf::MirrorAttr parse_mirror_line(const std::string& line);
     static ecf::MirrorAttr parse_mirror_line(const std::string& line, const std::string& name);

--- a/libs/node/test/TestMirrorAttr.cpp
+++ b/libs/node/test/TestMirrorAttr.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2009- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include "ecflow/node/Defs.hpp"
+#include "ecflow/node/InLimit.hpp"
+#include "ecflow/node/Limit.hpp"
+#include "ecflow/node/Suite.hpp"
+#include "ecflow/node/System.hpp"
+#include "ecflow/node/parser/DefsStructureParser.hpp"
+#include "ecflow/test/scaffold/Naming.hpp"
+
+BOOST_AUTO_TEST_SUITE(U_Node)
+
+BOOST_AUTO_TEST_SUITE(T_MirrorAttr)
+
+BOOST_AUTO_TEST_CASE(mirror_propagate_updates_parent_state) {
+    ECF_NAME_THIS_TEST();
+
+    using namespace ecf;
+
+    //
+    // This test does not exercise Mirror attribute itself.
+    //
+    // Instead it ensures that the `propagate` option on MirrorAttr correctly updates the
+    // parent node state when the mirrored task transitions to COMPLETE.
+    //
+    // Since the mirrored task does not actually run locally,
+    // this essentially exercises the following calling the sequence
+    // to ensure that limits are not consumed/released.
+    //
+    //    task->setStateOnly(...)
+    //    task->set_most_significant_state_up_node_tree(...)
+    //
+
+    std::string definition = R"(
+        suite s1
+          limit slot 3
+          family f1
+            task t1
+              inlimit slot 1
+          endfamily
+        endsuite
+    )";
+
+    Defs defs;
+    DefsStructureParser parser(&defs, definition, true);
+
+    std::string errorMsg, warningMsg;
+    bool parsedOK = parser.doParse(errorMsg, warningMsg);
+    BOOST_CHECK_MESSAGE(parsedOK, "Failed to parse definition: " << errorMsg);
+
+    auto s = defs.findAbsNode("/s1");
+    auto f = defs.findAbsNode("/s1/f1");
+    auto t = defs.findAbsNode("/s1/f1/t1");
+
+    defs.beginAll(); // all nodes → QUEUED
+
+    auto l = s->find_limit("slot");
+    BOOST_REQUIRE(l);
+    BOOST_CHECK_EQUAL(l->value(), 0); // limit starts "empty"
+
+    // --- Ensure setStateOnly() must NOT call update_limits()
+    //
+    t->setStateOnly(NState::SUBMITTED, true);
+    BOOST_CHECK_EQUAL(l->value(), 0);
+    t->setStateOnly(NState::COMPLETE, true);
+    BOOST_CHECK_EQUAL(l->value(), 0);
+
+    // --- Ensure set_most_significant_state_up_node_tree() propagates to parent
+    //
+    BOOST_CHECK_NE(f->state(), NState::COMPLETE);
+    t->set_most_significant_state_up_node_tree();
+    BOOST_CHECK_EQUAL(f->state(), NState::COMPLETE);
+
+    // --- Ensure set_state() DOES call update_limits()
+    //
+    // This *negative* test proves WHY `set_state(...)` cannot be used (i.e. incorrectly updates limits),
+    // and calling `setStateOnly(...)`+`set_most_significant_state_up_node_tree(...)` actually works
+    f->setStateOnly(NState::QUEUED);
+    t->setStateOnly(NState::QUEUED, true);
+    l->reset();
+    BOOST_CHECK_EQUAL(l->value(), 0);
+
+    t->set_state(NState::SUBMITTED);
+    BOOST_CHECK_EQUAL(l->value(), 1); // This represents the incorrect behaviour!
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/libs/node/test/parser/TestMirrorAttr.cpp
+++ b/libs/node/test/parser/TestMirrorAttr.cpp
@@ -13,10 +13,12 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "ecflow/core/PrintStyle.hpp"
 #include "ecflow/node/Defs.hpp"
 #include "ecflow/node/Family.hpp"
 #include "ecflow/node/MirrorAttr.hpp"
 #include "ecflow/node/Task.hpp"
+#include "ecflow/node/formatter/DefsWriter.hpp"
 #include "ecflow/node/parser/DefsStructureParser.hpp"
 #include "ecflow/test/scaffold/Naming.hpp"
 
@@ -63,6 +65,7 @@ BOOST_AUTO_TEST_CASE(can_parse_mirror_attribute_on_task_with_default_parameters)
     BOOST_CHECK_EQUAL(mirror.remote_port(), "%ECF_MIRROR_REMOTE_PORT%");
     BOOST_CHECK_EQUAL(mirror.polling(), "%ECF_MIRROR_REMOTE_POLLING%");
     BOOST_CHECK_EQUAL(mirror.ssl(), false);
+    BOOST_CHECK_EQUAL(mirror.propagate(), false);
 }
 
 BOOST_AUTO_TEST_CASE(can_parse_mirror_attribute_on_task_with_all_attributes) {
@@ -104,6 +107,177 @@ BOOST_AUTO_TEST_CASE(can_parse_mirror_attribute_on_task_with_all_attributes) {
     BOOST_CHECK_EQUAL(mirror.remote_port(), "1234");
     BOOST_CHECK_EQUAL(mirror.polling(), "20");
     BOOST_CHECK_EQUAL(mirror.ssl(), true);
+    BOOST_CHECK_EQUAL(mirror.propagate(), false);
+}
+
+BOOST_AUTO_TEST_CASE(can_parse_mirror_attribute_on_task_with_ssl_and_propagate) {
+    ECF_NAME_THIS_TEST();
+
+    using namespace ecf;
+
+    std::string definition = R"(
+        suite s1
+          family f1
+            task t1
+              mirror --name A --remote_path /s1/f1/t2 --remote_host hostname --remote_port 1234 --polling 20 --ssl --propagate
+          endfamily
+    )";
+
+    Defs defs;
+    DefsStructureParser parser(&defs, definition, true);
+
+    std::string errorMsg, warningMsg;
+    bool parsedOK = parser.doParse(errorMsg, warningMsg);
+    BOOST_CHECK_MESSAGE(parsedOK, "Failed to parse definition: " << errorMsg);
+
+    const auto& suites = defs.suites();
+    BOOST_CHECK_EQUAL(suites.size(), static_cast<size_t>(1));
+
+    const auto& families = suites[0]->familyVec();
+    BOOST_CHECK_EQUAL(families.size(), static_cast<size_t>(1));
+
+    const auto& tasks = families[0]->taskVec();
+    BOOST_CHECK_EQUAL(tasks.size(), static_cast<size_t>(1));
+
+    const auto& mirrors = tasks[0]->mirrors();
+    BOOST_CHECK_EQUAL(mirrors.size(), static_cast<size_t>(1));
+
+    const auto& mirror = mirrors[0];
+    BOOST_CHECK_EQUAL(mirror.name(), "A");
+    BOOST_CHECK_EQUAL(mirror.remote_path(), "/s1/f1/t2");
+    BOOST_CHECK_EQUAL(mirror.remote_host(), "hostname");
+    BOOST_CHECK_EQUAL(mirror.remote_port(), "1234");
+    BOOST_CHECK_EQUAL(mirror.polling(), "20");
+    BOOST_CHECK_EQUAL(mirror.ssl(), true);
+    BOOST_CHECK_EQUAL(mirror.propagate(), true);
+}
+
+BOOST_AUTO_TEST_CASE(can_roundtrip_serialise_mirror_preserving_propagate_option) {
+    ECF_NAME_THIS_TEST();
+
+    using namespace ecf;
+
+    {
+        MirrorAttr original{nullptr, "A", "/s/f/t", "host", "1234", "20", true, "auth", "", true};
+        std::string data;
+        ecf::save_as_string(data, original);
+
+        MirrorAttr restored;
+        ecf::restore_from_string(data, restored);
+
+        BOOST_CHECK_EQUAL(restored.name(), "A");
+        BOOST_CHECK_EQUAL(restored.remote_path(), "/s/f/t");
+        BOOST_CHECK_EQUAL(restored.ssl(), true);
+        BOOST_CHECK_EQUAL(restored.propagate(), true);
+    }
+
+    {
+        MirrorAttr original{nullptr, "B", "/s/f/t", "host", "1234", "20", false, "auth", "", false};
+        std::string data;
+        ecf::save_as_string(data, original);
+
+        MirrorAttr restored;
+        ecf::restore_from_string(data, restored);
+
+        BOOST_CHECK_EQUAL(restored.propagate(), false);
+    }
+}
+
+namespace legacy {
+
+struct MirrorAttrV0
+{
+    // This is MirrorAttr V0, which does *not* carry the `propagate_` field.
+    // The absence of CEREAL_CLASS_VERSION means the archive is stamped with version 0.
+
+    std::string name;
+    std::string remote_path;
+    std::string remote_host;
+    std::string remote_port;
+    std::string polling;
+    bool ssl = false;
+    std::string auth;
+    std::string reason;
+
+    template <class Archive>
+    void serialize(Archive& ar, std::uint32_t const /*version*/) {
+        ar & name;
+        ar & remote_path;
+        ar & remote_host;
+        ar & remote_port;
+        ar & polling;
+        ar & ssl;
+        ar & auth;
+        ar & reason;
+    }
+};
+
+} // namespace legacy
+
+BOOST_AUTO_TEST_CASE(can_deserialise_mirror_v0_with_propagate_defaulting_to_false) {
+    ECF_NAME_THIS_TEST();
+
+    using namespace ecf;
+
+    legacy::MirrorAttrV0 legacy;
+    legacy.name        = "A";
+    legacy.remote_path = "/s/f/t";
+    legacy.remote_host = "host";
+    legacy.remote_port = "1234";
+    legacy.polling     = "20";
+    legacy.ssl         = true;
+    legacy.auth        = "auth";
+    legacy.reason      = "";
+
+    std::string data;
+    ecf::save_as_string(data, legacy);
+
+    MirrorAttr restored;
+    ecf::restore_from_string(data, restored);
+
+    // Fields present in v0 are restored as expected...
+    BOOST_CHECK_EQUAL(restored.name(), "A");
+    BOOST_CHECK_EQUAL(restored.remote_path(), "/s/f/t");
+    BOOST_CHECK_EQUAL(restored.ssl(), true);
+    // ...and the absent `propagate` field defaults deterministically to false (rather than an indeterminate value)
+    BOOST_CHECK_EQUAL(restored.propagate(), false);
+}
+
+BOOST_AUTO_TEST_CASE(can_roundtrip_print_parse_mirror_preserving_propagate_option) {
+    ECF_NAME_THIS_TEST();
+
+    using namespace ecf;
+
+    std::string definition = R"(
+        suite s1
+          family f1
+            task t1
+              mirror --name A --remote_path /s1/f1/t2 --remote_host hostname --remote_port 1234 --polling 20 --ssl --propagate
+          endfamily
+    )";
+
+    Defs defs;
+    DefsStructureParser parser(&defs, definition, true);
+
+    std::string errorMsg, warningMsg;
+    BOOST_REQUIRE_MESSAGE(parser.doParse(errorMsg, warningMsg), "Failed to parse definition: " << errorMsg);
+
+    // Print the in-memory defs back to the text definition format...
+    std::string printed = ecf::as_string(defs, PrintStyle::DEFS);
+    BOOST_CHECK_MESSAGE(printed.find("--propagate") != std::string::npos,
+                        "Expected '--propagate' in printed defs:\n"
+                            << printed);
+
+    // ...and re-parse it, ensuring the `propagate` flag survives the print/parse round-trip
+    Defs reparsed;
+    DefsStructureParser reparser(&reparsed, printed, true);
+    BOOST_REQUIRE_MESSAGE(reparser.doParse(errorMsg, warningMsg),
+                          "Failed to re-parse printed definition: " << errorMsg << "\n"
+                                                                    << printed);
+
+    const auto& mirror = reparsed.suites()[0]->familyVec()[0]->taskVec()[0]->mirrors()[0];
+    BOOST_CHECK_EQUAL(mirror.ssl(), true);
+    BOOST_CHECK_EQUAL(mirror.propagate(), true);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/node/test/parser/TestMirrorAttr.cpp
+++ b/libs/node/test/parser/TestMirrorAttr.cpp
@@ -167,7 +167,12 @@ BOOST_AUTO_TEST_CASE(can_roundtrip_serialise_mirror_preserving_propagate_option)
 
         BOOST_CHECK_EQUAL(restored.name(), "A");
         BOOST_CHECK_EQUAL(restored.remote_path(), "/s/f/t");
+        BOOST_CHECK_EQUAL(restored.remote_host(), "host");
+        BOOST_CHECK_EQUAL(restored.remote_port(), "1234");
+        BOOST_CHECK_EQUAL(restored.polling(), "20");
         BOOST_CHECK_EQUAL(restored.ssl(), true);
+        BOOST_CHECK_EQUAL(restored.auth(), "auth");
+        BOOST_CHECK_EQUAL(restored.reason(), "");
         BOOST_CHECK_EQUAL(restored.propagate(), true);
     }
 
@@ -179,6 +184,14 @@ BOOST_AUTO_TEST_CASE(can_roundtrip_serialise_mirror_preserving_propagate_option)
         MirrorAttr restored;
         ecf::restore_from_string(data, restored);
 
+        BOOST_CHECK_EQUAL(restored.name(), "B");
+        BOOST_CHECK_EQUAL(restored.remote_path(), "/s/f/t");
+        BOOST_CHECK_EQUAL(restored.remote_host(), "host");
+        BOOST_CHECK_EQUAL(restored.remote_port(), "1234");
+        BOOST_CHECK_EQUAL(restored.polling(), "20");
+        BOOST_CHECK_EQUAL(restored.ssl(), false);
+        BOOST_CHECK_EQUAL(restored.auth(), "auth");
+        BOOST_CHECK_EQUAL(restored.reason(), "");
         BOOST_CHECK_EQUAL(restored.propagate(), false);
     }
 }
@@ -238,7 +251,12 @@ BOOST_AUTO_TEST_CASE(can_deserialise_mirror_v0_with_propagate_defaulting_to_fals
     // Fields present in v0 are restored as expected...
     BOOST_CHECK_EQUAL(restored.name(), "A");
     BOOST_CHECK_EQUAL(restored.remote_path(), "/s/f/t");
+    BOOST_CHECK_EQUAL(restored.remote_host(), "host");
+    BOOST_CHECK_EQUAL(restored.remote_port(), "1234");
+    BOOST_CHECK_EQUAL(restored.polling(), "20");
     BOOST_CHECK_EQUAL(restored.ssl(), true);
+    BOOST_CHECK_EQUAL(restored.auth(), "auth");
+    BOOST_CHECK_EQUAL(restored.reason(), "");
     // ...and the absent `propagate` field defaults deterministically to false (rather than an indeterminate value)
     BOOST_CHECK_EQUAL(restored.propagate(), false);
 }

--- a/libs/pyext/src/ecflow/python/ExportNodeAttr.cpp
+++ b/libs/pyext/src/ecflow/python/ExportNodeAttr.cpp
@@ -536,6 +536,7 @@ std::string AvisoAttr_str(const ecf::AvisoAttr& aviso) {
 /// @param polling The polling interval (defaults to `MirrorAttr::default_polling`).
 /// @param ssl Whether to use SSL for the remote connection.
 /// @param auth The authentication configuration (defaults to `MirrorAttr::default_remote_auth`).
+/// @param propagate If true, the remote node state is propagated up the local node tree (default false).
 /// @return The newly created MirrorAttr.
 ///
 ecf::MirrorAttr MirrorAttr_make(const std::string& name,

--- a/libs/pyext/src/ecflow/python/ExportNodeAttr.cpp
+++ b/libs/pyext/src/ecflow/python/ExportNodeAttr.cpp
@@ -544,8 +544,9 @@ ecf::MirrorAttr MirrorAttr_make(const std::string& name,
                                 const std::string& port    = ecf::MirrorAttr::default_remote_port,
                                 const std::string& polling = ecf::MirrorAttr::default_polling,
                                 bool ssl                   = false,
-                                const std::string& auth    = ecf::MirrorAttr::default_remote_auth) {
-    return ecf::MirrorAttr(nullptr, name, path, host, port, polling, ssl, auth, "");
+                                const std::string& auth    = ecf::MirrorAttr::default_remote_auth,
+                                bool propagate             = false) {
+    return ecf::MirrorAttr(nullptr, name, path, host, port, polling, ssl, auth, "", propagate);
 }
 
 ///
@@ -1503,7 +1504,8 @@ void export_NodeAttr(py::module& m) {
              py::arg("remote_port") = "%ECF_MIRROR_REMOTE_PORT%",
              py::arg("polling")     = "%ECF_MIRROR_REMOTE_POLLING%",
              py::arg("ssl")         = false,
-             py::arg("auth")        = "%ECF_MIRROR_REMOTE_AUTH%")
+             py::arg("auth")        = "%ECF_MIRROR_REMOTE_AUTH%",
+             py::arg("propagate")   = false)
         .def(py::self == py::self)
         .def("__hash__", &py_hash)
         .def("__str__", &MirrorAttr_str)
@@ -1531,5 +1533,8 @@ void export_NodeAttr(py::module& m) {
         .def("auth",
              &ecf::MirrorAttr::auth,
              py::return_value_policy::reference,
-             "Returns the path to Authentication credentials used to contact the remote ecFlow server");
+             "Returns the path to Authentication credentials used to contact the remote ecFlow server")
+        .def("propagate",
+             &ecf::MirrorAttr::propagate,
+             "Returns a boolean, where true means the Node state is propagated up the Node tree");
 }

--- a/libs/pyext/src/ecflow/python/NodeAttrDoc.cpp
+++ b/libs/pyext/src/ecflow/python/NodeAttrDoc.cpp
@@ -893,14 +893,16 @@ const char* NodeAttrDoc::mirror_doc() {
            "      string polling: The polling interval used to contact the remote ecFlow server\n"
            "      Bool ssl: `true`, when using SSL to contact the remote ecFlow server; `false`, otherwise\n"
            "      string auth: The path to the Mirror Authentication credentials\n"
+           "      Bool propagate: `true`, to propagate the node state up local tree; `false`, otherwise (default)\n"
            "\n"
            "\nUsage:\n\n"
            ".. code-block:: python\n\n"
            "   t1 = Task('t1',\n"
            "             MirrorAttr('name', '/remote/task', 'remote-ecflow', '3141', '60', True, '/path/to/auth'))\n"
            "\n"
-           "   t2 = Task('t2')\n"
-           "   t2.add_aviso('name', '/remote/task', 'remote-ecflow', '3141', '60', True, '/path/to/auth')\n"
+           "   t2 = Task('t2',\n"
+           "             MirrorAttr('name', '/remote/task', 'remote-ecflow', '3141', '60', True, '/path/to/auth', "
+           "True))\n"
            "\n"
-           "The parameters `remote_host`, `remote_port`, `polling`, `ssl`, and `auth` are optional\n";
+           "The parameters `remote_host`, `remote_port`, `polling`, `ssl`, `auth`, and `propagate` are optional\n";
 }

--- a/libs/pyext/test/py_u_TestMirror.py
+++ b/libs/pyext/test/py_u_TestMirror.py
@@ -78,7 +78,7 @@ def can_create_mirror_from_default_parameters_4():
     assert mirror.remote_port() == "r_port"
     assert mirror.polling() == "polling"
     assert mirror.ssl() == True
-    assert mirror.auth() == "%ECF_MIRROR_AUTH%"
+    assert mirror.auth() == "%ECF_MIRROR_REMOTE_AUTH%"
 
 
 def can_create_mirror_propagate_defaults_to_false():
@@ -214,6 +214,7 @@ if __name__ == "__main__":
     can_create_mirror_from_default_parameters_1()
     can_create_mirror_from_default_parameters_2()
     can_create_mirror_from_default_parameters_3()
+    can_create_mirror_from_default_parameters_4()
     can_create_mirror_propagate_defaults_to_false()
     can_create_mirror_with_propagate_as_positional_argument()
     can_create_mirror_with_propagate_as_keyword_argument()

--- a/libs/pyext/test/py_u_TestMirror.py
+++ b/libs/pyext/test/py_u_TestMirror.py
@@ -81,6 +81,59 @@ def can_create_mirror_from_default_parameters_4():
     assert mirror.auth() == "%ECF_MIRROR_AUTH%"
 
 
+def can_create_mirror_propagate_defaults_to_false():
+    mirror = ecf.MirrorAttr("name", "r_path", "r_host", "r_port", "polling", True, "auth")
+    assert mirror.propagate() == False
+
+
+def can_create_mirror_with_propagate_as_positional_argument():
+    mirror = ecf.MirrorAttr("name", "r_path", "r_host", "r_port", "polling", True, "auth", True)
+    assert mirror.name() == "name"
+    assert mirror.remote_path() == "r_path"
+    assert mirror.remote_host() == "r_host"
+    assert mirror.remote_port() == "r_port"
+    assert mirror.polling() == "polling"
+    assert mirror.ssl() == True
+    assert mirror.auth() == "auth"
+    assert mirror.propagate() == True
+
+
+def can_create_mirror_with_propagate_as_keyword_argument():
+    mirror = ecf.MirrorAttr("name", "r_path", propagate=True)
+    assert mirror.name() == "name"
+    assert mirror.remote_path() == "r_path"
+    assert mirror.ssl() == False
+    assert mirror.propagate() == True
+
+
+def mirror_str_reflects_ssl_and_propagate_flags():
+    enabled = ecf.MirrorAttr("name", "r_path", "r_host", "r_port", "polling", True, "auth", True)
+    assert "ssl=1" in str(enabled)
+    assert "propagate=1" in str(enabled)
+
+    disabled = ecf.MirrorAttr("name", "r_path", "r_host", "r_port", "polling", False, "auth", False)
+    assert "ssl=0" in str(disabled)
+    assert "propagate=0" in str(disabled)
+
+
+def can_add_mirror_with_propagate_to_task():
+    suite = ecf.Suite("s1")
+
+    family = ecf.Family("f1")
+    suite.add_family(family)
+
+    task = ecf.Task("t1")
+    family.add_task(task)
+
+    mirror = ecf.MirrorAttr("name", "r_path", "r_host", "r_port", "polling", True, "auth", True)
+    task.add_mirror(mirror)
+    assert len(list(task.mirrors)) == 1
+
+    actual = list(task.mirrors)[0]
+    assert actual.name() == "name"
+    assert actual.propagate() == True
+
+
 def can_add_mirror_to_task():
     suite = ecf.Suite("s1")
 
@@ -161,6 +214,11 @@ if __name__ == "__main__":
     can_create_mirror_from_default_parameters_1()
     can_create_mirror_from_default_parameters_2()
     can_create_mirror_from_default_parameters_3()
+    can_create_mirror_propagate_defaults_to_false()
+    can_create_mirror_with_propagate_as_positional_argument()
+    can_create_mirror_with_propagate_as_keyword_argument()
+    mirror_str_reflects_ssl_and_propagate_flags()
+    can_add_mirror_with_propagate_to_task()
     can_add_mirror_to_task()
     can_embed_mirror_into_task()
     cannot_have_multiple_mirrors_in_single_task()

--- a/libs/service/src/ecflow/service/Controller.hpp
+++ b/libs/service/src/ecflow/service/Controller.hpp
@@ -36,7 +36,7 @@ public:
     // Attribute-facing API
 
     void subscribe(const subscription_t& s) {
-        SLOG(D, "Controller: subscribe " << s);
+        SLOG(T, "Controller: subscribe " << s);
 
         {
             std::scoped_lock lock(subscribe_);
@@ -45,7 +45,7 @@ public:
     }
 
     notifications_t get_notifications(const std::string& name) {
-        SLOG(D, "Controller::get_notifications for " << name);
+        SLOG(T, "Controller::get_notifications for " << name);
 
         notifications_t found;
 
@@ -61,7 +61,7 @@ public:
     // Background Thread-facing API
 
     subscriptions_t get_subscriptions() {
-        SLOG(D, "Controller: collect subscriptions");
+        SLOG(T, "Controller: collect subscriptions");
 
         subscriptions_t found;
         {
@@ -74,7 +74,7 @@ public:
     }
 
     void notify(const notification_t& notification) {
-        SLOG(D, "Controller: notify " << notification);
+        SLOG(T, "Controller: notify " << notification);
 
         {
             std::scoped_lock lock(notify_);

--- a/libs/service/src/ecflow/service/mirror/Mirror.cpp
+++ b/libs/service/src/ecflow/service/mirror/Mirror.cpp
@@ -16,6 +16,7 @@ namespace ecf::service::mirror {
 
 std::ostream& operator<<(std::ostream& os, const MirrorRequest& r) {
     os << "MirrorRequest{";
+    os << "attribute=" << r.attribute << ", ";
     os << "path=" << r.path << ", ";
     os << "host=" << r.host << ", ";
     os << "port=" << r.port << ", ";

--- a/libs/service/src/ecflow/service/mirror/Mirror.hpp
+++ b/libs/service/src/ecflow/service/mirror/Mirror.hpp
@@ -27,6 +27,7 @@ namespace ecf::service::mirror {
  */
 class MirrorRequest {
 public:
+    std::string attribute; // '<node-path>:<mirror-name>' of the MirrorAttr that requested the mirror service
     std::string path;
     std::string host;
     std::string port;

--- a/libs/service/src/ecflow/service/mirror/MirrorClient.cpp
+++ b/libs/service/src/ecflow/service/mirror/MirrorClient.cpp
@@ -70,8 +70,8 @@ MirrorData MirrorClient::get_node_status(const std::string& remote_host,
                                          bool ssl,
                                          const std::string& remote_username,
                                          const std::string& remote_password) const {
-    SLOG(D, "MirrorClient: Accessing " << remote_host << ":" << remote_port << ", path=" << node_path);
-    SLOG(D, "MirrorClient: Authentication credentials:  " << remote_username << ":<omitted>");
+    SLOG(T, "MirrorClient: Accessing " << remote_host << ":" << remote_port << ", path=" << node_path);
+    SLOG(T, "MirrorClient: Authentication credentials:  " << remote_username << ":<omitted>");
 
     try {
         if (!impl_->initialized_) {
@@ -92,12 +92,12 @@ MirrorData MirrorClient::get_node_status(const std::string& remote_host,
             impl_->invoker_.ch1_register(false, std::vector{selected_suite});
         }
 
-        SLOG(D, "MirrorClient: retrieving the latest defs");
+        SLOG(T, "MirrorClient: retrieving the latest defs");
         impl_->invoker_.sync_local();
 
         auto defs = impl_->invoker_.defs();
         if (!defs) {
-            SLOG(E, "MirrorClient: unable to sync with remote defs");
+            SLOG(T, "MirrorClient: unable to sync with remote defs");
             throw std::runtime_error("MirrorClient: Failed to sync with remote defs");
         }
 
@@ -136,7 +136,7 @@ MirrorData MirrorClient::get_node_status(const std::string& remote_host,
         // ** Node Events
         data.events = node->events();
 
-        SLOG(D, "MirrorClient: found node (" << node_path << "), with state " << data.state);
+        SLOG(T, "MirrorClient: found node (" << node_path << "), with state " << data.state);
         return data;
     }
     catch (std::exception& e) {

--- a/libs/service/src/ecflow/service/mirror/MirrorService.cpp
+++ b/libs/service/src/ecflow/service/mirror/MirrorService.cpp
@@ -54,7 +54,6 @@ void MirrorService::start() {
         });
         expiry     = std::chrono::seconds{found->mirror_request_.polling};
     }
-    SLOG(D, "MirrorService: start polling, requested polling interval: " << expiry.count() << " s");
 
     if (expiry < minimum_expiry) {
         SLOG(W,
@@ -63,7 +62,7 @@ void MirrorService::start() {
         expiry = minimum_expiry;
     }
 
-    SLOG(D, "MirrorService: start polling, with polling interval: " << expiry.count() << " s");
+    SLOG(T, "MirrorService: start polling, with polling interval: " << expiry.count() << " s");
     executor_.start(std::chrono::seconds{expiry});
 }
 
@@ -72,10 +71,11 @@ void MirrorService::operator()(const std::chrono::system_clock::time_point& now)
     // Check notification for each listener
     {
         for (auto& entry : listeners_) {
-            SLOG(D,
+            SLOG(T,
                  "MirrorService: Mirroring " << entry.mirror_request_.path << " node from "
                                              << entry.mirror_request_.host << ":" << entry.mirror_request_.port);
 
+            auto attribute   = entry.mirror_request_.attribute;
             auto remote_path = entry.mirror_request_.path;
             auto remote_host = entry.mirror_request_.host;
             auto remote_port = entry.mirror_request_.port;
@@ -88,13 +88,21 @@ void MirrorService::operator()(const std::chrono::system_clock::time_point& now)
                 auto data =
                     mirror_.get_node_status(remote_host, remote_port, remote_path, ssl, remote_user, remote_pass);
 
-                SLOG(D, "MirrorService: Notifying remote node state: " << data.state);
+                auto latest_state      = static_cast<NState::State>(data.state);
+                auto latest_state_name = NState::toString(latest_state);
+                SLOG(D,
+                     "MirrorService: Notifying Mirror '"
+                         << attribute << "' from {path: '" << remote_path << "', host: '" << remote_host << "', port: '"
+                         << remote_port << "', ssl: '" << ssl << "'} to state '" << latest_state_name << "'");
                 MirrorNotification notification{remote_path, data};
                 notify_(notification);
             }
             catch (std::runtime_error& e) {
-                SLOG(W, "MirrorService: Failed to sync with remote node: " << e.what());
                 MirrorError error{remote_path, e.what()};
+                SLOG(W,
+                     "MirrorService: Failed to sync with remote {path: '"
+                         << remote_path << "', host: '" << remote_host << "', port: '" << remote_port << "', user: '"
+                         << remote_user << "', ssl: '" << ssl << "'}, due to: " << error.reason());
                 notify_(error);
             }
         }
@@ -102,14 +110,17 @@ void MirrorService::operator()(const std::chrono::system_clock::time_point& now)
 }
 
 void MirrorService::register_listener(const MirrorRequest& request) {
-    SLOG(D, "MirrorService: Registering Mirror: {" << request.path << "}");
+    SLOG(D,
+         "MirrorService: Register Mirror '" << request.attribute << "' to {path: '" << request.path << "', host: '"
+                                            << request.host << "', port: '" << request.port << "', polling: '"
+                                            << request.polling << "', ssl: '" << request.ssl << "'}");
     Entry& inserted = listeners_.emplace_back(Entry{request, "", ""});
     if (!request.auth.empty()) {
-        SLOG(D, "MirrorService: Loading auth {" << request.auth << "}");
+        SLOG(T, "MirrorService: Loading auth {" << request.auth << "}");
         auto found = ecf::service::auth::Credentials::load(request.auth);
         std::visit(ecf::overload{[&inserted](const ecf::service::auth::Credentials& credentials) {
                                      auto url = credentials.value("url").value_or("unknown");
-                                     SLOG(D, "MirrorService: using credentials for mirror: " << url);
+                                     SLOG(T, "MirrorService: using credentials for mirror: " << url);
 
                                      if (auto user = credentials.user(); user) {
                                          inserted.remote_username_ = user->username;

--- a/libs/service/test/mirror/TestMirror.cpp
+++ b/libs/service/test/mirror/TestMirror.cpp
@@ -19,8 +19,9 @@ BOOST_AUTO_TEST_SUITE(T_MirrorRequest)
 BOOST_AUTO_TEST_CASE(can_create_parameterised_mirror_request) {
     using namespace ecf::service::mirror;
 
-    MirrorRequest request{"path", "host", "1234", 60, true, "auth"};
+    MirrorRequest request{"/path/to/node:mirror", "path", "host", "1234", 60, true, "auth"};
 
+    BOOST_CHECK_EQUAL(request.attribute, "/path/to/node:mirror");
     BOOST_CHECK_EQUAL(request.path, "path");
     BOOST_CHECK_EQUAL(request.host, "host");
     BOOST_CHECK_EQUAL(request.port, "1234");
@@ -32,7 +33,7 @@ BOOST_AUTO_TEST_CASE(can_create_parameterised_mirror_request) {
 BOOST_AUTO_TEST_CASE(can_print_mirror_request) {
     using namespace ecf::service::mirror;
 
-    MirrorRequest request{"path", "host", "1234", 60, true, "auth"};
+    MirrorRequest request{"/path/to/node:mirror", "path", "host", "1234", 60, true, "auth"};
 
     BOOST_CHECK(MESSAGE(request).find("MirrorRequest") != std::string::npos);
 }

--- a/libs/service/test/mirror/TestMirrorService.cpp
+++ b/libs/service/test/mirror/TestMirrorService.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(can_create_start_and_stop_mirror_controller) {
 
     MirrorController controller;
 
-    controller.subscribe(MirrorRequest{"path", "host", "1234", 60, true, "auth"});
+    controller.subscribe(MirrorRequest{"/path/to/node:mirror", "path", "host", "1234", 60, true, "auth"});
 
     controller.start();
 


### PR DESCRIPTION
### Description

This enables the use of option `--propagate` to trigger the propagation of the state of a Mirror'ed node.

Fixes #353

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-367
<!-- PREVIEW-URL_END -->