### PR TITLE
Mixed bag of independent improvements

### DIFF
--- a/libs/node/src/ecflow/node/formatter/DefsWriter.hpp
+++ b/libs/node/src/ecflow/node/formatter/DefsWriter.hpp
@@ -38,7 +38,7 @@ struct Style
     Style(PrintStyle::Type_t s)
         : selected_(s) {}
 
-    PrintStyle::Type_t selected() { return selected_; }
+    PrintStyle::Type_t selected() const { return selected_; }
 
     template <PrintStyle::Type_t... Args>
     bool is_one_of() const {

--- a/libs/node/src/ecflow/node/formatter/DefsWriter.hpp
+++ b/libs/node/src/ecflow/node/formatter/DefsWriter.hpp
@@ -2322,6 +2322,14 @@ private:
 /* *** Write entry point **************************************************** */
 /* ************************************************************************** */
 
+///
+/// @brief Write an item to a buffer, using the specified context
+///
+/// @tparam T the type of item to write
+/// @param buffer the buffer to write to
+/// @param item the item to write
+/// @param ctx the context for writing
+///
 template <typename T>
 inline void write_t(std::string& buffer, const T& item, FormatContext& ctx) {
     buffer.reserve(1024 * 4); // Should be using a sensible default size for the buffer
@@ -2329,6 +2337,15 @@ inline void write_t(std::string& buffer, const T& item, FormatContext& ctx) {
     implementation::Writer<T, stringstreambuf>::write(output, item, ctx);
 }
 
+///
+/// @brief Write an item to a stream, using the specified context
+///
+/// @tparam Stream the type of the output stream
+/// @tparam T the type of item to write
+/// @param output the output stream to write to
+/// @param item the item to write
+/// @param ctx the context for writing
+///
 template <typename Stream, typename T>
 inline void write_t(Stream& output, const T& item, FormatContext& ctx) {
     std::string buffer;
@@ -2336,6 +2353,14 @@ inline void write_t(Stream& output, const T& item, FormatContext& ctx) {
     output << buffer;
 }
 
+///
+/// @brief Convert an item to a string, using the specified context
+///
+/// @tparam T the type of item to write
+/// @param item the item to write
+/// @param ctx the context for writing
+/// @return the item as a string
+///
 template <typename T>
 inline std::string as_string(const T& item, FormatContext& ctx) {
     std::string buffer;
@@ -2347,6 +2372,14 @@ inline std::string as_string(const T& item, FormatContext& ctx) {
 /* *** Write entry point (with PrintStyle) ********************************** */
 /* ************************************************************************** */
 
+///
+/// @brief Write an expression to a buffer, using the specified PrintStyle and type of the expression
+///
+/// @param buffer the buffer to write to
+/// @param item the expression to write
+/// @param style the print style to use
+/// @param type the type of expression (either "trigger" or "complete")
+///
 inline void write_t(std::string& buffer, const Expression& item, PrintStyle::Type_t style, const std::string& type) {
     buffer.reserve(1024 * 4); // Should be using a sensible default size for the buffer
     stringstreambuf output{buffer};
@@ -2354,6 +2387,14 @@ inline void write_t(std::string& buffer, const Expression& item, PrintStyle::Typ
     implementation::Writer<Expression, stringstreambuf>::write(output, item, ctx, type);
 }
 
+///
+/// @brief Write an item to a buffer, using the specified PrintStyle
+///
+/// @tparam T the type of item to write
+/// @param buffer the buffer to write to
+/// @param item the item to write
+/// @param style the print style to use
+///
 template <typename T>
 inline void write_t(std::string& buffer, const T& item, PrintStyle::Type_t style) {
     buffer.reserve(1024 * 4); // Should be using a sensible default size for the buffer
@@ -2362,6 +2403,15 @@ inline void write_t(std::string& buffer, const T& item, PrintStyle::Type_t style
     implementation::Writer<T, stringstreambuf>::write(output, item, ctx);
 }
 
+///
+/// @brief Write an item to an output stream, using the specified PrintStyle
+///
+/// @tparam Stream the type of the output stream
+/// @tparam T the type of item to write
+/// @param output the output stream
+/// @param item the item to write
+/// @param style the print style to use
+///
 template <typename Stream, typename T>
 inline void write_t(Stream& output, const T& item, PrintStyle::Type_t style) {
     std::string buffer;
@@ -2369,6 +2419,14 @@ inline void write_t(Stream& output, const T& item, PrintStyle::Type_t style) {
     output << buffer;
 }
 
+///
+/// @brief Convert an item to a string, using the specified PrintStyle
+///
+/// @tparam T the type of item to convert
+/// @param item the item to convert
+/// @param style the print style to use
+/// @return the item as a string
+///
 template <typename T>
 inline std::string as_string(const T& item, PrintStyle::Type_t style) {
     std::string buffer;

--- a/libs/server/src/ecflow/server/ServerEnvironment.cpp
+++ b/libs/server/src/ecflow/server/ServerEnvironment.cpp
@@ -424,66 +424,6 @@ bool ServerEnvironment::load_whitelist_file(std::string& errorMsg) const {
     return false;
 }
 
-// bool ServerEnvironment::authenticateReadAccess(const std::string& user,
-//                                                bool custom_user,
-//                                                const std::string& passwd) const {
-//     if (!custom_user) {
-//         if (!passwd_file_.authenticate(user, passwd))
-//             return false;
-//     }
-//     else {
-//         if (!passwd_custom_file_.authenticate(user, passwd))
-//             return false;
-//     }
-//
-//     // if *NO* users specified then all users are valid
-//     return white_list_file_.verify_read_access(user);
-// }
-
-// bool ServerEnvironment::authenticateReadAccess(const std::string& user,
-//                                                bool custom_user,
-//                                                const std::string& passwd,
-//                                                const std::string& path) const {
-//     if (!custom_user) {
-//         if (!passwd_file_.authenticate(user, passwd))
-//             return false;
-//     }
-//     else {
-//         if (!passwd_custom_file_.authenticate(user, passwd))
-//             return false;
-//     }
-//
-//     return white_list_file_.verify_read_access(user, path);
-// }
-//
-// bool ServerEnvironment::authenticateReadAccess(const std::string& user,
-//                                                bool custom_user,
-//                                                const std::string& passwd,
-//                                                const std::vector<std::string>& paths) const {
-//     if (!custom_user) {
-//         if (!passwd_file_.authenticate(user, passwd))
-//             return false;
-//     }
-//     else {
-//         if (!passwd_custom_file_.authenticate(user, passwd))
-//             return false;
-//     }
-//
-//     return white_list_file_.verify_read_access(user, paths);
-// }
-//
-// bool ServerEnvironment::authenticateWriteAccess(const std::string& user) const {
-//     // if *NO* users specified then all users have write access
-//     return white_list_file_.verify_write_access(user);
-// }
-// bool ServerEnvironment::authenticateWriteAccess(const std::string& user, const std::string& path) const {
-//     return white_list_file_.verify_write_access(user, path);
-// }
-// bool ServerEnvironment::authenticateWriteAccess(const std::string& user, const std::vector<std::string>& paths) const
-// {
-//     return white_list_file_.verify_write_access(user, paths);
-// }
-
 // ============================================================================================
 // Privates:
 // ============================================================================================

--- a/libs/server/src/ecflow/server/ServerEnvironment.hpp
+++ b/libs/server/src/ecflow/server/ServerEnvironment.hpp
@@ -170,26 +170,6 @@ public:
     /// If errors arise the exist user still stay in affect
     bool reloadWhiteListFile(std::string& errorMsg);
 
-    /// There are several kinds of authentification:
-    ///     a/ None
-    ///     b/ List mode.   ASCII file based on ECF_LISTS is defined
-    ///     c/ Secure mode. binary file based ECF_PASSWD is defined
-    /// At the moment we will only implement options a/ and b/
-    //
-    /// Returns true if the given user has access to the server, false otherwise
-    // bool authenticateReadAccess(const std::string& user, bool custom_user, const std::string& passwd) const;
-    // bool authenticateReadAccess(const std::string& user,
-    //                             bool custom_user,
-    //                             const std::string& passwd,
-    //                             const std::string& path) const;
-    // bool authenticateReadAccess(const std::string& user,
-    //                             bool custom_user,
-    //                             const std::string& passwd,
-    //                             const std::vector<std::string>& paths) const;
-    // bool authenticateWriteAccess(const std::string& user) const;
-    // bool authenticateWriteAccess(const std::string& user, const std::string& path) const;
-    // bool authenticateWriteAccess(const std::string& user, const std::vector<std::string>& paths) const;
-
     ecf::AuthenticationService& authentication() { return authentication_service_; }
     const ecf::AuthenticationService& authentication() const { return authentication_service_; }
 


### PR DESCRIPTION
### Description

This bundles a set of low-risk, behaviour-preserving cleanups to the node formatter and the server environment.

The bulk of the change renames the formatter's overly generic Context struct to FormatContext across the DefsWriter header and all its callers (ExprParser, Defs, the simulator visitors, the ExprAST rendering test, and the ecFlowUI trigger attribute) — a pure, mechanical rename with no semantic drift. On top of that, DefsWriter gets some hygiene: Style::selected() is marked const (it is a pure getter), and the write_t/as_string free-function entry points gain Doxygen describing their template parameters, arguments and return values.

Separately, the dead commented-out authenticateReadAccess/authenticateWriteAccess method family is removed from ServerEnvironment (both the header declarations and the source bodies, ~80 lines), leaving the live authorisation setup untouched. There are no functional changes anywhere in the range; the library builds clean and the T_ExprAST and simulator tests pass.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-387
<!-- PREVIEW-URL_END -->