### PR TITLE
remove incorrect Boost::unit_test_framework linking

### DIFF
--- a/libs/test/foolproof/CMakeLists.txt
+++ b/libs/test/foolproof/CMakeLists.txt
@@ -31,7 +31,6 @@ ecbuild_add_test(
     ecflow_all
     test_scaffold
     Boost::boost # Boost header-only libraries must be available (namely unit_test_framework)
-    Boost::unit_test_framework
     ${ADDITIONAL_BOOST_COMPONENTS}
   DEPENDS
     ecflow_server


### PR DESCRIPTION
### Description
s_foolproof uses header-only boost/test/included/unit_test.hpp which embeds all Boost.Test symbols. Adding Boost::unit_test_framework creates duplicates symbols with test_tools.o archive member, causing linker errors on systems with stricter symbol handling. Fixes [this](https://github.com/ecmwf/ecflow/issues/368) issue.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
