### PR TITLE
Improve the trigger/complete expression handling ECFLOW-2112

### DIFF
--- a/docs/_static/css/custom_style.css
+++ b/docs/_static/css/custom_style.css
@@ -67,3 +67,26 @@ div.admonition.implementation > .admonition-title {
     background-color: #e0e0e0;
     color: #424242;
 }
+
+/* Grammar (productionlist) blocks are rendered as a bare <pre> and can contain
+   long lines; keep them within the content area by scrolling horizontally
+   instead of overflowing past the right-hand border.
+   The `grammar-pre` class is added by _static/js/grammar_terminals.js to the
+   productionlist blocks only, so these rules do not affect other <pre> blocks. */
+.rst-content pre.grammar-pre {
+    max-width: 100%;
+    overflow-x: auto;
+    white-space: pre;
+    /* Match the size/metrics of code (highlight/literal) blocks: a bare <pre>
+       (as produced by productionlist) otherwise renders at 1em, much larger. */
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", Courier, monospace;
+    font-size: 12px;
+    line-height: 1.4;
+}
+
+/* Terminal (quoted) symbols in the grammar productionlist blocks, wrapped by
+   _static/js/grammar_terminals.js, are coloured blue to distinguish them from
+   the non-terminals. */
+.rst-content pre.grammar-pre .grammar-terminal {
+    color: #1565c0;
+}

--- a/docs/_static/js/grammar_terminals.js
+++ b/docs/_static/js/grammar_terminals.js
@@ -1,0 +1,60 @@
+// Colourise terminal (quoted) symbols in grammar ``productionlist`` blocks.
+//
+// Sphinx renders a ``.. productionlist::`` as a bare <pre> in which the
+// non-terminals are <strong>/<a> elements but the terminal literals (e.g.
+// ":", "(", "and") are plain text with no markup to style. This script wraps
+// each double-quoted literal in a <span class="grammar-terminal"> so it can be
+// coloured via CSS, making terminals stand out from non-terminals.
+(function () {
+    function colouriseTerminals(root) {
+        var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
+        var textNodes = [];
+        var node;
+        while ((node = walker.nextNode())) {
+            textNodes.push(node);
+        }
+        textNodes.forEach(function (textNode) {
+            var text = textNode.nodeValue;
+            if (text.indexOf('"') === -1) {
+                return;
+            }
+            var frag = document.createDocumentFragment();
+            var re = /"[^"]*"/g;
+            var last = 0;
+            var match;
+            while ((match = re.exec(text)) !== null) {
+                if (match.index > last) {
+                    frag.appendChild(document.createTextNode(text.slice(last, match.index)));
+                }
+                var span = document.createElement('span');
+                span.className = 'grammar-terminal';
+                span.textContent = match[0];
+                frag.appendChild(span);
+                last = re.lastIndex;
+            }
+            if (last < text.length) {
+                frag.appendChild(document.createTextNode(text.slice(last)));
+            }
+            textNode.parentNode.replaceChild(frag, textNode);
+        });
+    }
+
+    function run() {
+        var pres = document.querySelectorAll('.rst-content pre');
+        Array.prototype.forEach.call(pres, function (pre) {
+            // Only touch productionlist blocks (they contain grammar-token anchors).
+            if (pre.querySelector('strong[id^="grammar-token"]')) {
+                // Tag the block so the scoped CSS (see custom_style.css) applies to
+                // grammar blocks only, not to every <pre> on the page.
+                pre.classList.add('grammar-pre');
+                colouriseTerminals(pre);
+            }
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', run);
+    } else {
+        run();
+    }
+})();

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,6 +84,8 @@ html_static_path = ["_static"]
 
 html_css_files = ["css/custom_style.css"]
 
+html_js_files = ["js/grammar_terminals.js"]
+
 html_logo = ""
 
 highlight_language = "none"

--- a/docs/ug/index.rst
+++ b/docs/ug/index.rst
@@ -15,6 +15,7 @@ User Manual
    user_manual/python_based_suite_definition/index.rst
    user_manual/node_attribute_overview
    user_manual/definition_file_format
+   user_manual/expression_spec
    ecflow_ui/index.rst
    cookbook/index.rst
    elearning

--- a/docs/ug/user_manual/expression_spec.rst
+++ b/docs/ug/user_manual/expression_spec.rst
@@ -1,0 +1,423 @@
+.. _expression_spec:
+
+Trigger and complete expressions
+////////////////////////////////
+
+This is a technical, reference-level specification of the *expression* language used by the ``trigger`` and
+``complete`` attributes of a suite definition. This specification is intended to be authoritative and parser-agnostic.
+
+..  implementation::
+
+    In practice, the specification was derived directly from the source code (i.e. the expression lexer/parser and the
+    abstract syntax tree it produces) and describes the grammar the ecFlow server actually accepts, but is independent
+    of the actual parser implementation in use.
+
+.. _expr-introduction:
+
+Introduction
+============
+
+A ``trigger`` or ``complete`` attribute attaches a boolean *expression* to a node (``suite``, ``family``, ``task`` or
+``alias``). The expression is a condition over the current state of the definition tree, and it controls scheduling:
+
+- **trigger** — a *gate*.
+
+    A node with a trigger is held in the ``queued`` state and cannot start until its trigger expression evaluates to
+    *true*.
+
+- **complete** — a *shortcut*.
+
+    When a complete expression evaluates to *true*, the associated node is treated as ``complete`` without being run
+    (i.e. its children are not scheduled).
+
+Both attributes share exactly the same expression language; the only difference is how the resulting truth value is
+used by the scheduler.
+
+.. note::
+
+    If a node has both a trigger and a complete expression, the complete expression is evaluated and acted upon
+    *before* the trigger expression is evaluated.
+
+.. code-block:: shell
+
+    # trigger on the state of another node
+    task t1
+        trigger t0 == complete
+
+    # complete this task early when a sibling has already finished
+    task t2
+        trigger  ./prepare == complete
+        complete ./retrieve == complete
+
+Scope
+-----
+
+Expressions may reference, by :ref:`node path <expr-operands>`, any node in the definition and any of its attributes
+(events, meters, variables, limits, repeats, flags). References may be absolute (``/suite/family/task``) or relative to
+the node carrying the expression (``./sibling``, ``../uncle``). Referencing a node outside the current definition
+requires a matching ``extern``.
+
+An expression yields an integer; a **non-zero** result is *true* and a **zero** result is *false*. Comparisons and
+boolean operators yield ``1`` or ``0``, but a bare numeric operand is also a valid expression (for example ``trigger
+1`` is always true, and ``trigger /suite/limit:remaining`` is true while the value is non-zero).
+
+Abstract syntax tree
+--------------------
+
+.. implementation::
+
+    An expression string is parsed **once** into an *abstract syntax tree* (AST) — a tree of ``Ast`` nodes rooted at an
+    ``AstTop`` — and the AST is cached on the owning node. Thereafter every scheduling cycle simply *evaluates* the
+    cached tree; the text is never re-parsed.
+
+    Parsing is deferred: loading a checkpoint (``.check``) stores only the expression *string*, and the AST is built
+    lazily on first use (or eagerly by ``Defs::check()`` when a text ``.def`` is loaded). Because large operational
+    suites contain hundreds of thousands of expressions, this one-off parse is a measurable load-time cost.
+
+Understanding the tree shape helps predict how an expression is evaluated. The *flat* rendering below shows the
+fully-bracketed AST for each example (operators are shown in their canonical symbolic form):
+
+.. list-table:: Introductory examples
+   :header-rows: 1
+   :widths: 45 55
+
+   * - *Flat* Expression
+     - Parsed as (fully bracketed)
+   * - ``t0 == complete``
+     - ``(t0 == complete)`` — trigger on a node *state*
+   * - ``/data/get:ready == set``
+     - ``(/data/get:ready == set)`` — trigger on an *event*
+   * - ``t:step >= 240``
+     - ``(t:step >= 240)`` — trigger on a *meter* (or any numeric attribute)
+   * - ``a == complete and b == complete``
+     - ``((a == complete) and (b == complete))`` — several conditions
+   * - ``./model == complete or ./model == aborted``
+     - ``((./model == complete) or (./model == aborted))``
+   * - ``:YMD == 20240101``
+     - ``(:YMD == 20240101)`` — complete on a *date* (a ``repeat`` date variable)
+   * - ``(obs:YMD + 1) <= /o/main:YMD``
+     - ``((obs:YMD + 1) <= /o/main:YMD)`` — arithmetic on date variables
+
+.. _expr-concepts:
+
+Concepts
+========
+
+An expression is built from **operands** combined by **operators**, optionally grouped with parentheses. This section
+introduces the pieces — see the :ref:`expr-grammar` section for their exact syntax.
+
+.. important::
+
+    The expression language is **case-sensitive**.
+
+    Every keyword — node and event states (``complete``, ``set``, …), boolean and word-form comparison operators
+    (``and``, ``or``, ``not``, ``eq``, ``ne``, …) and function names — is recognised only in the exact casing shown.
+
+    A few operators do have an additional all-uppercase spelling (``AND``, ``OR``); these are separate, exact
+    spellings, not a relaxation of case-sensitivity.
+
+    Mixed-case forms of the operators, such as ``Or`` or ``NOT``, are rejected. For example, ``and`` is a valid operator
+    but ``AnD`` is not, and ``complete`` is a valid state whereas ``Complete`` is not.
+
+
+.. _expr-operands:
+
+Operands
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 30 46
+
+   * - Operand
+     - Example
+     - Meaning / value
+   * - Node state
+     - ``/suite/task``
+     - Only valid on the left of a state comparison (``== complete``). Resolves to the node's status.
+   * - Node attribute
+     - ``/path/to/node:name``
+     - The integer value of the named attribute of the node at ``/path/to/node``: an *event* (``set`` = 1,
+       ``clear`` = 0), a *meter*, a user or generated *variable*, a *limit*, a *repeat*, or a *queue*.
+   * - Parent attribute
+     - ``:name``
+     - The value of the attribute ``name``, resolved exactly like a *node attribute* but located **by name up the
+       ancestor chain**: the nearest of this node and its ancestors (up to the suite) that has an event, meter,
+       variable, repeat, generated variable, limit or queue called ``name``. Commonly used for inherited or generated
+       variables such as ``:YMD``.
+   * - Integer
+     - ``240``
+     - A non-negative integer literal. Integers of the form ``YYYYMMDD`` (e.g. ``20240101``) are commonly used to
+       represent dates.
+   * - Date/time instant
+     - ``20240101T060000``
+     - A calendar instant, ``YYYYMMDD`` followed by ``T`` and ``hhmmss``. Enables calendar-aware comparison and
+       arithmetic against date/time variables.
+   * - Flag
+     - ``path<flag>late``
+     - A boolean: 1 when the given flag (``late``, ``zombie`` or ``archived``) is set on the node at ``path``.
+   * - Calendar function
+     - ``cal::date_to_julian( path:YMD )``
+     - ``date_to_julian`` converts a ``YYYYMMDD`` value to a Julian day number; ``julian_to_date`` is the inverse. The
+       single argument must be a node attribute (``path:name``) or an integer.
+
+Operators
+---------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 34 44
+
+   * - Class
+     - Operators
+     - Notes
+   * - Boolean AND
+     - ``and``   ``AND``   ``&&``
+     - Higher precedence operator than ``OR``.
+   * - Boolean OR
+     - ``or``   ``OR``   ``||``
+     - Lower precedence operator than ``AND``.
+   * - Boolean NOT
+     - ``not``   ``!``   ``~``
+     - Unary, applies to the following comparison or parenthesised group.
+       While the word form ``not`` must be followed by whitespace (``not (a == complete)``),
+       the symbolic forms ``!`` and ``~`` do not require a separating space.
+   * - Equality
+     - ``==``   ``eq``   ``!=``   ``ne``
+     - The **only** operators allowed against a *node state* or *event state*; also usable numerically.
+   * - Relational
+     - ``<``  ``lt``   ``<=``  ``le``   ``>``  ``gt``   ``>=``  ``ge``
+     - **Numeric only** — both sides must be arithmetic expressions. ``t < complete`` is *not* valid.
+   * - Arithmetic
+     - ``+``   ``-``   ``*``   ``/``   ``%``
+     - Arithmetic operators have **no** internal precedence — see :ref:`expr-precedence`.
+
+The symbolic and word forms are interchangeable (``==`` and ``eq`` are the same operator).
+
+Division or modulo by zero is rejected when the definition is checked **only if the divisor can be evaluated to zero at
+that point** — that is, a literal ``0`` (``x / 0``) or an operand (such as a variable, meter, limit or repeat) whose
+*current* value is zero. Because the check evaluates the operands' present values, a divisor that is non-zero at check
+time passes, even if it may later become zero; conversely a divisor that happens to be zero at check time is rejected
+even if it would normally be non-zero.
+
+.. implementation::
+
+   A zero divisor encountered at *runtime* (during trigger/complete evaluation) does **not** abort evaluation or raise
+   an error to the user: the division or modulo is logged (``Divide by zero in trigger/complete expression``) and the
+   offending sub-expression yields ``0``. Evaluation of the surrounding expression then continues with that ``0`` — so,
+   for example, ``10 / v == 0`` becomes *true* when ``v`` is ``0``.
+
+Combining and grouping
+-----------------------
+
+Within an expression, conditions are combined with the boolean operators and, optionally, grouped with parentheses:
+
+.. code-block:: shell
+
+    trigger (a == complete or b == complete) and c == complete
+
+A single node may also build up one logical expression from **several** ``trigger`` (or ``complete``) lines, using the
+``-a`` (AND) and ``-o`` (OR) modifiers. The first line must be unmodified; subsequent lines are combined with the
+running expression:
+
+.. code-block:: shell
+
+    task t
+        trigger    a == complete
+        trigger -a b == complete     # AND a == complete and b == complete
+        trigger -o c == complete     # OR  ... or c == complete
+
+.. note::
+
+   The ``-a`` / ``-o`` modifiers are part of the *definition-file* syntax for accumulating parts, not part of the
+   expression grammar itself. The definition-file parser records each line as a separate part (tagged *first*, *and* or
+   *or*); it neither concatenates them into one string nor merges them. Each part is then parsed **independently** by
+   the expression parser into its own tree, and a separate aggregation step joins those trees under fresh ``and`` /
+   ``or`` nodes to form the node's single combined expression. The expression parser itself only ever sees one part at
+   a time and is unaware of the other lines.
+
+.. _expr-grammar:
+
+Grammar
+=======
+
+This section is the reference grammar, and describes the language accepted. It is written in Extended Backus–Naur form
+(EBNF) over two layers — a *lexical* layer that turns the source string into tokens, and a *syntactic* layer that
+combines tokens into an expression.
+
+Lexical analysis
+----------------
+
+The lexer first turns the raw expression string into a stream of *tokens* (names, integers, quoted literals, keywords
+and operator symbols). Two rules govern how that split is made — in particular, when a run of characters is treated as a
+keyword rather than as part of a name.
+
+Tokenisation is **greedy** (*longest match*): the lexer consumes the longest run that forms a single :token:`name` or
+:token:`integer` before any keyword is considered. A keyword is therefore recognised only when it stands as a complete
+token, delimited by whitespace, a bracket, an operator symbol or the end of the string. Consequently, tokens such as
+``completeand`` and ``515and`` are each a single :token:`name` — **not** ``complete``/``515`` followed by ``and`` — so
+a keyword adjacent to an operand must be separated by whitespace (``complete and``, ``515 and``).
+
+This separation requirement applies **only to the word-form keywords** (the states, and the word-form operators
+``and``, ``or``, ``not``, ``eq``, ``ne``, ``lt`` …), because those are :token:`name`-shaped. The **symbolic** operators
+(``==``, ``!=``, ``<``, ``<=``, ``+``, ``&&`` …) are not made of name characters and always self-delimit, so they never
+require surrounding whitespace: ``5<=6`` and ``a==complete`` are valid, whereas the word forms must be spaced
+(``5 le 6``, ``a eq complete``).
+
+Lexical elements
+----------------
+
+Whitespace (spaces and tabs) separates tokens and is otherwise insignificant, **except** that a :token:`node_path`,
+:token:`attribute`, :token:`flag_ref` and :token:`datetime` are single lexemes and may not contain interior
+whitespace.
+
+.. productionlist:: expr-lexical
+   name      : (letter | digit | "_") { letter | digit | "_" | "." }
+   integer   : digit { digit }
+   datetime  : digit digit digit digit digit digit digit digit "T"
+             : digit digit digit digit digit digit
+   flag      : "<flag>"
+
+A :token:`name` therefore matches the pattern ``\w(\w|\.)*`` (a leading letter, digit or underscore, then letters,
+digits, underscores or dots) — the same rule as node and attribute names elsewhere in the definition file. A run of
+digits followed immediately by letters (e.g. ``4dvar``) is a :token:`name`, not an :token:`integer`.
+
+Keywords
+--------
+
+The following words are recognised as operators or literals in the positions shown by the grammar. They are recognised
+only as complete tokens (never as a prefix of a longer :token:`name`); there is otherwise no reserved-word list (a node
+may legitimately be named ``complete``, and ``complete == complete`` is a valid comparison of that node against the
+state).
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 72
+
+   * - Category
+     - Words
+   * - Node states
+     - ``complete``  ``aborted``  ``queued``  ``submitted``  ``active``  ``unknown``
+   * - Event states
+     - ``set``  ``clear``
+   * - Flags
+     - ``late``  ``zombie``  ``archived``
+   * - Boolean
+     - ``and``  ``AND``  ``or``  ``OR``  ``not``
+   * - Comparison (word forms)
+     - ``eq``  ``ne``  ``lt``  ``le``  ``gt``  ``ge``
+   * - Functions
+     - ``cal::date_to_julian``  ``cal::julian_to_date``
+
+Syntactic grammar
+-----------------
+
+.. productionlist:: expr
+   expression       : subexpression
+   subexpression    : head [ (and | or) subexpression ]
+   head             : [ not ] ( "(" subexpression ")" | and_expr )
+   and_expr         : comparison { and [ not ] comparison }
+   comparison       : node_path eq_op node_state
+                    : | attribute eq_op event_state
+                    : | calc_expr [ cmp_op [ not ] calc_expr ]
+   calc_expr        : calc_factor { arith_op calc_factor }
+   calc_factor      : datetime
+                    : | integer
+                    : | "(" calc_expr ")"
+                    : | parent_attribute
+                    : | cal_function
+                    : | flag_ref
+                    : | attribute
+   attribute        : node_path ":" name
+   parent_attribute : ":" name
+   flag_ref         : ( node_path | "/" ) flag flag_name
+   cal_function     : ("cal::date_to_julian" | "cal::julian_to_date") "(" ( attribute | integer ) ")"
+   node_path        : absolute_path | dot_path | dotdot_path
+   absolute_path    : [ "/" ] name { "/"+ name }
+   dot_path         : "." "/" name { "/" name }
+   dotdot_path      : ".." { "/"+ ".." } { "/"+ name }
+   node_state       : "complete" | "aborted" | "queued" | "submitted" | "active" | "unknown"
+   event_state      : "set" | "clear"
+   flag_name        : "late" | "zombie" | "archived"
+   and              : "and" | "AND" | "&&"
+   or               : "or" | "OR" | "||"
+   not              : "not" | "!" | "~"
+   eq_op            : "==" | "eq" | "!=" | "ne"
+   cmp_op           : eq_op | "<" | "lt" | "<=" | "le" | ">" | "gt" | ">=" | "ge"
+   arith_op         : "+" | "-" | "*" | "/" | "%"
+
+Notes on the productions:
+
+- A **node-state** comparison (``node_path eq_op node_state``) accepts only the equality operators, and only a bare
+  node path on the left. Relational operators (``<``, ``>=`` …) and node states are never mixed: ``t < complete`` is
+  rejected.
+- A bare :token:`node_path` on its own (e.g. ``/a/b``) is **not** a valid operand — it must appear in a state
+  comparison. A bare :token:`attribute` (``a/b:step``), :token:`parent_attribute` (``:YMD``), :token:`integer`,
+  :token:`datetime` or :token:`flag_ref` *is* a valid, standalone expression.
+- There is **no unary sign**: ``-5`` and ``+x`` are not accepted; a leading ``+``/``-`` is only ever a binary
+  arithmetic operator.
+
+  .. implementation::
+
+     The parser accepts a leading operator syntactically (a prefix :token:`calc_factor`), but the resulting binary
+     node has no second operand, so the expression is rejected when the definition is checked — ``-5`` is therefore
+     never valid in practice.
+- The single argument of a ``cal::`` function must be a :token:`attribute` (``path:name``) or an
+  :token:`integer` — a :token:`parent_attribute` (``:name``) is not accepted there.
+
+.. _expr-precedence:
+
+Precedence and associativity
+----------------------------
+
+.. hint::
+
+    Mixed boolean precedence/associativity is subtle — add parentheses to make evaluation order explicit.
+
+The following list presents the order of precedence, from highest to lowest binding:
+
+#. Parentheses and function calls.
+#. Unary ``not`` / ``!`` / ``~``.
+#. Arithmetic ``+ - * / %`` — **all equal precedence, left-associative**. There is *no* multiplicative-over-additive
+   precedence, so ``1 + 2 * 3`` parses as ``((1 + 2) * 3)``, evaluating to ``9``. Use parentheses to force the intended
+   grouping, e.g. ``1 + (2 * 3)``.
+#. Comparison (equality and relational) — a comparison joins two arithmetic expressions and does not chain.
+#. Boolean ``and``.
+#. Boolean ``or``.
+
+Boolean associativity is deliberately **asymmetric**:
+
+- A run of comparisons joined only by ``and`` is **left-associative**: ``a==complete and b==complete and c==complete``
+  parses as ``(((a==complete) and (b==complete)) and (c==complete))``.
+- Once an ``or`` — or a parenthesised boolean group — is involved, the surrounding heads are chained
+  **right-associatively** by the mix of ``and``/``or``. Thus ``1==1 and 2==2 or 3==3`` parses as
+  ``(((1==1) and (2==2)) or (3==3))``.
+
+Worked examples
+---------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - Expression
+     - Parsed as (fully bracketed)
+   * - ``a == complete``
+     - ``(a == complete)``
+   * - ``t:step + 20 ge t:step1 - 20``
+     - ``((t:step + 20) >= (t:step1 - 20))``
+   * - ``cal::date_to_julian(/o/main:YMD) == cal::date_to_julian(20240101)``
+     - ``(date_to_julian(/o/main:YMD) == date_to_julian(20240101))``
+   * - ``not ./model == complete``
+     - ``not ((./model == complete))``
+   * - ``(a==complete or b==complete) and c==complete``
+     - ``(((a==complete) or (b==complete)) and (c==complete))``
+   * - ``:YMD + 1 == 20240102``
+     - ``((:YMD + 1) == 20240102)``
+
+.. note::
+
+   The ``cal::`` row above shows a *simplified* rendering. A ``cal::`` function node prints its **evaluated**
+   argument and result rather than the source operand, so the actual flat rendering of that example is
+   ``(date_to_julian(arg:0) = 0 == date_to_julian(arg:20240101) = 2460311)`` (the ``arg:`` value and the computed
+   Julian day depend on the current state). The bracketing of the surrounding expression is unchanged.

--- a/libs/node/CMakeLists.txt
+++ b/libs/node/CMakeLists.txt
@@ -118,6 +118,32 @@ target_clangformat(u_parser
   CONDITION ENABLE_TESTS
 )
 
+
+set(test_srcs
+  # Sources
+  test/expressions/TestExpressionsGoldenCorpus.cpp
+  test/expressions/TestExpressions_main.cpp # test entry point
+)
+ecbuild_add_test(
+  TARGET
+    u_expressions
+  LABELS
+    unit nightly fast
+  SOURCES
+    ${test_srcs}
+  LIBS
+    ecflow_all
+    test_scaffold
+    nlohmann::json
+    Boost::boost # Boost header-only libraries must be available (namely unit_test_framework)
+  TEST_DEPENDS
+    u_node
+)
+target_clangformat(u_expressions
+  CONDITION ENABLE_TESTS
+)
+
+
 if (ENABLE_ALL_TESTS)
   set(test_srcs
     test/TestSingleExprParse.cpp

--- a/libs/node/src/ecflow/node/ExprParser.cpp
+++ b/libs/node/src/ecflow/node/ExprParser.cpp
@@ -57,6 +57,23 @@ using namespace boost::spirit;
 using namespace phoenix;
 using namespace BOOST_SPIRIT_CLASSIC_NS;
 
+// ECFLOW-2112:
+// A keyword/word-operator token (and/or/eq/ne/ge/gt/le/lt, a node state, an event state, a flag name, an
+// integer or a datetime) must be a complete token: it must NOT be immediately followed by a character that
+// could continue an identifier. Otherwise 'glued' tokens such as 'completeand', '515and', 'andb' or
+// 'and../ret' would be silently (mis)parsed as two separate tokens, which silently changes the meaning of the
+// expression.
+//
+// The identifier-continuation characters are those allowed inside a name (letter, digit, '_' or '.') -- the
+// '.' is included because a name may contain it (e.g. '4dvar') and a relative path begins with it, so a
+// keyword glued to a following '.'/path (e.g. 'and./12') must also be rejected.
+//
+// WORD_BOUNDARY is a zero-width negative-lookahead assertion (it consumes no input) that fails when the next
+// character is an identifier-continuation character. It MUST be used inline, inside a lexeme/leaf/token
+// directive (never via a separate rule<>), so that the phrase-level whitespace skipper is not re-enabled and
+// the assertion is evaluated at the exact character immediately following the token.
+#define WORD_BOUNDARY (~epsilon_p(alnum_p | ch_p('_') | ch_p('.')))
+
 /////////////////////////////////////////////////////////////////////////////
 using treematch_t = tree_match<const char*>;
 using tree_iter_t = treematch_t::tree_iterator;
@@ -224,7 +241,7 @@ struct ExpressionGrammer : public grammar<ExpressionGrammer>
 
             // Integer is distinct from task/family names that are integers, since nodes with integer
             // names that occur in trigger/complete expression must have path ./0 ./1
-            integer   = leaf_node_d[uint_p];
+            integer   = leaf_node_d[uint_p >> WORD_BOUNDARY];
             plus      = root_node_d[str_p("+")];
             minus     = root_node_d[str_p("-")];
             divide    = root_node_d[str_p("/")];
@@ -233,19 +250,19 @@ struct ExpressionGrammer : public grammar<ExpressionGrammer>
             operators = plus | minus | divide | multiply | modulo;
 
             equal_1             = root_node_d[str_p("==")];
-            equal_2             = root_node_d[str_p("eq")];
+            equal_2             = lexeme_d[root_node_d[str_p("eq")] >> WORD_BOUNDARY];
             not_equal_1         = root_node_d[str_p("!=")];
-            not_equal_2         = root_node_d[str_p("ne")];
+            not_equal_2         = lexeme_d[root_node_d[str_p("ne")] >> WORD_BOUNDARY];
             equality_comparible = equal_1 | equal_2 | not_equal_2 | not_equal_1;
 
             greater_equals_1 = root_node_d[str_p(">=")];
-            greater_equals_2 = root_node_d[str_p("ge")];
+            greater_equals_2 = lexeme_d[root_node_d[str_p("ge")] >> WORD_BOUNDARY];
             less_equals_1    = root_node_d[str_p("<=")];
-            less_equals_2    = root_node_d[str_p("le")];
+            less_equals_2    = lexeme_d[root_node_d[str_p("le")] >> WORD_BOUNDARY];
             less_than_1      = root_node_d[str_p("<")];
-            less_than_2      = root_node_d[str_p("lt")];
+            less_than_2      = lexeme_d[root_node_d[str_p("lt")] >> WORD_BOUNDARY];
             greater_than_1   = root_node_d[str_p(">")];
-            greater_than_2   = root_node_d[str_p("gt")];
+            greater_than_2   = lexeme_d[root_node_d[str_p("gt")] >> WORD_BOUNDARY];
             // Prioritise to most common first, to speed up parsing
             less_than_comparable = greater_equals_2 | less_equals_2 | greater_than_2 | less_than_2 | greater_equals_1 |
                                    less_equals_1 | less_than_1 | greater_than_1;
@@ -255,28 +272,34 @@ struct ExpressionGrammer : public grammar<ExpressionGrammer>
             not3_r = root_node_d[str_p("!")];
             not_r  = not1_r | not3_r | not2_r;
 
-            and_r  = root_node_d[str_p("and")] || root_node_d[str_p("&&")] || root_node_d[str_p("AND")];
-            or_r   = root_node_d[str_p("or")] || root_node_d[str_p("||")] || root_node_d[str_p("OR")];
+            and_r = lexeme_d[root_node_d[str_p("and")] >> WORD_BOUNDARY] || root_node_d[str_p("&&")] ||
+                    lexeme_d[root_node_d[str_p("AND")] >> WORD_BOUNDARY];
+            or_r = lexeme_d[root_node_d[str_p("or")] >> WORD_BOUNDARY] || root_node_d[str_p("||")] ||
+                   lexeme_d[root_node_d[str_p("OR")] >> WORD_BOUNDARY];
             and_or = and_r | or_r;
 
-            event_state = leaf_node_d[str_p("set")] || leaf_node_d[str_p("clear")];
+            event_state = leaf_node_d[str_p("set") >> WORD_BOUNDARY] || leaf_node_d[str_p("clear") >> WORD_BOUNDARY];
 
-            node_state_unknown   = root_node_d[str_p("unknown")];
-            node_state_complete  = root_node_d[str_p("complete")];
-            node_state_queued    = root_node_d[str_p("queued")];
-            node_state_submitted = root_node_d[str_p("submitted")];
-            node_state_active    = root_node_d[str_p("active")];
-            node_state_aborted   = root_node_d[str_p("aborted")];
+            node_state_unknown   = lexeme_d[root_node_d[str_p("unknown")] >> WORD_BOUNDARY];
+            node_state_complete  = lexeme_d[root_node_d[str_p("complete")] >> WORD_BOUNDARY];
+            node_state_queued    = lexeme_d[root_node_d[str_p("queued")] >> WORD_BOUNDARY];
+            node_state_submitted = lexeme_d[root_node_d[str_p("submitted")] >> WORD_BOUNDARY];
+            node_state_active    = lexeme_d[root_node_d[str_p("active")] >> WORD_BOUNDARY];
+            node_state_aborted   = lexeme_d[root_node_d[str_p("aborted")] >> WORD_BOUNDARY];
             nodestate            = node_state_complete | node_state_aborted | node_state_queued | node_state_active |
                         node_state_submitted | node_state_unknown;
 
-            flag_late     = root_node_d[str_p("late")];
-            flag_zombie   = root_node_d[str_p("zombie")];
-            flag_archived = root_node_d[str_p("archived")];
+            flag_late     = lexeme_d[root_node_d[str_p("late")] >> WORD_BOUNDARY];
+            flag_zombie   = lexeme_d[root_node_d[str_p("zombie")] >> WORD_BOUNDARY];
+            flag_archived = lexeme_d[root_node_d[str_p("archived")] >> WORD_BOUNDARY];
             flag          = flag_late | flag_zombie | flag_archived;
 
-            variable            = leaf_node_d[nodename];
-            basic_variable_path = nodepath >> discard_node_d[ch_p(':')] >> variable;
+            variable = leaf_node_d[nodename];
+            // ECFLOW-2112: a variable path must be a contiguous token, i.e. no whitespace is allowed around the
+            // ':' separator (a legitimate variable path is always written as 'node:VAR'). This prevents a glued
+            // token such as '515and' (a valid node name, like '4dvar') from being combined with a following
+            // ' :VAR' to (mis)parse '<number>and :VAR' as a variable reference.
+            basic_variable_path = lexeme_d[nodepath >> discard_node_d[ch_p(':')] >> variable];
             parent_variable =
                 ch_p(':') >> variable; // if we discard_node, then we get just 'variable' and NOT parent_variable
 
@@ -288,7 +311,7 @@ struct ExpressionGrammer : public grammar<ExpressionGrammer>
                 str_p("cal::date_to_julian") >> discard_node_d[ch_p('(')] >> cal_argument >> discard_node_d[ch_p(')')];
             cal_julian_to_date =
                 str_p("cal::julian_to_date") >> discard_node_d[ch_p('(')] >> cal_argument >> discard_node_d[ch_p(')')];
-            datetime = leaf_node_d[lexeme_d[repeat_p(8)[digit_p] >> 'T' >> repeat_p(6)[digit_p]]];
+            datetime = leaf_node_d[lexeme_d[repeat_p(8)[digit_p] >> 'T' >> repeat_p(6)[digit_p] >> WORD_BOUNDARY]];
 
             calc_factor = datetime | integer | basic_variable_path |
                           discard_node_d[ch_p('(')] >> calc_expression >> discard_node_d[ch_p(')')] | flag_path |
@@ -355,6 +378,10 @@ struct ExpressionGrammer : public grammar<ExpressionGrammer>
         rule<ScannerT> const& start() const { return expression; }
     };
 };
+
+// WORD_BOUNDARY is only needed by the grammar definition above; undefine it so the
+// macro does not leak into the rest of this translation unit.
+#undef WORD_BOUNDARY
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/libs/node/test/TestExprParser.cpp
+++ b/libs/node/test/TestExprParser.cpp
@@ -940,6 +940,57 @@ BOOST_AUTO_TEST_CASE(test_parser_bad_expressions) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(test_parser_with_attached_tokens) {
+    ECF_NAME_THIS_TEST();
+
+    // ECFLOW-2112:
+    // A word operator (and/or/eq/ne/ge/gt/le/lt) must be a token in its own right, i.e. surrounded by
+    // whitespace/brackets. When it is "attached"/glued to an adjacent operand it forms a single identifier
+    // (e.g. 'completeand', '515and', 'andb') which silently changes the meaning of the expression.
+    // These expressions must be rejected by the parser.
+
+    using namespace std::string_literals;
+    std::vector expressions = {
+        // ---- The exact malformed expressions observed in operational checkpoints (ECFLOW-2112) ----
+        ":TIME ge 515and :ECF_DATE gt :YMD"s,
+        ":TIME ge 1115and :ECF_DATE gt :YMD"s,
+        "input eq completeand ( ( ../lag:YMD + 5) ge ../prep:YMD)"s,
+
+        // ---- 'and' attached to the preceding operand ----
+        "a == completeand b == complete"s, // node state glued to 'and'
+        "a eq completeand b eq complete"s, // word operators + state glued to 'and'
+        "1 == 1and 2 == 2"s,               // integer glued to 'and'
+        "a:value == 10and b:value == 20"s, // integer glued to 'and'
+
+        // ---- 'and' attached to the following operand ----
+        "a == complete andb == complete"s, // 'and' glued to node
+        "a == complete and2 == 2"s,        // 'and' glued to integer
+
+        // ---- 'or' attached to an operand ----
+        "a == completeor b == complete"s, // node state glued to 'or'
+        "a == complete orb == complete"s, // 'or' glued to node
+        "1 == 1or 2 == 2"s,               // integer glued to 'or'
+
+        // ---- word comparison operators glued to an operand ----
+        "aeq complete"s,                      // 'eq' glued to left operand
+        "a eqcomplete"s,                      // 'eq' glued to right operand
+        ":TIME ge515 and :ECF_DATE gt :YMD"s, // 'ge' glued to integer
+        "a ne completeand b == complete"s,    // 'ne'/state glued to 'and'
+
+        // ---- symbolic '==' interacting with a glued word operator ----
+        "a == completeand"s,                  // trailing glued 'and' after equality
+        "a == b == completeor c == complete"s // 'or' glued to state after chained '=='
+    };
+
+    for (const auto& expression : expressions) {
+
+        ExprParser theExprParser(expression);
+        std::string error;
+        auto actual = theExprParser.doParse(error);
+        BOOST_CHECK_MESSAGE(!actual, expression << " expected to fail (ECFLOW-2112 attached tokens)");
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libs/node/test/expressions/TestExpressionsGoldenCorpus.cpp
+++ b/libs/node/test/expressions/TestExpressionsGoldenCorpus.cpp
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2009- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+///
+/// @brief This tests checks the observable behaviour of the trigger/complete expression parser.
+///
+/// The validation is initially based on parsing each corpus expression and rendering the resulting
+/// abstract syntax tree as a fully-bracketed flat string. That rendering is then pinned so that any
+/// change altering it is caught as a regression.
+///
+/// The corpus is *external* (``data/corpus.json``) and is produced by the companion Python script
+/// ``extract_expressions``, which retrieves every trigger/complete expression from real definition
+/// (``.def``) and checkpoint (``.check``) files. This script takes the expression textually, combines
+/// multi-part expressions and deduplicates by AST structure. It also derives a set of invalid expressions
+/// by mutating the valid ones in ways that break their structure (e.g., dropping a parenthesis, swapping
+/// an operator, etc.).
+///
+/// Workflow:
+///
+///   1. Generate/refresh the expressions with ``extract_expressions``.
+///
+///   2. Fill/refresh the golden ``expected`` values and classify the rejection candidates by running
+///      this test with the environment variable ``ECF_GOLDEN_CORPUS=1`` set.
+///      This (re)parses every expression with the current parser and rewrites ``data/corpus.json`` in place.
+///
+///   3. Adopt/commit ``data/corpus.json``.
+///
+///      Normal test runs then assert that the parser:
+///       - reproduces every golden value byte-for-byte
+///       - rejects every invalid expression.
+///
+/// The ``render_expression`` function below is the single point that talks to the parser,
+/// so the corpus is checked against one well-defined rendering of the AST.
+///
+
+#include <cstdlib>
+#include <fstream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+#include <nlohmann/json.hpp>
+
+#include "ecflow/core/File.hpp"
+#include "ecflow/node/ExprAst.hpp"
+#include "ecflow/node/ExprDuplicate.hpp"
+#include "ecflow/node/ExprParser.hpp"
+#include "ecflow/test/scaffold/Naming.hpp"
+
+// Preserve the corpus key order (metadata, valid_expressions, invalid_expressions)
+// when the recording step rewrites the file.
+using json = nlohmann::ordered_json;
+
+BOOST_AUTO_TEST_SUITE(U_Expressions)
+
+BOOST_AUTO_TEST_SUITE(T_GoldenCorpus)
+
+namespace {
+
+std::string corpus_path() {
+    return ecf::File::test_data("libs/node/test/expressions/data/corpus.json", "expressions");
+}
+
+json load_corpus(const std::string& path) {
+    std::ifstream in(path);
+    BOOST_REQUIRE_MESSAGE(in.good(), "Cannot open corpus file: " << path);
+    json j;
+    in >> j;
+    return j;
+}
+
+///
+/// @brief Parses an expression and renders its AST as a fully-bracketed flat string.
+///
+/// @param[in]  expr      Trigger/complete expression to parse.
+/// @param[out] bracketed Fully-bracketed flat rendering of the resulting AST (the golden form).
+/// @param[out] error     Diagnostic message, set only when parsing fails.
+/// @return true when @p expr is accepted and rendered; false otherwise.
+///
+bool render_expression(const std::string& expr, std::string& bracketed, std::string& error) {
+    // Clear the process-wide duplicate-AST cache so every call is a deterministic
+    // "first parse" (a cached hit would return a clone, and AstNot::clone() does
+    // not preserve the 'not'/'~'/'!' spelling).
+    ExprDuplicate reclaim;
+
+    ExprParser parser(expr);
+    if (!parser.doParse(error)) {
+        return false;
+    }
+    AstTop* ast = parser.getAst();
+    if (!ast) {
+        error = "parser returned no AST";
+        return false;
+    }
+    std::ostringstream ss;
+    ast->print_flat(ss, true /*add_brackets*/);
+    bracketed = ss.str();
+    return true;
+}
+
+} // namespace
+
+//
+// (Re)Generate corpus values.
+//
+// This is only activated if ECF_GOLDEN_CORPUS=1.
+//
+// It effectively iterates over all valid expressions and records the fully-bracketed flat rendering of its AST.
+//
+BOOST_AUTO_TEST_CASE(regenerate_golden_corpus) {
+    ECF_NAME_THIS_TEST();
+
+    auto regenerate_requested = []() {
+        const char* flag = ::getenv("ECF_GOLDEN_CORPUS");
+        return flag != nullptr && std::string(flag) != "0";
+    };
+
+    if (!regenerate_requested()) {
+        BOOST_TEST_MESSAGE("Set ECF_GOLDEN_CORPUS=1 to (re)generate the golden 'expected' values");
+        return;
+    }
+
+    const std::string path = corpus_path();
+    json corpus            = load_corpus(path);
+
+    auto make_valid_entry = [](const std::string& expression, const std::string& expected) {
+        json entry          = json::object();
+        entry["expression"] = expression;
+        entry["expected"]   = expected;
+        return entry;
+    };
+
+    json valid_out = json::array();
+    std::set<std::string> valid_seen;
+    std::size_t valid_dropped = 0;
+    std::vector<std::string> dropped_samples;
+
+    // Re-record the golden rendering of every valid expression, dropping any the
+    // parser no longer accepts.
+    for (const auto& entry : corpus.at("valid_expressions")) {
+        const std::string expression = entry.at("expression").get<std::string>();
+
+        std::string bracketed;
+        std::string error;
+        if (!render_expression(expression, bracketed, error)) {
+            ++valid_dropped;
+            if (dropped_samples.size() < 20) {
+                dropped_samples.push_back(expression + "  [" + error + "]");
+            }
+            continue;
+        }
+        if (valid_seen.insert(expression).second) {
+            valid_out.push_back(make_valid_entry(expression, bracketed));
+        }
+    }
+
+    // Classify the automatically-derived invalid-expression candidates. Those the
+    // parser rejects are enforced rejections. Those the parser accepts are not, in
+    // fact, invalid: move them into valid_expressions with their golden rendering, so
+    // the behaviour is documented and locked rather than silently tolerated.
+    json invalid_out     = json::array();
+    std::size_t enforced = 0;
+    std::size_t moved    = 0;
+    std::vector<std::string> moved_samples;
+
+    if (corpus.contains("invalid_expressions")) {
+        for (const auto& entry : corpus.at("invalid_expressions")) {
+            const std::string expression = entry.at("expression").get<std::string>();
+
+            std::string bracketed;
+            std::string error;
+            if (render_expression(expression, bracketed, error)) {
+                // Accepted: this is a valid expression -> lock it in valid_expressions.
+                if (valid_seen.insert(expression).second) {
+                    valid_out.push_back(make_valid_entry(expression, bracketed));
+                    ++moved;
+                    if (moved_samples.size() < 20) {
+                        moved_samples.push_back(expression);
+                    }
+                }
+            }
+            else {
+                // Rejected as expected: keep it as an enforced rejection.
+                json out = entry;
+                out.erase("skip");
+                out.erase("reason");
+                invalid_out.push_back(out);
+                ++enforced;
+            }
+        }
+    }
+
+    corpus["valid_expressions"]                                = valid_out;
+    corpus["invalid_expressions"]                              = invalid_out;
+    corpus["metadata"]["recorded"]                             = json::object();
+    corpus["metadata"]["recorded"]["valid_expressions"]        = valid_out.size();
+    corpus["metadata"]["recorded"]["valid_dropped"]            = valid_dropped;
+    corpus["metadata"]["recorded"]["valid_moved_from_invalid"] = moved;
+    corpus["metadata"]["recorded"]["invalid_expressions"]      = invalid_out.size();
+
+    {
+        std::ofstream os(path);
+        BOOST_REQUIRE_MESSAGE(os.good(), "Cannot write corpus file: " << path);
+        os << corpus.dump(2) << "\n";
+    }
+
+    BOOST_TEST_MESSAGE("Valid: " << valid_out.size() << " (dropped " << valid_dropped << ", moved " << moved
+                                 << " from invalid); Invalid enforced: " << enforced);
+    for (const auto& sample : dropped_samples) {
+        BOOST_TEST_MESSAGE("  dropped: " << sample);
+    }
+    for (const auto& sample : moved_samples) {
+        BOOST_TEST_MESSAGE("  moved to valid (accepted by parser): " << sample);
+    }
+}
+
+//
+// The "golden" assertion.
+// Every expression in the corpus must parse and reproduce the expected/golden value.
+//
+BOOST_AUTO_TEST_CASE(test_golden_corpus) {
+    ECF_NAME_THIS_TEST();
+
+    const std::string path = corpus_path();
+    json corpus            = load_corpus(path);
+
+    const auto& entries = corpus.at("valid_expressions");
+    BOOST_REQUIRE_MESSAGE(!entries.empty(), "Golden corpus is empty: " << path);
+
+    std::size_t checked        = 0;
+    std::size_t parse_failures = 0;
+    std::size_t mismatches     = 0;
+
+    for (const auto& entry : entries) {
+        const std::string expression = entry.at("expression").get<std::string>();
+
+        BOOST_REQUIRE_MESSAGE(entry.contains("expected") && entry.at("expected").is_string(),
+                              "Corpus entry has no golden 'expected' value (run with ECF_GOLDEN_CORPUS=1): '"
+                                  << expression << "'");
+        const std::string expected = entry.at("expected").get<std::string>();
+
+        std::string bracketed;
+        std::string error;
+        if (!render_expression(expression, bracketed, error)) {
+            ++parse_failures;
+            BOOST_ERROR("Parser rejected golden corpus expression: '" << expression << "'  (" << error << ")");
+            continue;
+        }
+
+        if (bracketed != expected) {
+            ++mismatches;
+            BOOST_ERROR("AST rendering changed for: '" << expression << "'\n  expected: " << expected
+                                                       << "\n  actual:   " << bracketed);
+        }
+        ++checked;
+    }
+
+    BOOST_TEST_MESSAGE("Golden corpus: checked " << checked << " expression(s), " << parse_failures
+                                                 << " parse failure(s), " << mismatches << " mismatch(es)");
+    BOOST_REQUIRE_MESSAGE(parse_failures == 0 && mismatches == 0,
+                          "Golden corpus regressions: " << parse_failures << " parse failure(s), " << mismatches
+                                                        << " mismatch(es)");
+}
+
+//
+// The rejection assertion.
+//
+// Every expression in the rejection corpus is invalid and must be rejected by the parser.
+// A change that starts accepting one of them signals a parser that became too permissive.
+//
+BOOST_AUTO_TEST_CASE(test_rejected_corpus) {
+    ECF_NAME_THIS_TEST();
+
+    const std::string path = corpus_path();
+    json corpus            = load_corpus(path);
+
+    BOOST_REQUIRE_MESSAGE(corpus.contains("invalid_expressions"),
+                          "Corpus has no 'invalid_expressions' (run with ECF_GOLDEN_CORPUS=1): " << path);
+    const auto& rejections = corpus.at("invalid_expressions");
+    BOOST_REQUIRE_MESSAGE(!rejections.empty(), "Rejection corpus is empty: " << path);
+
+    std::size_t checked            = 0;
+    std::size_t unexpected_accepts = 0;
+
+    for (const auto& entry : rejections) {
+        const std::string expression = entry.at("expression").get<std::string>();
+
+        std::string bracketed;
+        std::string error;
+        if (render_expression(expression, bracketed, error)) {
+            ++unexpected_accepts;
+            BOOST_ERROR("Parser accepted an invalid expression: '" << expression << "'\n  rendered as: " << bracketed);
+        }
+        ++checked;
+    }
+
+    BOOST_TEST_MESSAGE("Rejection corpus: checked " << checked << " invalid expression(s), " << unexpected_accepts
+                                                    << " unexpectedly accepted");
+    BOOST_REQUIRE_MESSAGE(unexpected_accepts == 0,
+                          "Rejection corpus regressions: " << unexpected_accepts
+                                                           << " invalid expression(s) were accepted");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/libs/node/test/expressions/TestExpressions_main.cpp
+++ b/libs/node/test/expressions/TestExpressions_main.cpp
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2009- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#define BOOST_TEST_MODULE TestExpressions
+
+#include <boost/test/included/unit_test.hpp>

--- a/libs/node/test/expressions/data/corpus.json
+++ b/libs/node/test/expressions/data/corpus.json
@@ -1,0 +1,8638 @@
+{
+  "metadata": {
+    "generated": "2026-07-22T17:14:02+00:00",
+    "generator": "extract_expressions",
+    "recorded": {
+      "valid_expressions": 1366,
+      "invalid_expressions": 790
+    }
+  },
+  "valid_expressions": [
+    {
+      "expression": "(:attrib1 == 20230101T000000)",
+      "expected": "(:attrib1 == 20230101T000000)"
+    },
+    {
+      "expression": "(:attrib1 >= 20230101T000000)",
+      "expected": "(:attrib1 >= 20230101T000000)"
+    },
+    {
+      "expression": "(:attrib1 <= 20230101T000000)",
+      "expected": "(:attrib1 <= 20230101T000000)"
+    },
+    {
+      "expression": "(:attrib1 + 3 <= 19700101T000000)",
+      "expected": "((:attrib1 + 3) <= 19700101T000000)"
+    },
+    {
+      "expression": "(:attrib1 <= 19700101T000000 + 3)",
+      "expected": "(:attrib1 <= (19700101T000000 + 3))"
+    },
+    {
+      "expression": "(:attrib1 >= 19700101T000000 + 3)",
+      "expected": "(:attrib1 >= (19700101T000000 + 3))"
+    },
+    {
+      "expression": "((:attrib1 + 1) == (19700101T000000 + 1))",
+      "expected": "((:attrib1 + 1) == (19700101T000000 + 1))"
+    },
+    {
+      "expression": "(20240101T060000 == :attrib1)",
+      "expected": "(20240101T060000 == :attrib1)"
+    },
+    {
+      "expression": "(:attrib1 == 19700101T123456 and suite == complete)",
+      "expected": "((:attrib1 == 19700101T123456) and (suite == complete))"
+    },
+    {
+      "expression": "(((suite == complete) and (family == complete)) or (task == complete))",
+      "expected": "(((suite == complete) and (family == complete)) or (task == complete))"
+    },
+    {
+      "expression": "(1==0)",
+      "expected": "(1 == 0)"
+    },
+    {
+      "expression": "(/suite/family/task/node4/00 == queued)",
+      "expected": "(/suite/family/task/node4/00 == queued)"
+    },
+    {
+      "expression": "(suite==complete or suite==aborted)",
+      "expected": "((suite == complete) or (suite == aborted))"
+    },
+    {
+      "expression": "(suite == complete and family == complete)",
+      "expected": "((suite == complete) and (family == complete))"
+    },
+    {
+      "expression": "((suite == complete) and (family == complete))",
+      "expected": "((suite == complete) and (family == complete))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task/000/node4 == complete and node5 == complete)",
+      "expected": "((((suite == complete) and (family == complete)) and (task/000/node4 == complete)) and (node5 == complete))"
+    },
+    {
+      "expression": "(/suite/family/task/00/node4:attrib1)",
+      "expected": "/suite/family/task/00/node4:attrib1"
+    },
+    {
+      "expression": "((suite eq complete or suite/family:attrib1) and (task eq complete or task/family:attrib1) and (node4==complete or node4:attrib2))",
+      "expected": "(((suite == complete) or suite/family:attrib1) and (((task == complete) or task/family:attrib1) and ((node4 == complete) or node4:attrib2)))"
+    },
+    {
+      "expression": "((suite==complete or suite:attrib1) and family==complete)",
+      "expected": "(((suite == complete) or suite:attrib1) and (family == complete))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete)",
+      "expected": "((((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 eq complete)",
+      "expected": "((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete))"
+    },
+    {
+      "expression": "(./024 eq complete)",
+      "expected": "(./024 == complete)"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete)",
+      "expected": "(((suite == complete) and (family == complete)) and (task == complete))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete)",
+      "expected": "(((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete))"
+    },
+    {
+      "expression": "(suite eq complete and family eq complete)",
+      "expected": "((suite == complete) and (family == complete))"
+    },
+    {
+      "expression": "(../suite == complete and /family/task/00/node4 eq complete and :attrib1 eq 4)",
+      "expected": "(((../suite == complete) and (/family/task/00/node4 == complete)) and (:attrib1 == 4))"
+    },
+    {
+      "expression": "(suite:1 or suite eq complete)",
+      "expected": "(suite:1 or (suite == complete))"
+    },
+    {
+      "expression": "(suite == complete and family eq complete)",
+      "expected": "((suite == complete) and (family == complete))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 or (/suite/family/task:attrib1 eq :attrib2 and (/suite/family/task/node4:attrib3 gt :attrib4 or (/suite/family/task/node4:attrib3 eq :attrib4 and /suite/family/task/node4/node5:attrib5 gt :attrib6))))",
+      "expected": "((/suite/family/task:attrib1 > :attrib2) or ((/suite/family/task:attrib1 == :attrib2) and ((/suite/family/task/node4:attrib3 > :attrib4) or ((/suite/family/task/node4:attrib3 == :attrib4) and (/suite/family/task/node4/node5:attrib5 > :attrib6)))))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 / 10000 or (/suite/family/task:attrib1 eq :attrib2 / 10000 and (/suite/family/task/node4:attrib3 gt (:attrib2 / 100 % 100) or (/suite/family/task/node4:attrib3 eq (:attrib2 / 100 % 100) and /suite/family/task/node4/node5:attrib4 gt :attrib2 % 100))))",
+      "expected": "((/suite/family/task:attrib1 > (:attrib2 / 10000)) or ((/suite/family/task:attrib1 == (:attrib2 / 10000)) and ((/suite/family/task/node4:attrib3 > ((:attrib2 / 100) % 100)) or ((/suite/family/task/node4:attrib3 == ((:attrib2 / 100) % 100)) and (/suite/family/task/node4/node5:attrib4 > (:attrib2 % 100))))))"
+    },
+    {
+      "expression": "(../suite == complete and ../family eq complete and :attrib1 eq 1 and /task/node4/00/node5 eq complete)",
+      "expected": "((((../suite == complete) and (../family == complete)) and (:attrib1 == 1)) and (/task/node4/00/node5 == complete))"
+    },
+    {
+      "expression": "((:attrib1 * 100 + :attrib2) == 229)",
+      "expected": "(((:attrib1 * 100) + :attrib2) == 229)"
+    },
+    {
+      "expression": "(:attrib1 eq 1 or /suite/family/00/task/node4/node5 != active and /suite/node6/node7/node8:attrib2 ge :attrib2 and /suite/node6/node7/node8/node9:attrib3 ge :attrib3 or /suite/node6/node7/node8/node9 eq aborted or /suite/node6/node7/node8/node9/node10 eq complete or /suite/node6/node7/node8/node9/node10 eq queued)",
+      "expected": "((:attrib1 == 1) or ((((/suite/family/00/task/node4/node5 != active) and (/suite/node6/node7/node8:attrib2 >= :attrib2)) and (/suite/node6/node7/node8/node9:attrib3 >= :attrib3)) or ((/suite/node6/node7/node8/node9 == aborted) or ((/suite/node6/node7/node8/node9/node10 == complete) or (/suite/node6/node7/node8/node9/node10 == queued)))))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and (/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 17)",
+      "expected": "((((suite == complete) and (family == complete)) and (task == complete)) and ((/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 17))"
+    },
+    {
+      "expression": "(:attrib1 == 1 or suite == complete AND family == complete and suite == complete)",
+      "expected": "((:attrib1 == 1) or (((suite == complete) and (family == complete)) and (suite == complete)))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and ../../task/node4 eq complete)",
+      "expected": "(((suite == complete) and (family == complete)) and (../../task/node4 == complete))"
+    },
+    {
+      "expression": "(:attrib1 le /suite/family/task:attrib2)",
+      "expected": "(:attrib1 <= /suite/family/task:attrib2)"
+    },
+    {
+      "expression": "(:attrib1 lt /suite/family:attrib1)",
+      "expected": "(:attrib1 < /suite/family:attrib1)"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt :attrib1)",
+      "expected": "(/suite/family:attrib1 > :attrib1)"
+    },
+    {
+      "expression": "(/suite:attrib1 gt /suite/family:attrib2 and /suite:attrib3 ge 1600 and ../task ne complete)",
+      "expected": "(((/suite:attrib1 > /suite/family:attrib2) and (/suite:attrib3 >= 1600)) and (../task != complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 ))",
+      "expected": "((/suite/family:attrib1 > /suite/task:attrib1) or (/suite/family:attrib1 == /suite/task:attrib1))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete))",
+      "expected": "((/suite/family:attrib1 > /suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/12/node4/node5 == complete)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete) and /suite/task/node5/12/node6 eq complete)",
+      "expected": "((/suite/family:attrib1 > /suite/task:attrib1) or (((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/12/node4 == complete)) and (/suite/task/node5/12/node6 == complete)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete and /suite/family/12/node5==complete))",
+      "expected": "((/suite/family:attrib1 > /suite/task:attrib1) or (((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/12/node4 == complete)) and (/suite/family/12/node5 == complete)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete) AND (/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node6==complete and /suite/family/12/node6==complete))",
+      "expected": "((/suite/family:attrib1 > /suite/task:attrib1) or (((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/12/node4/node5 == complete)) and ((/suite/family:attrib1 > /suite/task:attrib1) or (((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/12/node6 == complete)) and (/suite/family/12/node6 == complete)))))"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/task/node4/node5/node6==complete)) and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/node5/node7/node8==complete)))",
+      "expected": "(((/suite/family:attrib1 > /suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/task/node4/node5/node6 == complete))) and ((/suite/family:attrib1 > /suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/node5/node7/node8 == complete))))"
+    },
+    {
+      "expression": "(1 != :attrib1 % 4)",
+      "expected": "(1 != (:attrib1 % 4))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt /suite/task:attrib1 and ./12==complete and ./node4==complete and ./00==complete and ./node5==complete)",
+      "expected": "(((((/suite/family:attrib1 > /suite/task:attrib1) and (./12 == complete)) and (./node4 == complete)) and (./00 == complete)) and (./node5 == complete))"
+    },
+    {
+      "expression": "(:attrib1 ge 1715)",
+      "expected": "(:attrib1 >= 1715)"
+    },
+    {
+      "expression": "(suite:attrib1 ge 0 or suite:attrib2 ge 0 or suite:attrib3 gt 48 or /family/task/12/node4/node5/node6/050/node7:attrib4 gt 24)",
+      "expected": "((suite:attrib1 >= 0) or ((suite:attrib2 >= 0) or ((suite:attrib3 > 48) or (/family/task/12/node4/node5/node6/050/node7:attrib4 > 24))))"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4/node5/050/node6:attrib1 gt 0 or /suite/family/12/task/node4/node5 eq complete)",
+      "expected": "((/suite/family/12/task/node4/node5/050/node6:attrib1 > 0) or (/suite/family/12/task/node4/node5 == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 lt /task/family:attrib1) or (/suite/family:attrib1==/task/family:attrib1 and /task/family/12==complete))",
+      "expected": "((/suite/family:attrib1 < /task/family:attrib1) or ((/suite/family:attrib1 == /task/family:attrib1) and (/task/family/12 == complete)))"
+    },
+    {
+      "expression": "(/suite/family/task==complete and (/suite/family:attrib1 eq /node4/family:attrib1))",
+      "expected": "((/suite/family/task == complete) and (/suite/family:attrib1 == /node4/family:attrib1))"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4:attrib1 ge ./node5:attrib2 or /suite/family/12/task/node6:attrib1 ge ./node5:attrib2 or /suite/family/12/task/node4 eq complete or /suite/family/12/task/node4 eq aborted))",
+      "expected": "((/suite/family/12/task/node4:attrib1 >= ./node5:attrib2) or ((/suite/family/12/task/node6:attrib1 >= ./node5:attrib2) or ((/suite/family/12/task/node4 == complete) or (/suite/family/12/task/node4 == aborted))))"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4/node5 == active or /suite/family/12/task/node4/node5 == complete) and (/suite/family/12/task/node6/node7 eq active or /suite/family/12/task/node6/node7 eq complete))",
+      "expected": "(((/suite/family/12/task/node4/node5 == active) or (/suite/family/12/task/node4/node5 == complete)) and ((/suite/family/12/task/node6/node7 == active) or (/suite/family/12/task/node6/node7 == complete)))"
+    },
+    {
+      "expression": "(../suite/family eq complete or (1==0 and (../task:attrib1 gt 16 or (../task:attrib1 gt 16 or ../task:attrib1 gt 16 or ../node4:attrib2 gt 16 or ../node4:attrib2 gt 16 or ../node4:attrib2 gt 16 or (../task eq complete and ../node4 eq complete)))))",
+      "expected": "((../suite/family == complete) or ((1 == 0) and ((../task:attrib1 > 16) or ((../task:attrib1 > 16) or ((../task:attrib1 > 16) or ((../node4:attrib2 > 16) or ((../node4:attrib2 > 16) or ((../node4:attrib2 > 16) or ((../task == complete) and (../node4 == complete))))))))))"
+    },
+    {
+      "expression": "(../suite:attrib1 gt 3 or ../family:attrib2 gt 3 or (../suite eq complete and ../family eq complete))",
+      "expected": "((../suite:attrib1 > 3) or ((../family:attrib2 > 3) or ((../suite == complete) and (../family == complete))))"
+    },
+    {
+      "expression": "(/suite/family/12/task:attrib1 gt 240 or /suite/family/12//node4/node5==complete)",
+      "expected": "((/suite/family/12/task:attrib1 > 240) or (/suite/family/12//node4/node5 == complete))"
+    },
+    {
+      "expression": "(../suite/family eq complete or 1==1)",
+      "expected": "((../suite/family == complete) or (1 == 1))"
+    },
+    {
+      "expression": "(((/suite/family/12/task/node4/node5==complete or /suite/family/12/node6:attrib1 ge 240 or /suite/family/12/node7:attrib2 ge 240)) and (( 20300101 gt /suite/family:attrib3 -1) or ( 20300101 eq /suite/family:attrib3) and (1==1)))",
+      "expected": "(((/suite/family/12/task/node4/node5 == complete) or ((/suite/family/12/node6:attrib1 >= 240) or (/suite/family/12/node7:attrib2 >= 240))) and ((20300101 > (/suite/family:attrib3 - 1)) or ((20300101 == /suite/family:attrib3) and (1 == 1))))"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4==complete and (/node5/family/12//node6/task==complete or /node5/family/12/node7:attrib1 ge 240 or /node5/family/12/node8:attrib2 ge 240)) and (node9 == complete))",
+      "expected": "(((/suite/family/12/task/node4 == complete) and ((/node5/family/12//node6/task == complete) or ((/node5/family/12/node7:attrib1 >= 240) or (/node5/family/12/node8:attrib2 >= 240)))) and (node9 == complete))"
+    },
+    {
+      "expression": "(../suite eq active or ../suite eq complete)",
+      "expected": "((../suite == active) or (../suite == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt :attrib1 or /suite/family/12/task/node4 eq complete) and (/node5/family/12//node6/task==complete or /node5/family/12/node7:attrib2 ge 240 or /node5/family/12/node8:attrib3 ge 240) AND node9 == complete)",
+      "expected": "(((/suite/family:attrib1 > :attrib1) or (/suite/family/12/task/node4 == complete)) and (((/node5/family/12//node6/task == complete) or ((/node5/family/12/node7:attrib2 >= 240) or (/node5/family/12/node8:attrib3 >= 240))) and (node9 == complete)))"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4 eq complete and (/suite/family/12//node5/node6==complete or /suite/family/12/node7:attrib1 ge 360 or /suite/family/12/node8:attrib2 ge 360) AND node9 == complete)",
+      "expected": "((/suite/family/12/task/node4 == complete) and (((/suite/family/12//node5/node6 == complete) or ((/suite/family/12/node7:attrib1 >= 360) or (/suite/family/12/node8:attrib2 >= 360))) and (node9 == complete)))"
+    },
+    {
+      "expression": "(/suite/family/12/task/240/node4==complete and (/suite/family/12/task/360/node4==complete) AND node5 == complete and /suite/family/12/node6==complete)",
+      "expected": "((/suite/family/12/task/240/node4 == complete) and ((/suite/family/12/task/360/node4 == complete) and ((node5 == complete) and (/suite/family/12/node6 == complete))))"
+    },
+    {
+      "expression": "(((/suite/family/12/task/node4==complete or /suite/family/12/node5:attrib1 ge 0) and /suite/family/12/node6/240==complete and /suite/family/12/node7/node8==complete))",
+      "expected": "(((/suite/family/12/task/node4 == complete) or (/suite/family/12/node5:attrib1 >= 0)) and ((/suite/family/12/node6/240 == complete) and (/suite/family/12/node7/node8 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4==complete or /suite/family/12/node5:attrib1 ge 240))",
+      "expected": "((/suite/family/12/task/node4 == complete) or (/suite/family/12/node5:attrib1 >= 240))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 eq :attrib1 and /suite/family/12/task/node4 == complete or /suite/family:attrib1 gt :attrib1 or ../../node5/node6 eq complete)",
+      "expected": "(((/suite/family:attrib1 == :attrib1) and (/suite/family/12/task/node4 == complete)) or ((/suite/family:attrib1 > :attrib1) or (../../node5/node6 == complete)))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt /task/family:attrib1)",
+      "expected": "(/suite/family:attrib1 > /task/family:attrib1)"
+    },
+    {
+      "expression": "((/suite/family/12/task:attrib1 ge 240 OR /suite/family/12/node4:attrib2 ge 240) OR /suite/family/12/node5 eq complete)",
+      "expected": "(((/suite/family/12/task:attrib1 >= 240) or (/suite/family/12/node4:attrib2 >= 240)) or (/suite/family/12/node5 == complete))"
+    },
+    {
+      "expression": "(./240/suite:attrib1 AND ((/family/task/12/node4 eq complete AND /family/task/12/node5 eq complete) AND /family/task/12/node6 eq complete))",
+      "expected": "(./240/suite:attrib1 and (((/family/task/12/node4 == complete) and (/family/task/12/node5 == complete)) and (/family/task/12/node6 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/12/task eq complete AND /suite/family/12/node4 eq complete) AND /suite/family/12/node5 eq complete)",
+      "expected": "(((/suite/family/12/task == complete) and (/suite/family/12/node4 == complete)) and (/suite/family/12/node5 == complete))"
+    },
+    {
+      "expression": "(suite/360 ne queued)",
+      "expected": "(suite/360 != queued)"
+    },
+    {
+      "expression": "(:attrib1 +1 lt :attrib2)",
+      "expected": "((:attrib1 + 1) < :attrib2)"
+    },
+    {
+      "expression": "(../suite:attrib1 gt 0 or ../family:attrib2 gt 0 or ../task eq complete)",
+      "expected": "((../suite:attrib1 > 0) or ((../family:attrib2 > 0) or (../task == complete)))"
+    },
+    {
+      "expression": "(suite/family eq complete and not suite/family:0 and not suite/family:120)",
+      "expected": "(((suite/family == complete) and not (suite/family:0)) and not (suite/family:120))"
+    },
+    {
+      "expression": "(../suite/family:0 OR ../suite/family eq complete)",
+      "expected": "(../suite/family:0 or (../suite/family == complete))"
+    },
+    {
+      "expression": "(suite eq active OR suite eq complete)",
+      "expected": "((suite == active) or (suite == complete))"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4:attrib1 gt 0)",
+      "expected": "(/suite/family/12/task/node4:attrib1 > 0)"
+    },
+    {
+      "expression": "(suite==complete AND family==complete AND 1940 lt :attrib1)",
+      "expected": "(((suite == complete) and (family == complete)) and (1940 < :attrib1))"
+    },
+    {
+      "expression": "(suite==complete AND family==complete AND task==complete)",
+      "expected": "(((suite == complete) and (family == complete)) and (task == complete))"
+    },
+    {
+      "expression": "(/suite/family/12/task:attrib1 ge 240 or /suite/family/12/node4:attrib2 ge 240 or /suite/family/12//node5/node6 eq complete)",
+      "expected": "((/suite/family/12/task:attrib1 >= 240) or ((/suite/family/12/node4:attrib2 >= 240) or (/suite/family/12//node5/node6 == complete)))"
+    },
+    {
+      "expression": "(./suite == complete and family == complete and task == complete and ./node4 == complete and ./12 == complete and ./24 == complete)",
+      "expected": "((((((./suite == complete) and (family == complete)) and (task == complete)) and (./node4 == complete)) and (./12 == complete)) and (./24 == complete))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and ./node8 == complete and ./node9 == complete and ./node10 == complete)",
+      "expected": "((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (./node8 == complete)) and (./node9 == complete)) and (./node10 == complete))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and ./node6 == complete and ./node7 == complete and ./node8 == complete)",
+      "expected": "((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (./node6 == complete)) and (./node7 == complete)) and (./node8 == complete))"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4 == complete or /suite/family/12/node5:attrib1 ge 240 or /suite/family/12/node6:attrib2 ge 240)",
+      "expected": "((/suite/family/12/task/node4 == complete) or ((/suite/family/12/node5:attrib1 >= 240) or (/suite/family/12/node6:attrib2 >= 240)))"
+    },
+    {
+      "expression": "(/suite/family/12/task:attrib1 ge 36 or /suite/family/12//node4:attrib2 ge 36 or ../node5 == complete)",
+      "expected": "((/suite/family/12/task:attrib1 >= 36) or ((/suite/family/12//node4:attrib2 >= 36) or (../node5 == complete)))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and suite == complete and family == complete and ../../task/node4 eq complete)",
+      "expected": "(((((suite == complete) and (family == complete)) and (suite == complete)) and (family == complete)) and (../../task/node4 == complete))"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4 == complete and node5 == complete and /suite/family/12/node6/240/node7:1)",
+      "expected": "(((/suite/family/12/task/node4 == complete) and (node5 == complete)) and /suite/family/12/node6/240/node7:1)"
+    },
+    {
+      "expression": "((./024 eq complete) and (../../240/suite==complete))",
+      "expected": "((./024 == complete) and (../../240/suite == complete))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and ../../task/node4 eq complete and ../../240/node4 eq complete)",
+      "expected": "((((suite == complete) and (family == complete)) and (../../task/node4 == complete)) and (../../240/node4 == complete))"
+    },
+    {
+      "expression": "(suite==complete and not suite:1)",
+      "expected": "((suite == complete) and not (suite:1))"
+    },
+    {
+      "expression": "((suite:1 and suite==complete) and (../family == complete))",
+      "expected": "((suite:1 and (suite == complete)) and (../family == complete))"
+    },
+    {
+      "expression": "(./240/suite:attrib1 AND /family/task/12/node4/node5 eq complete)",
+      "expected": "(./240/suite:attrib1 and (/family/task/12/node4/node5 == complete))"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4:attrib1 ge 45 OR /suite/family/12/task eq complete)",
+      "expected": "((/suite/family/12/task/node4:attrib1 >= 45) or (/suite/family/12/task == complete))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5==complete or /suite/family/task/node6:attrib1 ge 0) and /suite/family/task/node7/node8==complete))",
+      "expected": "(((/suite/family/task/node4/node5 == complete) or (/suite/family/task/node6:attrib1 >= 0)) and (/suite/family/task/node7/node8 == complete))"
+    },
+    {
+      "expression": "(suite:1 and suite==complete)",
+      "expected": "(suite:1 and (suite == complete))"
+    },
+    {
+      "expression": "(../suite/family eq complete or (1==0 and (../task:attrib1 gt 16 or ../task:attrib1 gt 16 or ../task:attrib1 gt 16 or ../node4:attrib2 gt 16 or ../node4:attrib2 gt 16 or ../node4:attrib2 gt 16 or (../task eq complete and ../node4 eq complete))))",
+      "expected": "((../suite/family == complete) or ((1 == 0) and ((../task:attrib1 > 16) or ((../task:attrib1 > 16) or ((../task:attrib1 > 16) or ((../node4:attrib2 > 16) or ((../node4:attrib2 > 16) or ((../node4:attrib2 > 16) or ((../task == complete) and (../node4 == complete))))))))))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt :attrib1 or /suite/family/00/task/node4==complete) and (/node5/family/00//node6/task==complete or /node5/family/00/node7:attrib2 ge 240 or /node5/family/00/node8:attrib3 ge 240) AND node9 == complete)",
+      "expected": "(((/suite/family:attrib1 > :attrib1) or (/suite/family/00/task/node4 == complete)) and (((/node5/family/00//node6/task == complete) or ((/node5/family/00/node7:attrib2 >= 240) or (/node5/family/00/node8:attrib3 >= 240))) and (node9 == complete)))"
+    },
+    {
+      "expression": "(/suite/family/00/task/node4 == complete and (/suite/family/00//node5/node6==complete or /suite/family/00/node7:attrib1 ge 360 or /suite/family/00/node8:attrib2 ge 360) AND node9 == complete)",
+      "expected": "((/suite/family/00/task/node4 == complete) and (((/suite/family/00//node5/node6 == complete) or ((/suite/family/00/node7:attrib1 >= 360) or (/suite/family/00/node8:attrib2 >= 360))) and (node9 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/00/task/node4 == complete and /suite/family:attrib1 eq :attrib1) or /suite/family:attrib1 gt :attrib1 or ../../node5/node6 eq complete)",
+      "expected": "(((/suite/family/00/task/node4 == complete) and (/suite/family:attrib1 == :attrib1)) or ((/suite/family:attrib1 > :attrib1) or (../../node5/node6 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/00/task:attrib1 ge 240 OR /suite/family/00/node4:attrib2 ge 240) OR /suite/family/00/node5/node6 eq complete) AND (/node7/family/00/node6/node8:attrib2 ge 240 OR /node7/family/00/node6 eq complete))",
+      "expected": "((((/suite/family/00/task:attrib1 >= 240) or (/suite/family/00/node4:attrib2 >= 240)) or (/suite/family/00/node5/node6 == complete)) and ((/node7/family/00/node6/node8:attrib2 >= 240) or (/node7/family/00/node6 == complete)))"
+    },
+    {
+      "expression": "((./240/suite:attrib1 AND /family/task/00/node4/node5 eq complete) AND /node6/task/00/node5 eq complete)",
+      "expected": "((./240/suite:attrib1 and (/family/task/00/node4/node5 == complete)) and (/node6/task/00/node5 == complete))"
+    },
+    {
+      "expression": "(((/suite/family/00/task eq complete AND /suite/family/00/node4 eq complete) AND /suite/family/00/node5/node6 eq complete) AND /node7/family/00/node6 eq complete)",
+      "expected": "((((/suite/family/00/task == complete) and (/suite/family/00/node4 == complete)) and (/suite/family/00/node5/node6 == complete)) and (/node7/family/00/node6 == complete))"
+    },
+    {
+      "expression": "(:attrib1 +1 lt :attrib2 and :attrib3 gt 1500)",
+      "expected": "(((:attrib1 + 1) < :attrib2) and (:attrib3 > 1500))"
+    },
+    {
+      "expression": "(:attrib1 ne 0 and :attrib1 ne 3)",
+      "expected": "((:attrib1 != 0) and (:attrib1 != 3))"
+    },
+    {
+      "expression": "(suite eq complete and not suite:attrib1)",
+      "expected": "((suite == complete) and not (suite:attrib1))"
+    },
+    {
+      "expression": "(:attrib1 ge :attrib2)",
+      "expected": "(:attrib1 >= :attrib2)"
+    },
+    {
+      "expression": "((:attrib1 %4) != 3 and (:attrib1 % 100) ne 30 and (:attrib1 % 100) ne 31)",
+      "expected": "((((:attrib1 % 4) != 3) and ((:attrib1 % 100) != 30)) and ((:attrib1 % 100) != 31))"
+    },
+    {
+      "expression": "(../suite == complete and ../family eq complete and ../task eq complete and ../../../node4/node5/node6 eq complete)",
+      "expected": "((((../suite == complete) and (../family == complete)) and (../task == complete)) and (../../../node4/node5/node6 == complete))"
+    },
+    {
+      "expression": "(/suite/family/task/node4/node5 == complete or /suite/family:attrib1 gt :attrib1)",
+      "expected": "((/suite/family/task/node4/node5 == complete) or (/suite/family:attrib1 > :attrib1))"
+    },
+    {
+      "expression": "((:attrib1 * 100 + :attrib2) == 229 or (:attrib1 * 100 + :attrib2) == 231 or (:attrib1 * 100 + :attrib2) == 431 or (:attrib1 * 100 + :attrib2) == 631 or (:attrib1 * 100 + :attrib2) == 931 or (:attrib1 * 100 + :attrib2) == 1131)",
+      "expected": "((((:attrib1 * 100) + :attrib2) == 229) or ((((:attrib1 * 100) + :attrib2) == 231) or ((((:attrib1 * 100) + :attrib2) == 431) or ((((:attrib1 * 100) + :attrib2) == 631) or ((((:attrib1 * 100) + :attrib2) == 931) or (((:attrib1 * 100) + :attrib2) == 1131))))))"
+    },
+    {
+      "expression": "(suite==active or suite==submitted or suite==complete)",
+      "expected": "((suite == active) or ((suite == submitted) or (suite == complete)))"
+    },
+    {
+      "expression": "(suite == complete AND family == complete and task/node4 eq complete)",
+      "expected": "(((suite == complete) and (family == complete)) and (task/node4 == complete))"
+    },
+    {
+      "expression": "(/suite/family/00/task/node4 eq complete and /suite/family/node5/task eq complete or /suite/family:attrib1 gt :attrib1)",
+      "expected": "(((/suite/family/00/task/node4 == complete) and (/suite/family/node5/task == complete)) or (/suite/family:attrib1 > :attrib1))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 eq :attrib1 and /suite/family/00/task/node4 eq complete) or /suite/family:attrib1 gt :attrib1)",
+      "expected": "(((/suite/family:attrib1 == :attrib1) and (/suite/family/00/task/node4 == complete)) or (/suite/family:attrib1 > :attrib1))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 eq :attrib1 and /suite/family/00/task/node4 == complete) or ../../node5/node6 eq complete or /suite/family:attrib1 gt :attrib1)",
+      "expected": "(((/suite/family:attrib1 == :attrib1) and (/suite/family/00/task/node4 == complete)) or ((../../node5/node6 == complete) or (/suite/family:attrib1 > :attrib1)))"
+    },
+    {
+      "expression": "(/suite/family/00/task/node4/node5 != active and node6 == complete and node7 == complete and node8 == complete and node9 == complete and /suite/family/00/node10/node11 == complete and (/suite/family/00/task/node4/node5 eq complete or 1 == 1 ))",
+      "expected": "(((((((/suite/family/00/task/node4/node5 != active) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (/suite/family/00/node10/node11 == complete)) and ((/suite/family/00/task/node4/node5 == complete) or (1 == 1)))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and ./node6 == complete and ./node7 == complete)",
+      "expected": "(((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (./node6 == complete)) and (./node7 == complete))"
+    },
+    {
+      "expression": "(1==1 or suite == complete and family == complete)",
+      "expected": "((1 == 1) or ((suite == complete) and (family == complete)))"
+    },
+    {
+      "expression": "(suite == complete and family eq complete and ../../../task/node4 eq complete)",
+      "expected": "(((suite == complete) and (family == complete)) and (../../../task/node4 == complete))"
+    },
+    {
+      "expression": "(suite/family == complete or 1==1)",
+      "expected": "((suite/family == complete) or (1 == 1))"
+    },
+    {
+      "expression": "(:attrib1 ne 0 and :attrib1 ne 3 and :attrib1 ne 9)",
+      "expected": "(((:attrib1 != 0) and (:attrib1 != 3)) and (:attrib1 != 9))"
+    },
+    {
+      "expression": "(:attrib1 % 2 == 1 and (:attrib1 % 100 ne 1 and :attrib2 ne 0))",
+      "expected": "(((:attrib1 % 2) == 1) and (((:attrib1 % 100) != 1) and (:attrib2 != 0)))"
+    },
+    {
+      "expression": "(:attrib1 % 2 ne 0 and :attrib1 % 100 ne 31)",
+      "expected": "(((:attrib1 % 2) != 0) and ((:attrib1 % 100) != 31))"
+    },
+    {
+      "expression": "((1==1) and (suite == complete))",
+      "expected": "((1 == 1) and (suite == complete))"
+    },
+    {
+      "expression": "(suite == complete and (/family/task/00:attrib1 gt :attrib1 or /family/task/00/node4/node5/node6/node7 eq complete))",
+      "expected": "((suite == complete) and ((/family/task/00:attrib1 > :attrib1) or (/family/task/00/node4/node5/node6/node7 == complete)))"
+    },
+    {
+      "expression": "(../../../suite/family/task eq complete and ../../../suite/family/node4/task eq complete and ../../../node4 eq complete)",
+      "expected": "(((../../../suite/family/task == complete) and (../../../suite/family/node4/task == complete)) and (../../../node4 == complete))"
+    },
+    {
+      "expression": "(:attrib1 %2 != 0 and (:attrib1 % 100 != 31))",
+      "expected": "(((:attrib1 % 2) != 0) and ((:attrib1 % 100) != 31))"
+    },
+    {
+      "expression": "(./00:attrib1 gt :attrib1 or (./00/suite/family eq complete and ./00:attrib1 eq :attrib1))",
+      "expected": "((./00:attrib1 > :attrib1) or ((./00/suite/family == complete) and (./00:attrib1 == :attrib1)))"
+    },
+    {
+      "expression": "(/suite/family/00:attrib1 gt :attrib1 or /suite/family/00/task/node4 eq complete)",
+      "expected": "((/suite/family/00:attrib1 > :attrib1) or (/suite/family/00/task/node4 == complete))"
+    },
+    {
+      "expression": "(../../00:attrib1 gt :attrib1 or (../../00/suite/family eq complete and ../../00/suite/task eq complete and ../../00:attrib1 eq :attrib1))",
+      "expected": "((../../00:attrib1 > :attrib1) or (((../../00/suite/family == complete) and (../../00/suite/task == complete)) and (../../00:attrib1 == :attrib1)))"
+    },
+    {
+      "expression": "(/suite/family/00:attrib1 ge /suite/family/task/node4:attrib1 and /node5/node6/node7/node8:attrib1 ge /suite/family/task/node4:attrib1)",
+      "expected": "((/suite/family/00:attrib1 >= /suite/family/task/node4:attrib1) and (/node5/node6/node7/node8:attrib1 >= /suite/family/task/node4:attrib1))"
+    },
+    {
+      "expression": "(suite eq complete and ../family:attrib1 le task:attrib2)",
+      "expected": "((suite == complete) and (../family:attrib1 <= task:attrib2))"
+    },
+    {
+      "expression": "((:attrib1 lt :attrib2 and :attrib3 eq 1208))",
+      "expected": "((:attrib1 < :attrib2) and (:attrib3 == 1208))"
+    },
+    {
+      "expression": "((not suite:1 and suite==complete) or (/family/task:attrib1 == /node4/task:attrib1))",
+      "expected": "((not (suite:1) and (suite == complete)) or (/family/task:attrib1 == /node4/task:attrib1))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 eq (/task/family:attrib1 + 1) and (/task/family/node4/node5/node6 eq complete or /task/family/node4/node5/node6:attrib2 gt 9)) or (/suite/family:attrib1 eq /task/family:attrib1))",
+      "expected": "(((/suite/family:attrib1 == (/task/family:attrib1 + 1)) and ((/task/family/node4/node5/node6 == complete) or (/task/family/node4/node5/node6:attrib2 > 9))) or (/suite/family:attrib1 == /task/family:attrib1))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 eq /task/family:attrib1 and (/task/family/node4/node5/node6 eq complete or /task/family/node4/node5/node6:attrib2 gt 9)) or (/suite/family:attrib1 lt /task/family:attrib1))",
+      "expected": "(((/suite/family:attrib1 == /task/family:attrib1) and ((/task/family/node4/node5/node6 == complete) or (/task/family/node4/node5/node6:attrib2 > 9))) or (/suite/family:attrib1 < /task/family:attrib1))"
+    },
+    {
+      "expression": "(:attrib1 gt 1630 or :attrib2 gt :attrib3 or (:attrib4 eq 1 and :attrib1 gt 1310))",
+      "expected": "((:attrib1 > 1630) or ((:attrib2 > :attrib3) or ((:attrib4 == 1) and (:attrib1 > 1310))))"
+    },
+    {
+      "expression": "(:attrib1 gt :attrib2 and (:attrib3 gt 430 or (:attrib4 eq 1 and :attrib3 gt 110)))",
+      "expected": "((:attrib1 > :attrib2) and ((:attrib3 > 430) or ((:attrib4 == 1) and (:attrib3 > 110))))"
+    },
+    {
+      "expression": "(suite:attrib1 >= 12)",
+      "expected": "(suite:attrib1 >= 12)"
+    },
+    {
+      "expression": "(:attrib1 ne 0)",
+      "expected": "(:attrib1 != 0)"
+    },
+    {
+      "expression": "((:attrib1 eq 0 or (suite/family eq complete)))",
+      "expected": "((:attrib1 == 0) or (suite/family == complete))"
+    },
+    {
+      "expression": "(../../suite/family/00 eq complete and task == complete and node4 == complete and /node5/node6/node7/node8 == complete)",
+      "expected": "((((../../suite/family/00 == complete) and (task == complete)) and (node4 == complete)) and (/node5/node6/node7/node8 == complete))"
+    },
+    {
+      "expression": "(:attrib1 == 0)",
+      "expected": "(:attrib1 == 0)"
+    },
+    {
+      "expression": "((suite == complete and ../../../family == complete and ../../../task == complete) and (node4 == complete))",
+      "expected": "((((suite == complete) and (../../../family == complete)) and (../../../task == complete)) and (node4 == complete))"
+    },
+    {
+      "expression": "(suite == complete and family:attrib1)",
+      "expected": "((suite == complete) and family:attrib1)"
+    },
+    {
+      "expression": "(suite == complete or suite/family:attrib1)",
+      "expected": "((suite == complete) or suite/family:attrib1)"
+    },
+    {
+      "expression": "((suite/family:attrib1 or suite == complete) and suite/family:attrib2 and task/node4 == complete)",
+      "expected": "((suite/family:attrib1 or (suite == complete)) and (suite/family:attrib2 and (task/node4 == complete)))"
+    },
+    {
+      "expression": "(suite/family:attrib1 or suite/family == complete)",
+      "expected": "(suite/family:attrib1 or (suite/family == complete))"
+    },
+    {
+      "expression": "(((suite == complete) and (../../family == complete)) and ((../../../../task/node4/node5 == complete OR ../node6/node7/node8:attrib1)))",
+      "expected": "(((suite == complete) and (../../family == complete)) and ((../../../../task/node4/node5 == complete) or ../node6/node7/node8:attrib1))"
+    },
+    {
+      "expression": "((../../../suite/family/task/node4:attrib1 or ../../../suite/family/task/node4 == complete) and (node5 == complete and node6 == complete))",
+      "expected": "((../../../suite/family/task/node4:attrib1 or (../../../suite/family/task/node4 == complete)) and ((node5 == complete) and (node6 == complete)))"
+    },
+    {
+      "expression": "(suite:attrib1 >= 12 and suite eq complete)",
+      "expected": "((suite:attrib1 >= 12) and (suite == complete))"
+    },
+    {
+      "expression": "(../../suite/family/task eq complete or ../../suite/family/task:attrib1 >= 3)",
+      "expected": "((../../suite/family/task == complete) or (../../suite/family/task:attrib1 >= 3))"
+    },
+    {
+      "expression": "(../../suite/family/task eq complete or ../../suite/family/task:attrib1 ge 14)",
+      "expected": "((../../suite/family/task == complete) or (../../suite/family/task:attrib1 >= 14))"
+    },
+    {
+      "expression": "((/suite/family/00/task/node4/node5:attrib1 ge 12 or /suite/family/00/task/node4/node5==complete) and /suite/family/00/node6/node4==complete)",
+      "expected": "(((/suite/family/00/task/node4/node5:attrib1 >= 12) or (/suite/family/00/task/node4/node5 == complete)) and (/suite/family/00/node6/node4 == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 == /suite/task:attrib1 and /suite/family/00/node4==complete and /suite/family/00/node5/node6==complete))",
+      "expected": "((/suite/family:attrib1 > /suite/task:attrib1) or (((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/00/node4 == complete)) and (/suite/family/00/node5/node6 == complete)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/00/node4 eq complete))",
+      "expected": "((/suite/family:attrib1 > /suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/00/node4 == complete)))"
+    },
+    {
+      "expression": "((suite:attrib1 or suite==complete) and ((/family/task:attrib2 gt /family/node4:attrib2) or (/family/task:attrib2 eq /family/node4:attrib2 and /family/task/00/node5 eq complete)))",
+      "expected": "((suite:attrib1 or (suite == complete)) and ((/family/task:attrib2 > /family/node4:attrib2) or ((/family/task:attrib2 == /family/node4:attrib2) and (/family/task/00/node5 == complete))))"
+    },
+    {
+      "expression": "(./00 == complete and ./12 == complete and /suite/family:attrib1 gt /suite/task:attrib1)",
+      "expected": "(((./00 == complete) and (./12 == complete)) and (/suite/family:attrib1 > /suite/task:attrib1))"
+    },
+    {
+      "expression": "((:attrib1 le /suite/family:attrib1 -2 or (:attrib1 eq /suite/family:attrib1 -1 and /suite/family/00/task/node4 eq complete)) and (/suite/family:attrib1 % 100 != 1))",
+      "expected": "(((:attrib1 <= (/suite/family:attrib1 - 2)) or ((:attrib1 == (/suite/family:attrib1 - 1)) and (/suite/family/00/task/node4 == complete))) and ((/suite/family:attrib1 % 100) != 1))"
+    },
+    {
+      "expression": "(:attrib1 == 0 or (( :attrib2 ge (2200 + :attrib3) and :attrib4 eq :attrib5 ) or ( :attrib4 gt :attrib5 )))",
+      "expected": "((:attrib1 == 0) or (((:attrib2 >= (2200 + :attrib3)) and (:attrib4 == :attrib5)) or (:attrib4 > :attrib5)))"
+    },
+    {
+      "expression": "((:attrib1 le /suite/family:attrib1 -2 or (:attrib1 eq /suite/family:attrib1 -1 and /suite/family/00/task/node4 eq complete)) and (/suite/family:attrib1 % 100 != 1) and :attrib1 le 20241231)",
+      "expected": "(((:attrib1 <= (/suite/family:attrib1 - 2)) or ((:attrib1 == (/suite/family:attrib1 - 1)) and (/suite/family/00/task/node4 == complete))) and (((/suite/family:attrib1 % 100) != 1) and (:attrib1 <= 20241231)))"
+    },
+    {
+      "expression": "(:attrib1 == 0 or (( :attrib2 ge (1000 + :attrib3) and :attrib4 eq :attrib5 + 1 ) or ( :attrib4 gt :attrib5 + 1 )))",
+      "expected": "((:attrib1 == 0) or (((:attrib2 >= (1000 + :attrib3)) and (:attrib4 == (:attrib5 + 1))) or (:attrib4 > (:attrib5 + 1))))"
+    },
+    {
+      "expression": "(./suite == complete and ./family == complete and :attrib1 lt 20250117)",
+      "expected": "(((./suite == complete) and (./family == complete)) and (:attrib1 < 20250117))"
+    },
+    {
+      "expression": "(suite eq complete and family eq complete and /task/1002/node4/node5/node6 == complete and node5/node7 == complete)",
+      "expected": "((((suite == complete) and (family == complete)) and (/task/1002/node4/node5/node6 == complete)) and (node5/node7 == complete))"
+    },
+    {
+      "expression": "(/suite/family/00/task/node4:attrib1 ge 6)",
+      "expected": "(/suite/family/00/task/node4:attrib1 >= 6)"
+    },
+    {
+      "expression": "(((/suite:attrib1 gt /suite/family:attrib2) and (/suite:attrib3 ge 0613)) and ((/suite/family/00/task/node4:attrib4 ge 96 or /suite/family/00/task/node4 eq complete)))",
+      "expected": "(((/suite:attrib1 > /suite/family:attrib2) and (/suite:attrib3 >= 613)) and ((/suite/family/00/task/node4:attrib4 >= 96) or (/suite/family/00/task/node4 == complete)))"
+    },
+    {
+      "expression": "((/suite:attrib1 ge 1813) and ((/suite/family/12/task/node4:attrib2 ge 96 or /suite/family/12/task/node4 eq complete)))",
+      "expected": "((/suite:attrib1 >= 1813) and ((/suite/family/12/task/node4:attrib2 >= 96) or (/suite/family/12/task/node4 == complete)))"
+    },
+    {
+      "expression": "((:attrib1 lt :attrib2 and :attrib3 eq 1210) and ../suite==complete)",
+      "expected": "(((:attrib1 < :attrib2) and (:attrib3 == 1210)) and (../suite == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 le /suite/task:attrib1+3) and (1==0))",
+      "expected": "((/suite/family:attrib1 <= (/suite/task:attrib1 + 3)) and (1 == 0))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 ge /task/family:attrib1))",
+      "expected": "(/suite/family:attrib1 >= /task/family:attrib1)"
+    },
+    {
+      "expression": "(:attrib1 gt 1830 or :attrib2 gt :attrib3 or (:attrib4 eq 1 and :attrib1 ge 1540))",
+      "expected": "((:attrib1 > 1830) or ((:attrib2 > :attrib3) or ((:attrib4 == 1) and (:attrib1 >= 1540))))"
+    },
+    {
+      "expression": "(:attrib1 gt :attrib2 and (:attrib3 gt 1330 or (:attrib4 eq 1 and :attrib3 ge 935)))",
+      "expected": "((:attrib1 > :attrib2) and ((:attrib3 > 1330) or ((:attrib4 == 1) and (:attrib3 >= 935))))"
+    },
+    {
+      "expression": "((:attrib1 gt 130 and :attrib2 gt :attrib3) or (:attrib4 eq 1 and :attrib1 ge 2140))",
+      "expected": "(((:attrib1 > 130) and (:attrib2 > :attrib3)) or ((:attrib4 == 1) and (:attrib1 >= 2140)))"
+    },
+    {
+      "expression": "((:attrib1 gt 130 and :attrib2 gt :attrib3) or (:attrib4 eq 1 and :attrib1 gt 2150))",
+      "expected": "(((:attrib1 > 130) and (:attrib2 > :attrib3)) or ((:attrib4 == 1) and (:attrib1 > 2150)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /task/family:attrib1) or (/suite/family:attrib1==/task/family:attrib1))",
+      "expected": "((/suite/family:attrib1 > /task/family:attrib1) or (/suite/family:attrib1 == /task/family:attrib1))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and (/task/node4/node5/node6/node7 eq active or /task/node4/node5/node6/node7 eq complete))",
+      "expected": "(((suite == complete) and (family == complete)) and ((/task/node4/node5/node6/node7 == active) or (/task/node4/node5/node6/node7 == complete)))"
+    },
+    {
+      "expression": "(:attrib1 eq 0)",
+      "expected": "(:attrib1 == 0)"
+    },
+    {
+      "expression": "(../../../suite/family/12/0 eq complete and task == complete)",
+      "expected": "((../../../suite/family/12/0 == complete) and (task == complete))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5:attrib1 gt 9 or /suite/family/task/node4/node5==complete) and (/suite/family/task/node6/node7 eq complete and /suite/family/task/node6/node8 eq complete and /suite/family/task/node6/node9 eq complete and /suite/family/task/node6/node10 eq complete or /suite/family/task/node6==complete))",
+      "expected": "(((/suite/family/task/node4/node5:attrib1 > 9) or (/suite/family/task/node4/node5 == complete)) and (((((/suite/family/task/node6/node7 == complete) and (/suite/family/task/node6/node8 == complete)) and (/suite/family/task/node6/node9 == complete)) and (/suite/family/task/node6/node10 == complete)) or (/suite/family/task/node6 == complete)))"
+    },
+    {
+      "expression": "(( /suite/family:attrib1 gt /task/family:attrib1) or (/suite/family:attrib1==/task/family:attrib1 and /suite/family/00/node4==complete) and (1==1 or /task/family/node5/node6==complete))",
+      "expected": "((/suite/family:attrib1 > /task/family:attrib1) or (((/suite/family:attrib1 == /task/family:attrib1) and (/suite/family/00/node4 == complete)) and ((1 == 1) or (/task/family/node5/node6 == complete))))"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4:attrib1 ge 360 or /suite/family/12/task/node4 eq complete)",
+      "expected": "((/suite/family/12/task/node4:attrib1 >= 360) or (/suite/family/12/task/node4 == complete))"
+    },
+    {
+      "expression": "((:attrib1 eq 0 or (suite/family/task eq complete)) and /node4/node5/node6/node7 eq complete)",
+      "expected": "(((:attrib1 == 0) or (suite/family/task == complete)) and (/node4/node5/node6/node7 == complete))"
+    },
+    {
+      "expression": "(( /suite/family:attrib1 gt /task/family:attrib1) or (/suite/family:attrib1==/task/family:attrib1 and /suite/family/00/node4==complete and /suite/family/00/node5/node6==complete) and /task/family/12/node7==complete)",
+      "expected": "((/suite/family:attrib1 > /task/family:attrib1) or ((((/suite/family:attrib1 == /task/family:attrib1) and (/suite/family/00/node4 == complete)) and (/suite/family/00/node5/node6 == complete)) and (/task/family/12/node7 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5:attrib1 ge 144 or /suite/family/task/node4/node5 eq complete))",
+      "expected": "((/suite/family/task/node4/node5:attrib1 >= 144) or (/suite/family/task/node4/node5 == complete))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5:attrib1 gt 9 or /suite/family/task/node4/node5==complete) and /suite/family/12/node6/node7/node8/node9==complete)",
+      "expected": "(((/suite/family/task/node4/node5:attrib1 > 9) or (/suite/family/task/node4/node5 == complete)) and (/suite/family/12/node6/node7/node8/node9 == complete))"
+    },
+    {
+      "expression": "(../../../suite/family/06/1 eq complete and task == complete and ((:attrib1==1 and :attrib2 gt :attrib3 AND :attrib4 gt 950) or :attrib1 eq 0))",
+      "expected": "(((../../../suite/family/06/1 == complete) and (task == complete)) and ((((:attrib1 == 1) and (:attrib2 > :attrib3)) and (:attrib4 > 950)) or (:attrib1 == 0)))"
+    },
+    {
+      "expression": "(./suite == complete and ./family == complete and ./task == complete and ./node4 == complete and ./12 == complete and ./00 == complete and ./node5 == complete and ./node6 == complete and node7 == complete)",
+      "expected": "(((((((((./suite == complete) and (./family == complete)) and (./task == complete)) and (./node4 == complete)) and (./12 == complete)) and (./00 == complete)) and (./node5 == complete)) and (./node6 == complete)) and (node7 == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 == /suite/task:attrib1 and /suite/family/node4/node5 == complete))",
+      "expected": "((/suite/family:attrib1 > /suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/node4/node5 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/node4/node5==complete and /suite/family/node4/node6==complete)) and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/node4/node5 eq complete and (/suite/family/node4/node6/node7:attrib2 ge 9 or /suite/family/node4/node6/node7 eq complete))))",
+      "expected": "(((/suite/family:attrib1 > /suite/task:attrib1) or (((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/node4/node5 == complete)) and (/suite/family/node4/node6 == complete))) and ((/suite/family:attrib1 > /suite/task:attrib1) or (((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/node4/node5 == complete)) and ((/suite/family/node4/node6/node7:attrib2 >= 9) or (/suite/family/node4/node6/node7 == complete)))))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and (/suite/family/node4/node5/node6:attrib2 ge 030 or /suite/family/node4/node5/node6==complete)))",
+      "expected": "((/suite/family:attrib1 > /suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and ((/suite/family/node4/node5/node6:attrib2 >= 30) or (/suite/family/node4/node5/node6 == complete))))"
+    },
+    {
+      "expression": "((suite == complete and family == complete and task == complete and node4 == complete and node5 == complete) and (node6 == complete))",
+      "expected": "((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete))"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and 1==1)) and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/node4/node5/node6 eq complete)))",
+      "expected": "(((/suite/family:attrib1 > /suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and (1 == 1))) and ((/suite/family:attrib1 > /suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/node4/node5/node6 == complete))))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 % 100) != 1)",
+      "expected": "((/suite/family:attrib1 % 100) != 1)"
+    },
+    {
+      "expression": "((/suite/family:attrib1 ge /suite/task:attrib1 and /suite/node4:attrib1 ge /suite/task:attrib1) and (family:attrib1 ge task:attrib1))",
+      "expected": "(((/suite/family:attrib1 >= /suite/task:attrib1) and (/suite/node4:attrib1 >= /suite/task:attrib1)) and (family:attrib1 >= task:attrib1))"
+    },
+    {
+      "expression": "(( /suite/family/task eq complete and /suite/node4/task eq complete))",
+      "expected": "((/suite/family/task == complete) and (/suite/node4/task == complete))"
+    },
+    {
+      "expression": "(((suite == complete) and (../../family == complete and ../../task == complete)) and (../node4/suite == complete))",
+      "expected": "(((suite == complete) and ((../../family == complete) and (../../task == complete))) and (../node4/suite == complete))"
+    },
+    {
+      "expression": "((./suite:attrib1 ge ./family:attrib1) and (task eq complete))",
+      "expected": "((./suite:attrib1 >= ./family:attrib1) and (task == complete))"
+    },
+    {
+      "expression": "(:attrib1 eq 1400 or ./1/suite eq complete or :attrib2 gt (:attrib3 +11))",
+      "expected": "((:attrib1 == 1400) or ((./1/suite == complete) or (:attrib2 > (:attrib3 + 11))))"
+    },
+    {
+      "expression": "((suite == complete) and (1==1))",
+      "expected": "((suite == complete) and (1 == 1))"
+    },
+    {
+      "expression": "((suite == complete) and (family:attrib1 gt task:attrib1))",
+      "expected": "((suite == complete) and (family:attrib1 > task:attrib1))"
+    },
+    {
+      "expression": "((:attrib1 % 10000) ne 101)",
+      "expected": "((:attrib1 % 10000) != 101)"
+    },
+    {
+      "expression": "((((suite eq complete and ./12 eq complete) and ./family eq complete) and ./00 eq complete) and ./task eq complete)",
+      "expected": "(((((suite == complete) and (./12 == complete)) and (./family == complete)) and (./00 == complete)) and (./task == complete))"
+    },
+    {
+      "expression": "((((((suite eq complete and ./12 eq complete) and ./family eq complete) and ./00 eq complete) and ./task eq complete) and node4 eq complete) and node5 eq complete)",
+      "expected": "(((((((suite == complete) and (./12 == complete)) and (./family == complete)) and (./00 == complete)) and (./task == complete)) and (node4 == complete)) and (node5 == complete))"
+    },
+    {
+      "expression": "((../suite/12 eq complete and ../suite:attrib1 eq ../family:attrib1) or ../family:attrib1 lt ../suite:attrib1)",
+      "expected": "(((../suite/12 == complete) and (../suite:attrib1 == ../family:attrib1)) or (../family:attrib1 < ../suite:attrib1))"
+    },
+    {
+      "expression": "(((./12 eq complete and ./suite eq complete) and ./00 eq complete) and ./family eq complete)",
+      "expected": "((((./12 == complete) and (./suite == complete)) and (./00 == complete)) and (./family == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 eq ../family:attrib1 and /suite/family/12/task/node4 eq complete) or node5 eq complete)",
+      "expected": "(((/suite/family:attrib1 == ../family:attrib1) and (/suite/family/12/task/node4 == complete)) or (node5 == complete))"
+    },
+    {
+      "expression": "(((/suite/family/12/task:attrib1 ge 240 or /suite/family/12/node4:attrib2 ge 240) or /suite/family/12/node5/node6 eq complete) or ../../../node7 eq complete)",
+      "expected": "((((/suite/family/12/task:attrib1 >= 240) or (/suite/family/12/node4:attrib2 >= 240)) or (/suite/family/12/node5/node6 == complete)) or (../../../node7 == complete))"
+    },
+    {
+      "expression": "(((/suite/family/12/task eq complete and /suite/family/12/node4 eq complete) and /suite/family/12/node5/node6 eq complete) or ../../../node7 eq complete)",
+      "expected": "((((/suite/family/12/task == complete) and (/suite/family/12/node4 == complete)) and (/suite/family/12/node5/node6 == complete)) or (../../../node7 == complete))"
+    },
+    {
+      "expression": "(suite:attrib1 lt family:attrib1)",
+      "expected": "(suite:attrib1 < family:attrib1)"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 > ./task:attrib1 or (/suite/family:attrib1 == ./task:attrib1 and /suite/family/node4/node5/node6 == complete))) and (./task:attrib1 le (../node7/task:attrib1 + /node8/9966:attrib2)))",
+      "expected": "(((/suite/family:attrib1 > ./task:attrib1) or ((/suite/family:attrib1 == ./task:attrib1) and (/suite/family/node4/node5/node6 == complete))) and (./task:attrib1 <= (../node7/task:attrib1 + /node8/9966:attrib2)))"
+    },
+    {
+      "expression": "(((../suite/family == complete and (../suite:attrib1 == ../task:attrib1-1)) or (../suite:attrib1 >= ../task:attrib1)) and node4 == complete and node5 == complete)",
+      "expected": "((((../suite/family == complete) and (../suite:attrib1 == (../task:attrib1 - 1))) or (../suite:attrib1 >= ../task:attrib1)) and ((node4 == complete) and (node5 == complete)))"
+    },
+    {
+      "expression": "(((../suite/family == complete and (../suite:attrib1 == ../task:attrib1)) or (../suite:attrib1 > ../task:attrib1)) and node4 == complete and node5 == complete)",
+      "expected": "((((../suite/family == complete) and (../suite:attrib1 == ../task:attrib1)) or (../suite:attrib1 > ../task:attrib1)) and ((node4 == complete) and (node5 == complete)))"
+    },
+    {
+      "expression": "(/suite/9966/family/task/node4 == complete and /suite/9966/family/task/node4:attrib1 == /suite/9966/family/node5/node4:attrib1 or (/suite/9966/family/task/node4:attrib1 gt /suite/9966/family/node5/node4:attrib1) and (/suite/9966/family/node5/node4:attrib1 le /suite/9966/family/node6/node4:attrib1 + /suite/9966:attrib2))",
+      "expected": "(((/suite/9966/family/task/node4 == complete) and (/suite/9966/family/task/node4:attrib1 == /suite/9966/family/node5/node4:attrib1)) or ((/suite/9966/family/task/node4:attrib1 > /suite/9966/family/node5/node4:attrib1) and (/suite/9966/family/node5/node4:attrib1 <= (/suite/9966/family/node6/node4:attrib1 + /suite/9966:attrib2))))"
+    },
+    {
+      "expression": "((/suite/9966/family/task/node4/node5/node6/node7:attrib1 >= 12 and /suite/9966/family/task/node4/node5/node6/node8 eq complete and /suite/9966/family/task/node4/node5/node6/node9==complete and /suite/9966/family/task/node4/family/node6 == complete and (/suite/9966/family/task/node4:attrib2 == /suite/9966/family/task/node10:attrib2-1)) or (/suite/9966/family/task/node4:attrib2 >= /suite/9966/family/task/node10:attrib2))",
+      "expected": "((((((/suite/9966/family/task/node4/node5/node6/node7:attrib1 >= 12) and (/suite/9966/family/task/node4/node5/node6/node8 == complete)) and (/suite/9966/family/task/node4/node5/node6/node9 == complete)) and (/suite/9966/family/task/node4/family/node6 == complete)) and (/suite/9966/family/task/node4:attrib2 == (/suite/9966/family/task/node10:attrib2 - 1))) or (/suite/9966/family/task/node4:attrib2 >= /suite/9966/family/task/node10:attrib2))"
+    },
+    {
+      "expression": "((/suite/9966/family/task/node4/node5 == complete and /suite/9966/family/task/node4/node6 == complete and /suite/9966/family/task/node4/node7/node8/node9 == complete and /suite/9966/family/task/node4/node7/node8/node10 == complete and /suite/9966/family/task/node4/node7/node8/node11 == complete and (/suite/9966/family/task/node4:attrib1 == /suite/9966/family/task/node12:attrib1-1)) or (/suite/9966/family/task/node4:attrib1 >= /suite/9966/family/task/node12:attrib1))",
+      "expected": "(((((((/suite/9966/family/task/node4/node5 == complete) and (/suite/9966/family/task/node4/node6 == complete)) and (/suite/9966/family/task/node4/node7/node8/node9 == complete)) and (/suite/9966/family/task/node4/node7/node8/node10 == complete)) and (/suite/9966/family/task/node4/node7/node8/node11 == complete)) and (/suite/9966/family/task/node4:attrib1 == (/suite/9966/family/task/node12:attrib1 - 1))) or (/suite/9966/family/task/node4:attrib1 >= /suite/9966/family/task/node12:attrib1))"
+    },
+    {
+      "expression": "(((/suite/9966/family/task/node4/node5/node6/node7:attrib1 >= 12 and /suite/9966/family/task/node4/node5/node6/node8 eq complete and /suite/9966/family/task/node4/node5/node6/node9==complete and /suite/9966/family/task/node4/family/node10 == complete and (/suite/9966/family/task/node4:attrib2 == /suite/9966/family/task/node11:attrib2-1)) or (/suite/9966/family/task/node4:attrib2 >= /suite/9966/family/task/node11:attrib2)) and ../node10/node12 == complete)",
+      "expected": "(((((((/suite/9966/family/task/node4/node5/node6/node7:attrib1 >= 12) and (/suite/9966/family/task/node4/node5/node6/node8 == complete)) and (/suite/9966/family/task/node4/node5/node6/node9 == complete)) and (/suite/9966/family/task/node4/family/node10 == complete)) and (/suite/9966/family/task/node4:attrib2 == (/suite/9966/family/task/node11:attrib2 - 1))) or (/suite/9966/family/task/node4:attrib2 >= /suite/9966/family/task/node11:attrib2)) and (../node10/node12 == complete))"
+    },
+    {
+      "expression": "((/suite/9966/family/task/node4/node5 == complete and /suite/9966/family/task/node4/node6 == complete and /suite/9966/family/task/node4/node7 == complete and /suite/9966/family/task/node4/node8/node9/node10 == complete and /suite/9966/family/task/node4/node8/node9/node11 == complete and /suite/9966/family/task/node4/node8/node9/node12 == complete and (/suite/9966/family/task/node4:attrib1 == /suite/9966/family/task/node13:attrib1-1)) or (/suite/9966/family/task/node4:attrib1 >= /suite/9966/family/task/node13:attrib1))",
+      "expected": "((((((((/suite/9966/family/task/node4/node5 == complete) and (/suite/9966/family/task/node4/node6 == complete)) and (/suite/9966/family/task/node4/node7 == complete)) and (/suite/9966/family/task/node4/node8/node9/node10 == complete)) and (/suite/9966/family/task/node4/node8/node9/node11 == complete)) and (/suite/9966/family/task/node4/node8/node9/node12 == complete)) and (/suite/9966/family/task/node4:attrib1 == (/suite/9966/family/task/node13:attrib1 - 1))) or (/suite/9966/family/task/node4:attrib1 >= /suite/9966/family/task/node13:attrib1))"
+    },
+    {
+      "expression": "(suite:attrib1 >= 12 or suite eq complete)",
+      "expected": "((suite:attrib1 >= 12) or (suite == complete))"
+    },
+    {
+      "expression": "(../../suite:attrib1 >= 3 or ../../suite == complete)",
+      "expected": "((../../suite:attrib1 >= 3) or (../../suite == complete))"
+    },
+    {
+      "expression": "((/suite/9966/family/task/node4/node5/node6/node7:attrib1 >= 12 and /suite/9966/family/task/node4/node5/node6/node8 eq complete and /suite/9966/family/task/node4/node5/node6/node9==complete and /suite/9966/family/task/node4/family/node6 == complete and (/suite/9966/family/task/node4:attrib2 == /suite/9966/family/task/node10:attrib2)) or (/suite/9966/family/task/node4:attrib2 > /suite/9966/family/task/node10:attrib2))",
+      "expected": "((((((/suite/9966/family/task/node4/node5/node6/node7:attrib1 >= 12) and (/suite/9966/family/task/node4/node5/node6/node8 == complete)) and (/suite/9966/family/task/node4/node5/node6/node9 == complete)) and (/suite/9966/family/task/node4/family/node6 == complete)) and (/suite/9966/family/task/node4:attrib2 == /suite/9966/family/task/node10:attrib2)) or (/suite/9966/family/task/node4:attrib2 > /suite/9966/family/task/node10:attrib2))"
+    },
+    {
+      "expression": "((/suite/9966/family/task/node4/node5 == complete and /suite/9966/family/task/node4/node6 == complete and /suite/9966/family/task/node4/node7/node8/node9 == complete and /suite/9966/family/task/node4/node7/node8/node10 == complete and /suite/9966/family/task/node4/node7/node8/node11 == complete and (/suite/9966/family/task/node4:attrib1 == /suite/9966/family/task/node12:attrib1)) or (/suite/9966/family/task/node4:attrib1 > /suite/9966/family/task/node12:attrib1))",
+      "expected": "(((((((/suite/9966/family/task/node4/node5 == complete) and (/suite/9966/family/task/node4/node6 == complete)) and (/suite/9966/family/task/node4/node7/node8/node9 == complete)) and (/suite/9966/family/task/node4/node7/node8/node10 == complete)) and (/suite/9966/family/task/node4/node7/node8/node11 == complete)) and (/suite/9966/family/task/node4:attrib1 == /suite/9966/family/task/node12:attrib1)) or (/suite/9966/family/task/node4:attrib1 > /suite/9966/family/task/node12:attrib1))"
+    },
+    {
+      "expression": "(((/suite/9966/family/task/node4/node5/node6/node7:attrib1 >= 12 and /suite/9966/family/task/node4/node5/node6/node8 eq complete and /suite/9966/family/task/node4/node5/node6/node9==complete and /suite/9966/family/task/node4/family/node10 == complete and (/suite/9966/family/task/node4:attrib2 == /suite/9966/family/task/node11:attrib2)) or (/suite/9966/family/task/node4:attrib2 > /suite/9966/family/task/node11:attrib2)) and ../node10/node12 == complete)",
+      "expected": "(((((((/suite/9966/family/task/node4/node5/node6/node7:attrib1 >= 12) and (/suite/9966/family/task/node4/node5/node6/node8 == complete)) and (/suite/9966/family/task/node4/node5/node6/node9 == complete)) and (/suite/9966/family/task/node4/family/node10 == complete)) and (/suite/9966/family/task/node4:attrib2 == /suite/9966/family/task/node11:attrib2)) or (/suite/9966/family/task/node4:attrib2 > /suite/9966/family/task/node11:attrib2)) and (../node10/node12 == complete))"
+    },
+    {
+      "expression": "((/suite/9966/family/task/node4/node5 == complete and /suite/9966/family/task/node4/node6 == complete and /suite/9966/family/task/node4/node7 == complete and /suite/9966/family/task/node4/node8/node9/node10 == complete and /suite/9966/family/task/node4/node8/node9/node11 == complete and /suite/9966/family/task/node4/node8/node9/node12 == complete and (/suite/9966/family/task/node4:attrib1 == /suite/9966/family/task/node13:attrib1)) or (/suite/9966/family/task/node4:attrib1 > /suite/9966/family/task/node13:attrib1))",
+      "expected": "((((((((/suite/9966/family/task/node4/node5 == complete) and (/suite/9966/family/task/node4/node6 == complete)) and (/suite/9966/family/task/node4/node7 == complete)) and (/suite/9966/family/task/node4/node8/node9/node10 == complete)) and (/suite/9966/family/task/node4/node8/node9/node11 == complete)) and (/suite/9966/family/task/node4/node8/node9/node12 == complete)) and (/suite/9966/family/task/node4:attrib1 == /suite/9966/family/task/node13:attrib1)) or (/suite/9966/family/task/node4:attrib1 > /suite/9966/family/task/node13:attrib1))"
+    },
+    {
+      "expression": "(/suite/9966/family/task/node4/family == complete and /suite/9966/family/task/node4:attrib1 == /suite/9966/family/node5/node4:attrib1 or (/suite/9966/family/task/node4:attrib1 gt /suite/9966/family/node5/node4:attrib1))",
+      "expected": "(((/suite/9966/family/task/node4/family == complete) and (/suite/9966/family/task/node4:attrib1 == /suite/9966/family/node5/node4:attrib1)) or (/suite/9966/family/task/node4:attrib1 > /suite/9966/family/node5/node4:attrib1))"
+    },
+    {
+      "expression": "((/suite/9966/family/task/node4/node5 == complete and /suite/9966/family/task/node4/node6 == complete and /suite/9966/family/task/node4:attrib1 == /suite/9966/family/node7/node4:attrib1) or (/suite/9966/family/task/node4:attrib1 gt /suite/9966/family/node7/node4:attrib1))",
+      "expected": "((((/suite/9966/family/task/node4/node5 == complete) and (/suite/9966/family/task/node4/node6 == complete)) and (/suite/9966/family/task/node4:attrib1 == /suite/9966/family/node7/node4:attrib1)) or (/suite/9966/family/task/node4:attrib1 > /suite/9966/family/node7/node4:attrib1))"
+    },
+    {
+      "expression": "(((../suite:attrib1 >= ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1-1) and ../suite/task == complete)) and node4 == complete and node5 == complete)",
+      "expected": "(((../suite:attrib1 >= ../family:attrib1) or ((../suite:attrib1 == (../family:attrib1 - 1)) and (../suite/task == complete))) and ((node4 == complete) and (node5 == complete)))"
+    },
+    {
+      "expression": "((((../suite:attrib1 >= ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1-1) and ../suite/task == complete)) and node4 == complete and node5 == complete) and (node6 == complete))",
+      "expected": "((((../suite:attrib1 >= ../family:attrib1) or ((../suite:attrib1 == (../family:attrib1 - 1)) and (../suite/task == complete))) and ((node4 == complete) and (node5 == complete))) and (node6 == complete))"
+    },
+    {
+      "expression": "((((/suite/9966/family/task/node4:attrib1 gt /suite/9966/family/node5/node4:attrib1) or (/suite/9966/family/task/node4/node6 == complete))) and (node7 == complete))",
+      "expected": "(((/suite/9966/family/task/node4:attrib1 > /suite/9966/family/node5/node4:attrib1) or (/suite/9966/family/task/node4/node6 == complete)) and (node7 == complete))"
+    },
+    {
+      "expression": "(((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and ../suite/task == complete)) and node4 == complete and node5 == complete)",
+      "expected": "(((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and (../suite/task == complete))) and ((node4 == complete) and (node5 == complete)))"
+    },
+    {
+      "expression": "((((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and ../suite/task == complete)) and node4 == complete and node5 == complete) and (node6 == complete))",
+      "expected": "((((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and (../suite/task == complete))) and ((node4 == complete) and (node5 == complete))) and (node6 == complete))"
+    },
+    {
+      "expression": "((/suite/9966/family/task/node4/node5/node6 == complete and /suite/9966/family/task/node4:attrib1 == /suite/9966/family/node7:attrib1 + 1 or (/suite/9966/family/task/node4:attrib1 gt /suite/9966/family/node7:attrib1 + 1)) and (/suite/9966/family/task/node8/node5/node6 == complete and /suite/9966/family/task/node8:attrib1 == /suite/9966/family/node7:attrib1 or (/suite/9966/family/task/node8:attrib1 gt /suite/9966/family/node7:attrib1 )))",
+      "expected": "((((/suite/9966/family/task/node4/node5/node6 == complete) and (/suite/9966/family/task/node4:attrib1 == (/suite/9966/family/node7:attrib1 + 1))) or (/suite/9966/family/task/node4:attrib1 > (/suite/9966/family/node7:attrib1 + 1))) and (((/suite/9966/family/task/node8/node5/node6 == complete) and (/suite/9966/family/task/node8:attrib1 == /suite/9966/family/node7:attrib1)) or (/suite/9966/family/task/node8:attrib1 > /suite/9966/family/node7:attrib1)))"
+    },
+    {
+      "expression": "(suite:attrib1 le ../family/suite:attrib1)",
+      "expected": "(suite:attrib1 <= ../family/suite:attrib1)"
+    },
+    {
+      "expression": "((suite == complete) and (/family/9966/task/node4/node5/node6 == complete and /family/9966/task/node4/node5:attrib1 == /family/9966/task/node7/node5:attrib1 or (/family/9966/task/node4/node5:attrib1 gt /family/9966/task/node7/node5:attrib1)))",
+      "expected": "((suite == complete) and (((/family/9966/task/node4/node5/node6 == complete) and (/family/9966/task/node4/node5:attrib1 == /family/9966/task/node7/node5:attrib1)) or (/family/9966/task/node4/node5:attrib1 > /family/9966/task/node7/node5:attrib1)))"
+    },
+    {
+      "expression": "((/suite/9966/family/task/node4/node5 == complete and /suite/9966/family/task/node4:attrib1 == /suite/9966/family/node6/node4:attrib1 or (/suite/9966/family/task/node4:attrib1 gt /suite/9966/family/node6/node4:attrib1)) and (/suite/9966/family/task/node4/node7 == complete and /suite/9966/family/task/node4:attrib1 == /suite/9966/family/node6/node4:attrib1 or (/suite/9966/family/task/node4:attrib1 gt /suite/9966/family/node6/node4:attrib1)))",
+      "expected": "((((/suite/9966/family/task/node4/node5 == complete) and (/suite/9966/family/task/node4:attrib1 == /suite/9966/family/node6/node4:attrib1)) or (/suite/9966/family/task/node4:attrib1 > /suite/9966/family/node6/node4:attrib1)) and (((/suite/9966/family/task/node4/node7 == complete) and (/suite/9966/family/task/node4:attrib1 == /suite/9966/family/node6/node4:attrib1)) or (/suite/9966/family/task/node4:attrib1 > /suite/9966/family/node6/node4:attrib1)))"
+    },
+    {
+      "expression": "((/suite/9966/family/task/node4:attrib1 == /suite/9966/family/task/node5:attrib1) and /suite/9966/family/node6/node4/node7 == complete and /suite/9966/family/node6/node4:attrib1 == /suite/9966/family/task/node4:attrib1 or (/suite/9966/family/node6/node4:attrib1 gt /suite/9966/family/task/node4:attrib1))",
+      "expected": "((/suite/9966/family/task/node4:attrib1 == /suite/9966/family/task/node5:attrib1) and (((/suite/9966/family/node6/node4/node7 == complete) and (/suite/9966/family/node6/node4:attrib1 == /suite/9966/family/task/node4:attrib1)) or (/suite/9966/family/node6/node4:attrib1 > /suite/9966/family/task/node4:attrib1)))"
+    },
+    {
+      "expression": "((/suite/9966/family/task/node4:attrib1 gt /suite/9966/family/task/node5:attrib1) and /suite/9966/family/node6/node5/node7 == complete and /suite/9966/family/node6/node5:attrib1 == /suite/9966/family/task/node5:attrib1 or (/suite/9966/family/node6/node5:attrib1 gt /suite/9966/family/task/node5:attrib1))",
+      "expected": "((/suite/9966/family/task/node4:attrib1 > /suite/9966/family/task/node5:attrib1) and (((/suite/9966/family/node6/node5/node7 == complete) and (/suite/9966/family/node6/node5:attrib1 == /suite/9966/family/task/node5:attrib1)) or (/suite/9966/family/node6/node5:attrib1 > /suite/9966/family/task/node5:attrib1)))"
+    },
+    {
+      "expression": "((((/suite/family/task/12/family/node4 eq complete) and (/node5/node6/node7/node8/task:attrib1 eq /suite/family/task:attrib1)) or (/node5/node6/node7/node8/task:attrib1 lt /suite/family/task:attrib1)))",
+      "expected": "(((/suite/family/task/12/family/node4 == complete) and (/node5/node6/node7/node8/task:attrib1 == /suite/family/task:attrib1)) or (/node5/node6/node7/node8/task:attrib1 < /suite/family/task:attrib1))"
+    },
+    {
+      "expression": "(((((suite eq complete and ./12 eq complete) and ./family eq complete) and ./00 eq complete) and ./task eq complete) and node4 eq complete)",
+      "expected": "((((((suite == complete) and (./12 == complete)) and (./family == complete)) and (./00 == complete)) and (./task == complete)) and (node4 == complete))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/12/360/node6 eq complete and /suite/family/task/node4/node5:attrib1 eq :attrib1) or (/suite/family/task/node4/node5:attrib1 gt :attrib1)))",
+      "expected": "(((/suite/family/task/node4/node5/12/360/node6 == complete) and (/suite/family/task/node4/node5:attrib1 == :attrib1)) or (/suite/family/task/node4/node5:attrib1 > :attrib1))"
+    },
+    {
+      "expression": "(../suite/12 eq complete or ../family:attrib1 lt ../suite:attrib1)",
+      "expected": "((../suite/12 == complete) or (../family:attrib1 < ../suite:attrib1))"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 eq ../family:attrib1 and (/suite/family/12/task:attrib2 ge 0 or /suite/family/12 eq complete)) or node4 eq complete) and ../node5 eq complete)",
+      "expected": "((((/suite/family:attrib1 == ../family:attrib1) and ((/suite/family/12/task:attrib2 >= 0) or (/suite/family/12 == complete))) or (node4 == complete)) and (../node5 == complete))"
+    },
+    {
+      "expression": "((/suite/9993/family/task/node4:attrib1 >= /suite/9993/family/task/node5:attrib1) or ((/suite/9993/family/task/node4:attrib1 == /suite/9993/family/task/node5:attrib1-1) and /suite/9993/family/task/node4/node6/node7:attrib2 >= 12 and /suite/9993/family/task/node4/node6/node8==complete and /suite/9993/family/task/node4/family==complete))",
+      "expected": "((/suite/9993/family/task/node4:attrib1 >= /suite/9993/family/task/node5:attrib1) or ((/suite/9993/family/task/node4:attrib1 == (/suite/9993/family/task/node5:attrib1 - 1)) and (((/suite/9993/family/task/node4/node6/node7:attrib2 >= 12) and (/suite/9993/family/task/node4/node6/node8 == complete)) and (/suite/9993/family/task/node4/family == complete))))"
+    },
+    {
+      "expression": "((/suite/9993/family/task/node4:attrib1 > /suite/9993/family/task/node5:attrib1) or ((/suite/9993/family/task/node4:attrib1 == /suite/9993/family/task/node5:attrib1) and /suite/9993/family/task/node4/node6/node7:attrib2 >= 12 and /suite/9993/family/task/node4/node6/node8==complete and /suite/9993/family/task/node4/family==complete))",
+      "expected": "((/suite/9993/family/task/node4:attrib1 > /suite/9993/family/task/node5:attrib1) or ((/suite/9993/family/task/node4:attrib1 == /suite/9993/family/task/node5:attrib1) and (((/suite/9993/family/task/node4/node6/node7:attrib2 >= 12) and (/suite/9993/family/task/node4/node6/node8 == complete)) and (/suite/9993/family/task/node4/family == complete))))"
+    },
+    {
+      "expression": "(suite == complete && family == complete)",
+      "expected": "((suite == complete) and (family == complete))"
+    },
+    {
+      "expression": "(20010613 == complete)",
+      "expected": "(20010613 == complete)"
+    },
+    {
+      "expression": "(:attrib1 eq 1405 or :attrib2 eq 1 or 1==1)",
+      "expected": "((:attrib1 == 1405) or ((:attrib2 == 1) or (1 == 1)))"
+    },
+    {
+      "expression": "(( ( /suite/family:attrib1 ge task:attrib1) and (/suite/node4/node5:attrib1 ge task:attrib1)))",
+      "expected": "((/suite/family:attrib1 >= task:attrib1) and (/suite/node4/node5:attrib1 >= task:attrib1))"
+    },
+    {
+      "expression": "(((/suite/family/task:attrib1 ge /suite/node4/node5/node6:attrib1) or (/suite/family/task:attrib1 eq /suite/node4/node5/node6:attrib1 and /suite/family/task/node7 eq complete)) or (/suite/family:attrib2 gt /suite/node4/node5:attrib2))",
+      "expected": "(((/suite/family/task:attrib1 >= /suite/node4/node5/node6:attrib1) or ((/suite/family/task:attrib1 == /suite/node4/node5/node6:attrib1) and (/suite/family/task/node7 == complete))) or (/suite/family:attrib2 > /suite/node4/node5:attrib2))"
+    },
+    {
+      "expression": "((/suite/family/task:attrib1 + /suite/family/task/node4:attrib2) gt (/suite/family/node5:attrib1 + /suite/family/node5/node4:attrib2))",
+      "expected": "((/suite/family/task:attrib1 + /suite/family/task/node4:attrib2) > (/suite/family/node5:attrib1 + /suite/family/node5/node4:attrib2))"
+    },
+    {
+      "expression": "(((suite:attrib1 gt family:attrib1) or (suite:attrib1 eq family:attrib1 and suite/task==complete ) or (suite==complete )))",
+      "expected": "((suite:attrib1 > family:attrib1) or (((suite:attrib1 == family:attrib1) and (suite/task == complete)) or (suite == complete)))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and ((/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 19 or (/node4/node5/node6:attrib1 - :attrib2) < 19))",
+      "expected": "((((suite == complete) and (family == complete)) and (task == complete)) and (((/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 19) or ((/node4/node5/node6:attrib1 - :attrib2) < 19)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5==complete or /suite/family/task/node6:attrib1 ge 000)) and (../node7/000==complete))",
+      "expected": "(((/suite/family/task/node4/node5 == complete) or (/suite/family/task/node6:attrib1 >= 0)) and (../node7/000 == complete))"
+    },
+    {
+      "expression": "(../suite:attrib1 <= :attrib2 and :attrib3 > 1000)",
+      "expected": "((../suite:attrib1 <= :attrib2) and (:attrib3 > 1000))"
+    },
+    {
+      "expression": "(suite:attrib1 <= /family/task/node4:attrib1 and /family/node5 == complete)",
+      "expected": "((suite:attrib1 <= /family/task/node4:attrib1) and (/family/node5 == complete))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 > ../node4:attrib1 and node5 == complete)",
+      "expected": "((/suite/family/task:attrib1 > ../node4:attrib1) and (node5 == complete))"
+    },
+    {
+      "expression": "(/suite/family == complete and task:attrib1 < /suite/node4:attrib1)",
+      "expected": "((/suite/family == complete) and (task:attrib1 < /suite/node4:attrib1))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 < /suite/task:attrib1 or /suite/family:attrib1 == /suite/task:attrib1 and /suite/task/node4/06/node5 == complete)",
+      "expected": "((/suite/family:attrib1 < /suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/task/node4/06/node5 == complete)))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 > ../task:attrib1 and node4 == complete and 06 == complete and 18 == complete)",
+      "expected": "((((/suite/family:attrib1 > ../task:attrib1) and (node4 == complete)) and (06 == complete)) and (18 == complete))"
+    },
+    {
+      "expression": "((./suite == complete or ./suite:attrib1 gt ./family:attrib1))",
+      "expected": "((./suite == complete) or (./suite:attrib1 > ./family:attrib1))"
+    },
+    {
+      "expression": "((1 eq 1))",
+      "expected": "(1 == 1)"
+    },
+    {
+      "expression": "((suite == complete or ./suite:attrib1 gt ./family:attrib1) and (not task:attrib2))",
+      "expected": "(((suite == complete) or (./suite:attrib1 > ./family:attrib1)) and not (task:attrib2))"
+    },
+    {
+      "expression": "((suite == complete or ./suite:attrib1 gt ./family:attrib1) and (task == complete or ./task:attrib1 gt ./family:attrib1) and (not node4:attrib2))",
+      "expected": "(((suite == complete) or (./suite:attrib1 > ./family:attrib1)) and (((task == complete) or (./task:attrib1 > ./family:attrib1)) and not (node4:attrib2)))"
+    },
+    {
+      "expression": "(suite == complete && family==complete && task == complete && node4 == complete)",
+      "expected": "((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete))"
+    },
+    {
+      "expression": "(/suite/family/archived/task:attrib1 gt ./task:attrib1)",
+      "expected": "(/suite/family/archived/task:attrib1 > ./task:attrib1)"
+    },
+    {
+      "expression": "(../../suite:attrib1 < :attrib2 and :attrib3 > 1100)",
+      "expected": "((../../suite:attrib1 < :attrib2) and (:attrib3 > 1100))"
+    },
+    {
+      "expression": "(cal::date_to_julian(../suite:attrib1) lt ../family:attrib2 or (cal::date_to_julian(../suite:attrib1) eq ../family:attrib2 and ./06:attrib3 le ../family:attrib4))",
+      "expected": "((date_to_julian(arg:0) = 0 < ../family:attrib2) or ((date_to_julian(arg:0) = 0 == ../family:attrib2) and (./06:attrib3 <= ../family:attrib4)))"
+    },
+    {
+      "expression": "(cal::date_to_julian(../suite:attrib1) + 1 lt ../family:attrib2 or (cal::date_to_julian(../suite:attrib1) + 1 eq ../family:attrib2 and ./00:attrib3 le ../family:attrib4))",
+      "expected": "(((date_to_julian(arg:0) = 0 + 1) < ../family:attrib2) or (((date_to_julian(arg:0) = 0 + 1) == ../family:attrib2) and (./00:attrib3 <= ../family:attrib4)))"
+    },
+    {
+      "expression": "(../../../suite:attrib1 lt ../../../family/task:attrib1 or (../../../suite:attrib1 eq ../../../family/task:attrib1 and ../../../family/task/12 eq complete))",
+      "expected": "((../../../suite:attrib1 < ../../../family/task:attrib1) or ((../../../suite:attrib1 == ../../../family/task:attrib1) and (../../../family/task/12 == complete)))"
+    },
+    {
+      "expression": "(../../../suite:attrib1 or ../../../suite:attrib2)",
+      "expected": "(../../../suite:attrib1 or ../../../suite:attrib2)"
+    },
+    {
+      "expression": "(suite:attrib1 le family:attrib1 and task eq complete)",
+      "expected": "((suite:attrib1 <= family:attrib1) and (task == complete))"
+    },
+    {
+      "expression": "(../../suite:attrib1 eq ../../family:attrib1 and ../../family/task/13:attrib2)",
+      "expected": "((../../suite:attrib1 == ../../family:attrib1) and ../../family/task/13:attrib2)"
+    },
+    {
+      "expression": "(../../suite:attrib1 lt ../../family:attrib1 or ((../../suite:attrib1 eq ../../family:attrib1 and ../../family/task/00 eq complete) and ../../family/node4/00 eq complete))",
+      "expected": "((../../suite:attrib1 < ../../family:attrib1) or (((../../suite:attrib1 == ../../family:attrib1) and (../../family/task/00 == complete)) and (../../family/node4/00 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4:attrib1 ge 45 or /suite/family/12/task eq complete) or ../../../node5 eq complete)",
+      "expected": "(((/suite/family/12/task/node4:attrib1 >= 45) or (/suite/family/12/task == complete)) or (../../../node5 == complete))"
+    },
+    {
+      "expression": "(((/suite/family/12/task:attrib1 ge 240 or /suite/family/12/node4:attrib2 ge 240) or /suite/family/12/node5/node6 eq complete) and (/node7/family/12/node6/node8:attrib2 ge 240 or /node7/family/12/node6 eq complete))",
+      "expected": "((((/suite/family/12/task:attrib1 >= 240) or (/suite/family/12/node4:attrib2 >= 240)) or (/suite/family/12/node5/node6 == complete)) and ((/node7/family/12/node6/node8:attrib2 >= 240) or (/node7/family/12/node6 == complete)))"
+    },
+    {
+      "expression": "((./240/suite:attrib1 and /family/task/12/node4/node5 eq complete) and /node6/task/12/node5 eq complete)",
+      "expected": "((./240/suite:attrib1 and (/family/task/12/node4/node5 == complete)) and (/node6/task/12/node5 == complete))"
+    },
+    {
+      "expression": "((((/suite/family/12/task:attrib1 ge 72 or /suite/family/12/node4:attrib2 ge 72) or /suite/family/12/node5/node6 eq complete) or ../../../node7 eq complete) and ((/node8/family/12/node6/node9:attrib2 ge 72 or /node8/family/12/node6 eq complete) or ../../../node7 eq complete))",
+      "expected": "(((((/suite/family/12/task:attrib1 >= 72) or (/suite/family/12/node4:attrib2 >= 72)) or (/suite/family/12/node5/node6 == complete)) or (../../../node7 == complete)) and (((/node8/family/12/node6/node9:attrib2 >= 72) or (/node8/family/12/node6 == complete)) or (../../../node7 == complete)))"
+    },
+    {
+      "expression": "((((/suite/family/12/task eq complete and /suite/family/12/node4 eq complete) and /suite/family/12/node5/node6 eq complete) or ../../../node7 eq complete) and (/node8/family/12/node6 eq complete or ../../../node7 eq complete))",
+      "expected": "(((((/suite/family/12/task == complete) and (/suite/family/12/node4 == complete)) and (/suite/family/12/node5/node6 == complete)) or (../../../node7 == complete)) and ((/node8/family/12/node6 == complete) or (../../../node7 == complete)))"
+    },
+    {
+      "expression": "(:attrib1 - :attrib2 le 8)",
+      "expected": "((:attrib1 - :attrib2) <= 8)"
+    },
+    {
+      "expression": "(../../../suite:attrib1 ge ../../family:attrib1)",
+      "expected": "(../../../suite:attrib1 >= ../../family:attrib1)"
+    },
+    {
+      "expression": "((suite eq complete and family eq complete) and task eq complete)",
+      "expected": "(((suite == complete) and (family == complete)) and (task == complete))"
+    },
+    {
+      "expression": "((suite eq complete and family eq complete) and cal::date_to_julian(../task:attrib1) + 5 ge cal::date_to_julian(../node4:attrib1))",
+      "expected": "(((suite == complete) and (family == complete)) and ((date_to_julian(arg:0) = 0 + 5) >= date_to_julian(arg:0) = 0))"
+    },
+    {
+      "expression": "(suite:attrib1 gt family:attrib1 or (suite:attrib1 eq family:attrib1 and suite/task eq complete))",
+      "expected": "((suite:attrib1 > family:attrib1) or ((suite:attrib1 == family:attrib1) and (suite/task == complete)))"
+    },
+    {
+      "expression": "(suite eq complete or suite:attrib1)",
+      "expected": "((suite == complete) or suite:attrib1)"
+    },
+    {
+      "expression": "(suite eq complete and (../../../../family:attrib1 ge ../../../../task:attrib1 or (cal::date_to_julian(../../../../task:attrib1) eq cal::date_to_julian(../../../../family:attrib1) + 5 and ../../../../family/node4 eq complete)))",
+      "expected": "((suite == complete) and ((../../../../family:attrib1 >= ../../../../task:attrib1) or ((date_to_julian(arg:0) = 0 == (date_to_julian(arg:0) = 0 + 5)) and (../../../../family/node4 == complete))))"
+    },
+    {
+      "expression": "(../../suite:attrib1 ne 1)",
+      "expected": "(../../suite:attrib1 != 1)"
+    },
+    {
+      "expression": "((suite:attrib1 gt family:attrib1 or (suite:attrib1 eq family:attrib1 and suite/task eq complete)) or suite eq complete)",
+      "expected": "(((suite:attrib1 > family:attrib1) or ((suite:attrib1 == family:attrib1) and (suite/task == complete))) or (suite == complete))"
+    },
+    {
+      "expression": "(((suite:attrib1 gt family:attrib1 or (suite:attrib1 eq family:attrib1 and suite/task eq complete)) or suite eq complete) and ((node4:attrib1 gt family:attrib1 or (node4:attrib1 eq family:attrib1 and node4/node5 eq complete)) or node4/node5 eq complete))",
+      "expected": "((((suite:attrib1 > family:attrib1) or ((suite:attrib1 == family:attrib1) and (suite/task == complete))) or (suite == complete)) and (((node4:attrib1 > family:attrib1) or ((node4:attrib1 == family:attrib1) and (node4/node5 == complete))) or (node4/node5 == complete)))"
+    },
+    {
+      "expression": "((((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and node6 eq complete) and (../node7:attrib1 gt ../node8:attrib1 or ../node7 eq complete))",
+      "expected": "(((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and ((../node7:attrib1 > ../node8:attrib1) or (../node7 == complete)))"
+    },
+    {
+      "expression": "(((((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and node6 eq complete) and node7 eq complete) and node8 eq complete)",
+      "expected": "((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete))"
+    },
+    {
+      "expression": "((../suite:attrib1 / 100) % 100 ne 01)",
+      "expected": "(((../suite:attrib1 / 100) % 100) != 1)"
+    },
+    {
+      "expression": "((suite:attrib1 le family:attrib1 + 4))",
+      "expected": "(suite:attrib1 <= (family:attrib1 + 4))"
+    },
+    {
+      "expression": "((../../suite:attrib1 lt :attrib2 - 2 or (../../suite:attrib1 eq :attrib2 - 2 and :attrib3 ge 1240)) and ../family==complete)",
+      "expected": "(((../../suite:attrib1 < (:attrib2 - 2)) or ((../../suite:attrib1 == (:attrib2 - 2)) and (:attrib3 >= 1240))) and (../family == complete))"
+    },
+    {
+      "expression": "(1 eq 0)",
+      "expected": "(1 == 0)"
+    },
+    {
+      "expression": "(suite:attrib1 le family:attrib1 + 3 and (task:attrib1 gt suite:attrib1 or task/node4 eq complete))",
+      "expected": "((suite:attrib1 <= (family:attrib1 + 3)) and ((task:attrib1 > suite:attrib1) or (task/node4 == complete)))"
+    },
+    {
+      "expression": "(suite:attrib1 gt family:attrib1 or suite/task eq complete)",
+      "expected": "((suite:attrib1 > family:attrib1) or (suite/task == complete))"
+    },
+    {
+      "expression": "((((((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and node6 eq complete) and node7 eq complete) and node8 eq complete) and node9 eq complete)",
+      "expected": "(((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete))"
+    },
+    {
+      "expression": "(suite eq complete and ../family:attrib1 gt ../task:attrib1 and ../node4:attrib1 gt ../task:attrib1)",
+      "expected": "(((suite == complete) and (../family:attrib1 > ../task:attrib1)) and (../node4:attrib1 > ../task:attrib1))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 == /task/node4/node5/node6/node7:attrib1 and /suite/family/00 == complete) or (/suite/family:attrib1 > /task/node4/node5/node6/node7:attrib1))",
+      "expected": "(((/suite/family:attrib1 == /task/node4/node5/node6/node7:attrib1) and (/suite/family/00 == complete)) or (/suite/family:attrib1 > /task/node4/node5/node6/node7:attrib1))"
+    },
+    {
+      "expression": "(../suite/family:attrib1 > ../task:attrib1 and node4 == complete and node5 == complete)",
+      "expected": "(((../suite/family:attrib1 > ../task:attrib1) and (node4 == complete)) and (node5 == complete))"
+    },
+    {
+      "expression": "(../suite/family:attrib1 > ../task:attrib1 and node4 == complete and node5 == complete and node6 == complete)",
+      "expected": "((((../suite/family:attrib1 > ../task:attrib1) and (node4 == complete)) and (node5 == complete)) and (node6 == complete))"
+    },
+    {
+      "expression": "(suite == complete and family/task:attrib1 >= node4:attrib1)",
+      "expected": "((suite == complete) and (family/task:attrib1 >= node4:attrib1))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 > /suite/family/node4/20230801:attrib1 or /suite/family/node4/20230801:attrib1 == /suite/family/task:attrib1 and (/suite/family/task/node5 == complete and /suite/family/task/node6 == complete and /suite/family/task/node7 == complete and /suite/family/task/node8 == complete))",
+      "expected": "((/suite/family/task:attrib1 > /suite/family/node4/20230801:attrib1) or ((/suite/family/node4/20230801:attrib1 == /suite/family/task:attrib1) and ((((/suite/family/task/node5 == complete) and (/suite/family/task/node6 == complete)) and (/suite/family/task/node7 == complete)) and (/suite/family/task/node8 == complete))))"
+    },
+    {
+      "expression": "(suite:attrib1 >= family:attrib1)",
+      "expected": "(suite:attrib1 >= family:attrib1)"
+    },
+    {
+      "expression": "(suite:attrib1 > family:attrib1)",
+      "expected": "(suite:attrib1 > family:attrib1)"
+    },
+    {
+      "expression": "(/suite/family:attrib1 == 1)",
+      "expected": "(/suite/family:attrib1 == 1)"
+    },
+    {
+      "expression": "(../suite:attrib1 <= /family/task/node4/node5/node6:attrib1)",
+      "expected": "(../suite:attrib1 <= /family/task/node4/node5/node6:attrib1)"
+    },
+    {
+      "expression": "(/suite/family/task/node4:attrib1 == 1 or /suite/family/task/node4:attrib2 == 1)",
+      "expected": "((/suite/family/task/node4:attrib1 == 1) or (/suite/family/task/node4:attrib2 == 1))"
+    },
+    {
+      "expression": "(/suite/family/task/node4:attrib1 == 1 and not /suite/family/node5:attrib2)",
+      "expected": "((/suite/family/task/node4:attrib1 == 1) and not (/suite/family/node5:attrib2))"
+    },
+    {
+      "expression": "(../suite:attrib1 < ../family/task/node4:attrib2 and ../suite:attrib1 <= /node5/node6/node7/node8/node9:attrib1)",
+      "expected": "((../suite:attrib1 < ../family/task/node4:attrib2) and (../suite:attrib1 <= /node5/node6/node7/node8/node9:attrib1))"
+    },
+    {
+      "expression": "(../suite:attrib1 < /family/task/node4/node5/node6/node7:attrib2 and node8 == complete)",
+      "expected": "((../suite:attrib1 < /family/task/node4/node5/node6/node7:attrib2) and (node8 == complete))"
+    },
+    {
+      "expression": "(../suite/family:attrib1 > ../task:attrib1 and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete)",
+      "expected": "(((((((../suite/family:attrib1 > ../task:attrib1) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete))"
+    },
+    {
+      "expression": "((/suite/family/task:attrib1*10000 + /suite/family/task/node4:attrib2*100+ /suite/family/task/node4/node5:attrib3) gt 20240101)",
+      "expected": "(((((/suite/family/task:attrib1 * 10000) + /suite/family/task/node4:attrib2) * 100) + /suite/family/task/node4/node5:attrib3) > 20240101)"
+    },
+    {
+      "expression": "(not ../suite:attrib1)",
+      "expected": "not (../suite:attrib1)"
+    },
+    {
+      "expression": "(../suite:attrib1 < /family/task/suite/node4:attrib1 and node5 == complete and node6 == complete and node7 == complete and node8 == complete)",
+      "expected": "(((((../suite:attrib1 < /family/task/suite/node4:attrib1) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 > ../task:attrib1 and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete)",
+      "expected": "((((((/suite/family/task:attrib1 > ../task:attrib1) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete))"
+    },
+    {
+      "expression": "(12 == complete and 00 == complete)",
+      "expected": "((12 == complete) and (00 == complete))"
+    },
+    {
+      "expression": "(/suite/family/task/00/node4 == complete and not node5 == queued)",
+      "expected": "((/suite/family/task/00/node4 == complete) and not ((node5 == queued)))"
+    },
+    {
+      "expression": "(suite:attrib1 and family:attrib1)",
+      "expected": "(suite:attrib1 and family:attrib1)"
+    },
+    {
+      "expression": "(suite == complete and 12 == complete and 00 == complete)",
+      "expected": "(((suite == complete) and (12 == complete)) and (00 == complete))"
+    },
+    {
+      "expression": "(../suite:attrib1 > ../family:attrib1 and 00 == complete)",
+      "expected": "((../suite:attrib1 > ../family:attrib1) and (00 == complete))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task:attrib1 <= node4/node4/node5:attrib1)",
+      "expected": "(((suite == complete) and (family == complete)) and (task:attrib1 <= node4/node4/node5:attrib1))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete and node15 == complete and node16 == complete and node17 == complete and node18 == complete and node19 == complete and node20 == complete and node21 == complete and node22 == complete and node23 == complete and node24 == complete and node25 == complete and node26 == complete and node27 == complete and node28 == complete and node29 == complete and node30 == complete and node31 == complete and node32 == complete and node33 == complete and node34 == complete and node35 == complete and node36 == complete and node37 == complete and node38 == complete and node39 == complete and node40 == complete)",
+      "expected": "((((((((((((((((((((((((((((((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)) and (node17 == complete)) and (node18 == complete)) and (node19 == complete)) and (node20 == complete)) and (node21 == complete)) and (node22 == complete)) and (node23 == complete)) and (node24 == complete)) and (node25 == complete)) and (node26 == complete)) and (node27 == complete)) and (node28 == complete)) and (node29 == complete)) and (node30 == complete)) and (node31 == complete)) and (node32 == complete)) and (node33 == complete)) and (node34 == complete)) and (node35 == complete)) and (node36 == complete)) and (node37 == complete)) and (node38 == complete)) and (node39 == complete)) and (node40 == complete))"
+    },
+    {
+      "expression": "((/suite/family/task:attrib1 < /suite/family/node4:attrib1 or /suite/family/task:attrib1 == /suite/family/node4:attrib1 and /suite/family/node4/node5/20/node6 == complete) and node7 == complete)",
+      "expected": "(((/suite/family/task:attrib1 < /suite/family/node4:attrib1) or ((/suite/family/task:attrib1 == /suite/family/node4:attrib1) and (/suite/family/node4/node5/20/node6 == complete))) and (node7 == complete))"
+    },
+    {
+      "expression": "(../suite:attrib1 >= :attrib2 or ../suite == complete)",
+      "expected": "((../suite:attrib1 >= :attrib2) or (../suite == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 > ./task:attrib1) and (./task:attrib1 le (../node4/task:attrib1 + /node5/node6:attrib2)))",
+      "expected": "((/suite/family:attrib1 > ./task:attrib1) and (./task:attrib1 <= (../node4/task:attrib1 + /node5/node6:attrib2)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1-1) and /suite/family/task/node4/node5/node7/node8:attrib2 >= 12 and /suite/family/task/node4/node5/node7/node9==complete and /suite/family/task/node4/node5/task==complete)) and node10 == complete)",
+      "expected": "(((/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node6:attrib1 - 1)) and (((/suite/family/task/node4/node5/node7/node8:attrib2 >= 12) and (/suite/family/task/node4/node5/node7/node9 == complete)) and (/suite/family/task/node4/node5/task == complete)))) and (node10 == complete))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5/task/node6/node7/node8 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node9:attrib1-1)) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node9:attrib1))",
+      "expected": "(((/suite/family/task/node4/node5/task/node6/node7/node8 == complete) and (/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node9:attrib1 - 1))) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node9:attrib1))"
+    },
+    {
+      "expression": "((suite == complete) and (../family/task:attrib1 or ../family/task == complete))",
+      "expected": "((suite == complete) and (../family/task:attrib1 or (../family/task == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and /suite/family/task/node4/node5/node7/node8:attrib2 >= 12 and /suite/family/task/node4/node5/node7/node9==complete and /suite/family/task/node4/node5/task==complete)) and node10 == complete)",
+      "expected": "(((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and (((/suite/family/task/node4/node5/node7/node8:attrib2 >= 12) and (/suite/family/task/node4/node5/node7/node9 == complete)) and (/suite/family/task/node4/node5/task == complete)))) and (node10 == complete))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5/task/node6/node7/node8 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node9:attrib1)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node9:attrib1))",
+      "expected": "(((/suite/family/task/node4/node5/task/node6/node7/node8 == complete) and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node9:attrib1)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node9:attrib1))"
+    },
+    {
+      "expression": "((((/suite/family/task/node4/node5:attrib1 gt /suite/family/task/node6/node5:attrib1) or (/suite/family/task/node4/node5/node7 == complete)) and ((../node8:attrib1 >= ../node5:attrib1) or ((../node8:attrib1 == ../node5:attrib1-1) and ../node8/node9 == complete))) and (node10 == complete))",
+      "expected": "((((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node6/node5:attrib1) or (/suite/family/task/node4/node5/node7 == complete)) and ((../node8:attrib1 >= ../node5:attrib1) or ((../node8:attrib1 == (../node5:attrib1 - 1)) and (../node8/node9 == complete)))) and (node10 == complete))"
+    },
+    {
+      "expression": "((((/suite/family/task/node4/node5:attrib1 gt /suite/family/task/node6/node5:attrib1) or (/suite/family/task/node4/node5/node7 == complete)) and ((../node8:attrib1 > ../node5:attrib1) or ((../node8:attrib1 == ../node5:attrib1) and ../node8/node9 == complete))) and (node10 == complete))",
+      "expected": "((((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node6/node5:attrib1) or (/suite/family/task/node4/node5/node7 == complete)) and ((../node8:attrib1 > ../node5:attrib1) or ((../node8:attrib1 == ../node5:attrib1) and (../node8/node9 == complete)))) and (node10 == complete))"
+    },
+    {
+      "expression": "(./00:attrib1 le ../suite/00:attrib1 + 2 or ../suite/00 eq complete)",
+      "expected": "((./00:attrib1 <= (../suite/00:attrib1 + 2)) or (../suite/00 == complete))"
+    },
+    {
+      "expression": "(../00:attrib1 le ../../suite/00:attrib1 or ../../suite/00 eq complete)",
+      "expected": "((../00:attrib1 <= ../../suite/00:attrib1) or (../../suite/00 == complete))"
+    },
+    {
+      "expression": "(((((((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and node6 eq complete) and node7 eq complete) and node8 eq complete) and node9 eq complete) and node10 eq complete)",
+      "expected": "((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete))"
+    },
+    {
+      "expression": "((./00:attrib1 lt ../suite/00:attrib1 or ../suite/00 eq complete) and (./00:attrib1 le ../../family/00:attrib1 + 1 or ../../family/00 eq complete))",
+      "expected": "(((./00:attrib1 < ../suite/00:attrib1) or (../suite/00 == complete)) and ((./00:attrib1 <= (../../family/00:attrib1 + 1)) or (../../family/00 == complete)))"
+    },
+    {
+      "expression": "(./00:attrib1 lt ../suite/family/00:attrib1 or ../suite/family/00 eq complete)",
+      "expected": "((./00:attrib1 < ../suite/family/00:attrib1) or (../suite/family/00 == complete))"
+    },
+    {
+      "expression": "((../../../suite/family/00:attrib1 gt ../../00:attrib1 + 1 or (../../../suite/family/00:attrib1 eq ../../00:attrib1 + 1 and ../../../suite/family/00/task eq complete)) or ../../../suite/family/00 eq complete)",
+      "expected": "(((../../../suite/family/00:attrib1 > (../../00:attrib1 + 1)) or ((../../../suite/family/00:attrib1 == (../../00:attrib1 + 1)) and (../../../suite/family/00/task == complete))) or (../../../suite/family/00 == complete))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 > task:attrib1 and task:attrib1 le (../node4/task:attrib1 + /node5/node6:attrib2))",
+      "expected": "((/suite/family:attrib1 > task:attrib1) and (task:attrib1 <= (../node4/task:attrib1 + /node5/node6:attrib2)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1-1) and /suite/family/task/node4/node5/node7/node8:attrib2 >= 12 and /suite/family/task/node4/node5/node7/node9==complete and /suite/family/task/node4/node5/task==complete)) and node10 == complete and node11 == complete)",
+      "expected": "(((/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node6:attrib1 - 1)) and (((/suite/family/task/node4/node5/node7/node8:attrib2 >= 12) and (/suite/family/task/node4/node5/node7/node9 == complete)) and (/suite/family/task/node4/node5/task == complete)))) and ((node10 == complete) and (node11 == complete)))"
+    },
+    {
+      "expression": "(../../../suite/family:attrib1 or ../../../suite/family:attrib2 or ../../../suite/family == complete)",
+      "expected": "(../../../suite/family:attrib1 or (../../../suite/family:attrib2 or (../../../suite/family == complete)))"
+    },
+    {
+      "expression": "((../suite:attrib1 or ../suite == complete))",
+      "expected": "(../suite:attrib1 or (../suite == complete))"
+    },
+    {
+      "expression": "(((suite == complete) and (family == complete)) and (../task/node4:attrib1 or ../task/node4 == complete))",
+      "expected": "(((suite == complete) and (family == complete)) and (../task/node4:attrib1 or (../task/node4 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and /suite/family/task/node4/node5/node7/node8:attrib2 >= 12 and /suite/family/task/node4/node5/node7/node9==complete and /suite/family/task/node4/node5/task==complete)) and node10 == complete and node11 == complete)",
+      "expected": "(((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and (((/suite/family/task/node4/node5/node7/node8:attrib2 >= 12) and (/suite/family/task/node4/node5/node7/node9 == complete)) and (/suite/family/task/node4/node5/task == complete)))) and ((node10 == complete) and (node11 == complete)))"
+    },
+    {
+      "expression": "(((suite == complete and family == complete) and task == complete) and node4 == complete)",
+      "expected": "((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete))"
+    },
+    {
+      "expression": "(suite:attrib1 <= family:attrib1 + 2 or family == complete)",
+      "expected": "((suite:attrib1 <= (family:attrib1 + 2)) or (family == complete))"
+    },
+    {
+      "expression": "(../suite:attrib1 <= ../family:attrib1 or ../family == complete)",
+      "expected": "((../suite:attrib1 <= ../family:attrib1) or (../family == complete))"
+    },
+    {
+      "expression": "(((((suite == complete and family == complete) and task == complete) and node4 == complete) and node5 == complete) and node6 == complete)",
+      "expected": "((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete))"
+    },
+    {
+      "expression": "((((((((suite == complete and family == complete) and task == complete) and node4 == complete) and node5 == complete) and node6 == complete) and node7 == complete) and node8 == complete) and node9 == complete)",
+      "expected": "(((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete))"
+    },
+    {
+      "expression": "((suite:attrib1 < family:attrib1 or family == complete) and (suite:attrib1 <= ../task:attrib1 + 1 or ../task == complete))",
+      "expected": "(((suite:attrib1 < family:attrib1) or (family == complete)) and ((suite:attrib1 <= (../task:attrib1 + 1)) or (../task == complete)))"
+    },
+    {
+      "expression": "((suite == complete and family == complete) and task == complete)",
+      "expected": "(((suite == complete) and (family == complete)) and (task == complete))"
+    },
+    {
+      "expression": "(suite:attrib1 < family/task:attrib1 or family/task == complete)",
+      "expected": "((suite:attrib1 < family/task:attrib1) or (family/task == complete))"
+    },
+    {
+      "expression": "((../../suite/family:attrib1 > ../../task:attrib1 + 1 or (../../suite/family:attrib1 == ../../task:attrib1 + 1 and ../../suite/family/node4 == complete)) or ../../suite/family == complete)",
+      "expected": "(((../../suite/family:attrib1 > (../../task:attrib1 + 1)) or ((../../suite/family:attrib1 == (../../task:attrib1 + 1)) and (../../suite/family/node4 == complete))) or (../../suite/family == complete))"
+    },
+    {
+      "expression": "(suite:attrib1 < :attrib2)",
+      "expected": "(suite:attrib1 < :attrib2)"
+    },
+    {
+      "expression": "(:attrib1 < ../suite/family:attrib1 and :attrib1 <= ../task/family:attrib1 + :attrib2)",
+      "expected": "((:attrib1 < ../suite/family:attrib1) and (:attrib1 <= (../task/family:attrib1 + :attrib2)))"
+    },
+    {
+      "expression": "(../../suite/family == complete and ../../suite/family:attrib1 == ../family:attrib1 or (../../suite/family:attrib1 > ../family:attrib1) and (../family:attrib1 <= ../../task/family:attrib1 + ../../../../node4:attrib2))",
+      "expected": "(((../../suite/family == complete) and (../../suite/family:attrib1 == ../family:attrib1)) or ((../../suite/family:attrib1 > ../family:attrib1) and (../family:attrib1 <= (../../task/family:attrib1 + ../../../../node4:attrib2))))"
+    },
+    {
+      "expression": "(suite == complete and ../family/task:attrib1 or ../family/task == complete)",
+      "expected": "(((suite == complete) and ../family/task:attrib1) or (../family/task == complete))"
+    },
+    {
+      "expression": "(../../suite/family/task == complete and ../../suite/family:attrib1 == ../family:attrib1 or (../../suite/family:attrib1 > ../family:attrib1))",
+      "expected": "(((../../suite/family/task == complete) and (../../suite/family:attrib1 == ../family:attrib1)) or (../../suite/family:attrib1 > ../family:attrib1))"
+    },
+    {
+      "expression": "(((../../suite/family:attrib1 > ../family:attrib1) or (../../suite/family/task == complete)) and ((../node4:attrib1 >= ../family:attrib1) or ((../node4:attrib1 == ../family:attrib1 - 1) and ../node4/node5 == complete)) and node6 == complete)",
+      "expected": "(((../../suite/family:attrib1 > ../family:attrib1) or (../../suite/family/task == complete)) and (((../node4:attrib1 >= ../family:attrib1) or ((../node4:attrib1 == (../family:attrib1 - 1)) and (../node4/node5 == complete))) and (node6 == complete)))"
+    },
+    {
+      "expression": "(((../../suite/family:attrib1 > ../family:attrib1) or (../../suite/family/task == complete)) and ((../node4:attrib1 > ../family:attrib1) or ((../node4:attrib1 == ../family:attrib1) and ../node4/node5 == complete)) and node6 == complete)",
+      "expected": "(((../../suite/family:attrib1 > ../family:attrib1) or (../../suite/family/task == complete)) and (((../node4:attrib1 > ../family:attrib1) or ((../node4:attrib1 == ../family:attrib1) and (../node4/node5 == complete))) and (node6 == complete)))"
+    },
+    {
+      "expression": "(./suite:attrib1 le (../family/suite:attrib1 + :attrib2))",
+      "expected": "(./suite:attrib1 <= (../family/suite:attrib1 + :attrib2))"
+    },
+    {
+      "expression": "((:attrib1 < ../suite/family:attrib1 or (:attrib1 == ../suite/family:attrib1 and ../suite/family eq complete)) and :attrib1 <= ../task/family:attrib1 + :attrib2)",
+      "expected": "(((:attrib1 < ../suite/family:attrib1) or ((:attrib1 == ../suite/family:attrib1) and (../suite/family == complete))) and (:attrib1 <= (../task/family:attrib1 + :attrib2)))"
+    },
+    {
+      "expression": "(../../suite/family:attrib1 > :attrib1 and (../task:attrib1 >= :attrib1 or (../task:attrib1 == :attrib1 - 1 and ../task/node4 == complete)) and node5 == complete)",
+      "expected": "((../../suite/family:attrib1 > :attrib1) and (((../task:attrib1 >= :attrib1) or ((../task:attrib1 == (:attrib1 - 1)) and (../task/node4 == complete))) and (node5 == complete)))"
+    },
+    {
+      "expression": "(../../suite/family:attrib1 > :attrib1 and (../task:attrib1 > :attrib1 or (../task:attrib1 == :attrib1 and ../task/node4 == complete)) and node5 == complete)",
+      "expected": "((../../suite/family:attrib1 > :attrib1) and (((../task:attrib1 > :attrib1) or ((../task:attrib1 == :attrib1) and (../task/node4 == complete))) and (node5 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/task/00/node4/node5 eq complete))",
+      "expected": "(/suite/family/task/00/node4/node5 == complete)"
+    },
+    {
+      "expression": "((/suite/family/task/00/node4/node5/0000 eq complete and /suite/family/task/00/node4/node5/0001 eq complete and /suite/family/task/00/node4/node5/0002 eq complete and /suite/family/task/00/node4/node5/0003 eq complete and /suite/family/task/00/node4/node5/0004 eq complete and /suite/family/task/00/node4/node5/0005 eq complete and /suite/family/task/00/node4/node5/0006 eq complete and /suite/family/task/00/node4/node5/0007 eq complete and /suite/family/task/00/node4/node5/0008 eq complete and /suite/family/task/00/node4/node5/0009 eq complete and /suite/family/task/00/node4/node5/0010 eq complete and /suite/family/task/00/node4/node5/0011 eq complete and /suite/family/task/00/node4/node5/0012 eq complete and /suite/family/task/00/node4/node5/0013 eq complete and /suite/family/task/00/node4/node5/0014 eq complete and /suite/family/task/00/node4/node5/0015 eq complete and /suite/family/task/00/node4/node5/0016 eq complete and /suite/family/task/00/node4/node5/0017 eq complete and /suite/family/task/00/node4/node5/0018 eq complete and /suite/family/task/00/node4/node5/0019 eq complete and /suite/family/task/00/node4/node5/0020 eq complete and /suite/family/task/00/node4/node5/0021 eq complete and /suite/family/task/00/node4/node5/0022 eq complete and /suite/family/task/00/node4/node5/0023 eq complete and /suite/family/task/00/node4/node5/0024 eq complete and /suite/family/task/00/node4/node5/0025 eq complete and /suite/family/task/00/node4/node5/0026 eq complete and /suite/family/task/00/node4/node5/0027 eq complete and /suite/family/task/00/node4/node5/0028 eq complete and /suite/family/task/00/node4/node5/0029 eq complete and /suite/family/task/00/node4/node5/0030 eq complete and /suite/family/task/00/node4/node5/0031 eq complete and /suite/family/task/00/node4/node5/0032 eq complete and /suite/family/task/00/node4/node5/0033 eq complete and /suite/family/task/00/node4/node5/0034 eq complete and /suite/family/task/00/node4/node5/0035 eq complete and /suite/family/task/00/node4/node5/0036 eq complete and /suite/family/task/00/node4/node5/0037 eq complete and /suite/family/task/00/node4/node5/0038 eq complete and /suite/family/task/00/node4/node5/0039 eq complete and /suite/family/task/00/node4/node5/0040 eq complete and /suite/family/task/00/node4/node5/0041 eq complete and /suite/family/task/00/node4/node5/0042 eq complete and /suite/family/task/00/node4/node5/0043 eq complete and /suite/family/task/00/node4/node5/0044 eq complete and /suite/family/task/00/node4/node5/0045 eq complete))",
+      "expected": "((((((((((((((((((((((((((((((((((((((((((((((/suite/family/task/00/node4/node5/0000 == complete) and (/suite/family/task/00/node4/node5/0001 == complete)) and (/suite/family/task/00/node4/node5/0002 == complete)) and (/suite/family/task/00/node4/node5/0003 == complete)) and (/suite/family/task/00/node4/node5/0004 == complete)) and (/suite/family/task/00/node4/node5/0005 == complete)) and (/suite/family/task/00/node4/node5/0006 == complete)) and (/suite/family/task/00/node4/node5/0007 == complete)) and (/suite/family/task/00/node4/node5/0008 == complete)) and (/suite/family/task/00/node4/node5/0009 == complete)) and (/suite/family/task/00/node4/node5/0010 == complete)) and (/suite/family/task/00/node4/node5/0011 == complete)) and (/suite/family/task/00/node4/node5/0012 == complete)) and (/suite/family/task/00/node4/node5/0013 == complete)) and (/suite/family/task/00/node4/node5/0014 == complete)) and (/suite/family/task/00/node4/node5/0015 == complete)) and (/suite/family/task/00/node4/node5/0016 == complete)) and (/suite/family/task/00/node4/node5/0017 == complete)) and (/suite/family/task/00/node4/node5/0018 == complete)) and (/suite/family/task/00/node4/node5/0019 == complete)) and (/suite/family/task/00/node4/node5/0020 == complete)) and (/suite/family/task/00/node4/node5/0021 == complete)) and (/suite/family/task/00/node4/node5/0022 == complete)) and (/suite/family/task/00/node4/node5/0023 == complete)) and (/suite/family/task/00/node4/node5/0024 == complete)) and (/suite/family/task/00/node4/node5/0025 == complete)) and (/suite/family/task/00/node4/node5/0026 == complete)) and (/suite/family/task/00/node4/node5/0027 == complete)) and (/suite/family/task/00/node4/node5/0028 == complete)) and (/suite/family/task/00/node4/node5/0029 == complete)) and (/suite/family/task/00/node4/node5/0030 == complete)) and (/suite/family/task/00/node4/node5/0031 == complete)) and (/suite/family/task/00/node4/node5/0032 == complete)) and (/suite/family/task/00/node4/node5/0033 == complete)) and (/suite/family/task/00/node4/node5/0034 == complete)) and (/suite/family/task/00/node4/node5/0035 == complete)) and (/suite/family/task/00/node4/node5/0036 == complete)) and (/suite/family/task/00/node4/node5/0037 == complete)) and (/suite/family/task/00/node4/node5/0038 == complete)) and (/suite/family/task/00/node4/node5/0039 == complete)) and (/suite/family/task/00/node4/node5/0040 == complete)) and (/suite/family/task/00/node4/node5/0041 == complete)) and (/suite/family/task/00/node4/node5/0042 == complete)) and (/suite/family/task/00/node4/node5/0043 == complete)) and (/suite/family/task/00/node4/node5/0044 == complete)) and (/suite/family/task/00/node4/node5/0045 == complete))"
+    },
+    {
+      "expression": "((/suite/family/task/00/node4/node5/0046 eq complete and /suite/family/task/00/node4/node5/0047 eq complete and /suite/family/task/00/node4/node5/0048 eq complete and /suite/family/task/00/node4/node5/0049 eq complete and /suite/family/task/00/node4/node5/0050 eq complete and /suite/family/task/00/node4/node5/0051 eq complete and /suite/family/task/00/node4/node5/0052 eq complete and /suite/family/task/00/node4/node5/0053 eq complete and /suite/family/task/00/node4/node5/0054 eq complete and /suite/family/task/00/node4/node5/0055 eq complete and /suite/family/task/00/node4/node5/0056 eq complete and /suite/family/task/00/node4/node5/0057 eq complete and /suite/family/task/00/node4/node5/0058 eq complete and /suite/family/task/00/node4/node5/0059 eq complete and /suite/family/task/00/node4/node5/0060 eq complete and /suite/family/task/00/node4/node5/0061 eq complete and /suite/family/task/00/node4/node5/0062 eq complete and /suite/family/task/00/node4/node5/0063 eq complete and /suite/family/task/00/node4/node5/0064 eq complete and /suite/family/task/00/node4/node5/0065 eq complete and /suite/family/task/00/node4/node5/0066 eq complete and /suite/family/task/00/node4/node5/0067 eq complete and /suite/family/task/00/node4/node5/0068 eq complete and /suite/family/task/00/node4/node5/0069 eq complete and /suite/family/task/00/node4/node5/0070 eq complete and /suite/family/task/00/node4/node5/0071 eq complete and /suite/family/task/00/node4/node5/0072 eq complete and /suite/family/task/00/node4/node5/0073 eq complete and /suite/family/task/00/node4/node5/0074 eq complete and /suite/family/task/00/node4/node5/0075 eq complete and /suite/family/task/00/node4/node5/0076 eq complete and /suite/family/task/00/node4/node5/0077 eq complete and /suite/family/task/00/node4/node5/0078 eq complete and /suite/family/task/00/node4/node5/0079 eq complete and /suite/family/task/00/node4/node5/0080 eq complete and /suite/family/task/00/node4/node5/0081 eq complete and /suite/family/task/00/node4/node5/0082 eq complete and /suite/family/task/00/node4/node5/0083 eq complete and /suite/family/task/00/node4/node5/0084 eq complete and /suite/family/task/00/node4/node5/0085 eq complete and /suite/family/task/00/node4/node5/0086 eq complete and /suite/family/task/00/node4/node5/0087 eq complete and /suite/family/task/00/node4/node5/0088 eq complete and /suite/family/task/00/node4/node5/0089 eq complete and /suite/family/task/00/node4/node5/0090 eq complete))",
+      "expected": "(((((((((((((((((((((((((((((((((((((((((((((/suite/family/task/00/node4/node5/0046 == complete) and (/suite/family/task/00/node4/node5/0047 == complete)) and (/suite/family/task/00/node4/node5/0048 == complete)) and (/suite/family/task/00/node4/node5/0049 == complete)) and (/suite/family/task/00/node4/node5/0050 == complete)) and (/suite/family/task/00/node4/node5/0051 == complete)) and (/suite/family/task/00/node4/node5/0052 == complete)) and (/suite/family/task/00/node4/node5/0053 == complete)) and (/suite/family/task/00/node4/node5/0054 == complete)) and (/suite/family/task/00/node4/node5/0055 == complete)) and (/suite/family/task/00/node4/node5/0056 == complete)) and (/suite/family/task/00/node4/node5/0057 == complete)) and (/suite/family/task/00/node4/node5/0058 == complete)) and (/suite/family/task/00/node4/node5/0059 == complete)) and (/suite/family/task/00/node4/node5/0060 == complete)) and (/suite/family/task/00/node4/node5/0061 == complete)) and (/suite/family/task/00/node4/node5/0062 == complete)) and (/suite/family/task/00/node4/node5/0063 == complete)) and (/suite/family/task/00/node4/node5/0064 == complete)) and (/suite/family/task/00/node4/node5/0065 == complete)) and (/suite/family/task/00/node4/node5/0066 == complete)) and (/suite/family/task/00/node4/node5/0067 == complete)) and (/suite/family/task/00/node4/node5/0068 == complete)) and (/suite/family/task/00/node4/node5/0069 == complete)) and (/suite/family/task/00/node4/node5/0070 == complete)) and (/suite/family/task/00/node4/node5/0071 == complete)) and (/suite/family/task/00/node4/node5/0072 == complete)) and (/suite/family/task/00/node4/node5/0073 == complete)) and (/suite/family/task/00/node4/node5/0074 == complete)) and (/suite/family/task/00/node4/node5/0075 == complete)) and (/suite/family/task/00/node4/node5/0076 == complete)) and (/suite/family/task/00/node4/node5/0077 == complete)) and (/suite/family/task/00/node4/node5/0078 == complete)) and (/suite/family/task/00/node4/node5/0079 == complete)) and (/suite/family/task/00/node4/node5/0080 == complete)) and (/suite/family/task/00/node4/node5/0081 == complete)) and (/suite/family/task/00/node4/node5/0082 == complete)) and (/suite/family/task/00/node4/node5/0083 == complete)) and (/suite/family/task/00/node4/node5/0084 == complete)) and (/suite/family/task/00/node4/node5/0085 == complete)) and (/suite/family/task/00/node4/node5/0086 == complete)) and (/suite/family/task/00/node4/node5/0087 == complete)) and (/suite/family/task/00/node4/node5/0088 == complete)) and (/suite/family/task/00/node4/node5/0089 == complete)) and (/suite/family/task/00/node4/node5/0090 == complete))"
+    },
+    {
+      "expression": "((/suite/family/task/00/node4/node5/0093 eq complete and /suite/family/task/00/node4/node5/0096 eq complete and /suite/family/task/00/node4/node5/0099 eq complete and /suite/family/task/00/node4/node5/0102 eq complete and /suite/family/task/00/node4/node5/0105 eq complete and /suite/family/task/00/node4/node5/0108 eq complete and /suite/family/task/00/node4/node5/0111 eq complete and /suite/family/task/00/node4/node5/0114 eq complete and /suite/family/task/00/node4/node5/0117 eq complete and /suite/family/task/00/node4/node5/0120 eq complete and /suite/family/task/00/node4/node5/0123 eq complete and /suite/family/task/00/node4/node5/0126 eq complete and /suite/family/task/00/node4/node5/0129 eq complete and /suite/family/task/00/node4/node5/0132 eq complete and /suite/family/task/00/node4/node5/0135 eq complete and /suite/family/task/00/node4/node5/0138 eq complete and /suite/family/task/00/node4/node5/0141 eq complete and /suite/family/task/00/node4/node5/0144 eq complete))",
+      "expected": "((((((((((((((((((/suite/family/task/00/node4/node5/0093 == complete) and (/suite/family/task/00/node4/node5/0096 == complete)) and (/suite/family/task/00/node4/node5/0099 == complete)) and (/suite/family/task/00/node4/node5/0102 == complete)) and (/suite/family/task/00/node4/node5/0105 == complete)) and (/suite/family/task/00/node4/node5/0108 == complete)) and (/suite/family/task/00/node4/node5/0111 == complete)) and (/suite/family/task/00/node4/node5/0114 == complete)) and (/suite/family/task/00/node4/node5/0117 == complete)) and (/suite/family/task/00/node4/node5/0120 == complete)) and (/suite/family/task/00/node4/node5/0123 == complete)) and (/suite/family/task/00/node4/node5/0126 == complete)) and (/suite/family/task/00/node4/node5/0129 == complete)) and (/suite/family/task/00/node4/node5/0132 == complete)) and (/suite/family/task/00/node4/node5/0135 == complete)) and (/suite/family/task/00/node4/node5/0138 == complete)) and (/suite/family/task/00/node4/node5/0141 == complete)) and (/suite/family/task/00/node4/node5/0144 == complete))"
+    },
+    {
+      "expression": "((/suite/family/task/00/node4/node5/0150 eq complete and /suite/family/task/00/node4/node5/0156 eq complete and /suite/family/task/00/node4/node5/0162 eq complete and /suite/family/task/00/node4/node5/0168 eq complete and /suite/family/task/00/node4/node5/0174 eq complete and /suite/family/task/00/node4/node5/0180 eq complete and /suite/family/task/00/node4/node5/0186 eq complete and /suite/family/task/00/node4/node5/0192 eq complete and /suite/family/task/00/node4/node5/0198 eq complete and /suite/family/task/00/node4/node5/0204 eq complete and /suite/family/task/00/node4/node5/0210 eq complete and /suite/family/task/00/node4/node5/0216 eq complete and /suite/family/task/00/node4/node5/0222 eq complete and /suite/family/task/00/node4/node5/0228 eq complete and /suite/family/task/00/node4/node5/0234 eq complete and /suite/family/task/00/node4/node5/0240 eq complete))",
+      "expected": "((((((((((((((((/suite/family/task/00/node4/node5/0150 == complete) and (/suite/family/task/00/node4/node5/0156 == complete)) and (/suite/family/task/00/node4/node5/0162 == complete)) and (/suite/family/task/00/node4/node5/0168 == complete)) and (/suite/family/task/00/node4/node5/0174 == complete)) and (/suite/family/task/00/node4/node5/0180 == complete)) and (/suite/family/task/00/node4/node5/0186 == complete)) and (/suite/family/task/00/node4/node5/0192 == complete)) and (/suite/family/task/00/node4/node5/0198 == complete)) and (/suite/family/task/00/node4/node5/0204 == complete)) and (/suite/family/task/00/node4/node5/0210 == complete)) and (/suite/family/task/00/node4/node5/0216 == complete)) and (/suite/family/task/00/node4/node5/0222 == complete)) and (/suite/family/task/00/node4/node5/0228 == complete)) and (/suite/family/task/00/node4/node5/0234 == complete)) and (/suite/family/task/00/node4/node5/0240 == complete))"
+    },
+    {
+      "expression": "((/suite/family/task/00/node4/node5/0246 eq complete and /suite/family/task/00/node4/node5/0252 eq complete and /suite/family/task/00/node4/node5/0258 eq complete and /suite/family/task/00/node4/node5/0264 eq complete and /suite/family/task/00/node4/node5/0270 eq complete and /suite/family/task/00/node4/node5/0276 eq complete and /suite/family/task/00/node4/node5/0282 eq complete and /suite/family/task/00/node4/node5/0288 eq complete and /suite/family/task/00/node4/node5/0294 eq complete and /suite/family/task/00/node4/node5/0300 eq complete and /suite/family/task/00/node4/node5/0306 eq complete and /suite/family/task/00/node4/node5/0312 eq complete and /suite/family/task/00/node4/node5/0318 eq complete and /suite/family/task/00/node4/node5/0324 eq complete and /suite/family/task/00/node4/node5/0330 eq complete and /suite/family/task/00/node4/node5/0336 eq complete and /suite/family/task/00/node4/node5/0342 eq complete and /suite/family/task/00/node4/node5/0348 eq complete and /suite/family/task/00/node4/node5/0354 eq complete and /suite/family/task/00/node4/node5/0360 eq complete))",
+      "expected": "((((((((((((((((((((/suite/family/task/00/node4/node5/0246 == complete) and (/suite/family/task/00/node4/node5/0252 == complete)) and (/suite/family/task/00/node4/node5/0258 == complete)) and (/suite/family/task/00/node4/node5/0264 == complete)) and (/suite/family/task/00/node4/node5/0270 == complete)) and (/suite/family/task/00/node4/node5/0276 == complete)) and (/suite/family/task/00/node4/node5/0282 == complete)) and (/suite/family/task/00/node4/node5/0288 == complete)) and (/suite/family/task/00/node4/node5/0294 == complete)) and (/suite/family/task/00/node4/node5/0300 == complete)) and (/suite/family/task/00/node4/node5/0306 == complete)) and (/suite/family/task/00/node4/node5/0312 == complete)) and (/suite/family/task/00/node4/node5/0318 == complete)) and (/suite/family/task/00/node4/node5/0324 == complete)) and (/suite/family/task/00/node4/node5/0330 == complete)) and (/suite/family/task/00/node4/node5/0336 == complete)) and (/suite/family/task/00/node4/node5/0342 == complete)) and (/suite/family/task/00/node4/node5/0348 == complete)) and (/suite/family/task/00/node4/node5/0354 == complete)) and (/suite/family/task/00/node4/node5/0360 == complete))"
+    },
+    {
+      "expression": "(not (suite:attrib1) and suite eq complete)",
+      "expected": "(not (suite:attrib1) and (suite == complete))"
+    },
+    {
+      "expression": "(suite:attrib1 and suite eq complete)",
+      "expected": "(suite:attrib1 and (suite == complete))"
+    },
+    {
+      "expression": "(((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((suite eq complete and ../../family/0000/task eq complete) and ../../family/0001/task eq complete) and ../../family/0002/task eq complete) and ../../family/0003/task eq complete) and ../../family/0004/task eq complete) and ../../family/0005/task eq complete) and ../../family/0006/task eq complete) and ../../family/0007/task eq complete) and ../../family/0008/task eq complete) and ../../family/0009/task eq complete) and ../../family/0010/task eq complete) and ../../family/0011/task eq complete) and ../../family/0012/task eq complete) and ../../family/0013/task eq complete) and ../../family/0014/task eq complete) and ../../family/0015/task eq complete) and ../../family/0016/task eq complete) and ../../family/0017/task eq complete) and ../../family/0018/task eq complete) and ../../family/0019/task eq complete) and ../../family/0020/task eq complete) and ../../family/0021/task eq complete) and ../../family/0022/task eq complete) and ../../family/0023/task eq complete) and ../../family/0024/task eq complete) and ../../family/0025/task eq complete) and ../../family/0026/task eq complete) and ../../family/0027/task eq complete) and ../../family/0028/task eq complete) and ../../family/0029/task eq complete) and ../../family/0030/task eq complete) and ../../family/0031/task eq complete) and ../../family/0032/task eq complete) and ../../family/0033/task eq complete) and ../../family/0034/task eq complete) and ../../family/0035/task eq complete) and ../../family/0036/task eq complete) and ../../family/0037/task eq complete) and ../../family/0038/task eq complete) and ../../family/0039/task eq complete) and ../../family/0040/task eq complete) and ../../family/0041/task eq complete) and ../../family/0042/task eq complete) and ../../family/0043/task eq complete) and ../../family/0044/task eq complete) and ../../family/0045/task eq complete) and ../../family/0046/task eq complete) and ../../family/0047/task eq complete) and ../../family/0048/task eq complete) and ../../family/0049/task eq complete) and ../../family/0050/task eq complete) and ../../family/0051/task eq complete) and ../../family/0052/task eq complete) and ../../family/0053/task eq complete) and ../../family/0054/task eq complete) and ../../family/0055/task eq complete) and ../../family/0056/task eq complete) and ../../family/0057/task eq complete) and ../../family/0058/task eq complete) and ../../family/0059/task eq complete) and ../../family/0060/task eq complete) and ../../family/0061/task eq complete) and ../../family/0062/task eq complete) and ../../family/0063/task eq complete) and ../../family/0064/task eq complete) and ../../family/0065/task eq complete) and ../../family/0066/task eq complete) and ../../family/0067/task eq complete) and ../../family/0068/task eq complete) and ../../family/0069/task eq complete) and ../../family/0070/task eq complete) and ../../family/0071/task eq complete) and ../../family/0072/task eq complete) and ../../family/0073/task eq complete) and ../../family/0074/task eq complete) and ../../family/0075/task eq complete) and ../../family/0076/task eq complete) and ../../family/0077/task eq complete) and ../../family/0078/task eq complete) and ../../family/0079/task eq complete) and ../../family/0080/task eq complete) and ../../family/0081/task eq complete) and ../../family/0082/task eq complete) and ../../family/0083/task eq complete) and ../../family/0084/task eq complete) and ../../family/0085/task eq complete) and ../../family/0086/task eq complete) and ../../family/0087/task eq complete) and ../../family/0088/task eq complete) and ../../family/0089/task eq complete) and ../../family/0090/task eq complete) and ../../family/0093/task eq complete) and ../../family/0096/task eq complete) and ../../family/0099/task eq complete) and ../../family/0102/task eq complete) and ../../family/0105/task eq complete) and ../../family/0108/task eq complete) and ../../family/0111/task eq complete) and ../../family/0114/task eq complete) and ../../family/0117/task eq complete) and ../../family/0120/task eq complete) and ../../family/0123/task eq complete) and ../../family/0126/task eq complete) and ../../family/0129/task eq complete) and ../../family/0132/task eq complete) and ../../family/0135/task eq complete) and ../../family/0138/task eq complete) and ../../family/0141/task eq complete) and ../../family/0144/task eq complete) and ../../family/0150/task eq complete) and ../../family/0156/task eq complete) and ../../family/0162/task eq complete) and ../../family/0168/task eq complete) and ../../family/0174/task eq complete) and ../../family/0180/task eq complete) and ../../family/0186/task eq complete) and ../../family/0192/task eq complete) and ../../family/0198/task eq complete) and ../../family/0204/task eq complete) and ../../family/0210/task eq complete) and ../../family/0216/task eq complete) and ../../family/0222/task eq complete) and ../../family/0228/task eq complete) and ../../family/0234/task eq complete) and ../../family/0240/task eq complete)",
+      "expected": "((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((suite == complete) and (../../family/0000/task == complete)) and (../../family/0001/task == complete)) and (../../family/0002/task == complete)) and (../../family/0003/task == complete)) and (../../family/0004/task == complete)) and (../../family/0005/task == complete)) and (../../family/0006/task == complete)) and (../../family/0007/task == complete)) and (../../family/0008/task == complete)) and (../../family/0009/task == complete)) and (../../family/0010/task == complete)) and (../../family/0011/task == complete)) and (../../family/0012/task == complete)) and (../../family/0013/task == complete)) and (../../family/0014/task == complete)) and (../../family/0015/task == complete)) and (../../family/0016/task == complete)) and (../../family/0017/task == complete)) and (../../family/0018/task == complete)) and (../../family/0019/task == complete)) and (../../family/0020/task == complete)) and (../../family/0021/task == complete)) and (../../family/0022/task == complete)) and (../../family/0023/task == complete)) and (../../family/0024/task == complete)) and (../../family/0025/task == complete)) and (../../family/0026/task == complete)) and (../../family/0027/task == complete)) and (../../family/0028/task == complete)) and (../../family/0029/task == complete)) and (../../family/0030/task == complete)) and (../../family/0031/task == complete)) and (../../family/0032/task == complete)) and (../../family/0033/task == complete)) and (../../family/0034/task == complete)) and (../../family/0035/task == complete)) and (../../family/0036/task == complete)) and (../../family/0037/task == complete)) and (../../family/0038/task == complete)) and (../../family/0039/task == complete)) and (../../family/0040/task == complete)) and (../../family/0041/task == complete)) and (../../family/0042/task == complete)) and (../../family/0043/task == complete)) and (../../family/0044/task == complete)) and (../../family/0045/task == complete)) and (../../family/0046/task == complete)) and (../../family/0047/task == complete)) and (../../family/0048/task == complete)) and (../../family/0049/task == complete)) and (../../family/0050/task == complete)) and (../../family/0051/task == complete)) and (../../family/0052/task == complete)) and (../../family/0053/task == complete)) and (../../family/0054/task == complete)) and (../../family/0055/task == complete)) and (../../family/0056/task == complete)) and (../../family/0057/task == complete)) and (../../family/0058/task == complete)) and (../../family/0059/task == complete)) and (../../family/0060/task == complete)) and (../../family/0061/task == complete)) and (../../family/0062/task == complete)) and (../../family/0063/task == complete)) and (../../family/0064/task == complete)) and (../../family/0065/task == complete)) and (../../family/0066/task == complete)) and (../../family/0067/task == complete)) and (../../family/0068/task == complete)) and (../../family/0069/task == complete)) and (../../family/0070/task == complete)) and (../../family/0071/task == complete)) and (../../family/0072/task == complete)) and (../../family/0073/task == complete)) and (../../family/0074/task == complete)) and (../../family/0075/task == complete)) and (../../family/0076/task == complete)) and (../../family/0077/task == complete)) and (../../family/0078/task == complete)) and (../../family/0079/task == complete)) and (../../family/0080/task == complete)) and (../../family/0081/task == complete)) and (../../family/0082/task == complete)) and (../../family/0083/task == complete)) and (../../family/0084/task == complete)) and (../../family/0085/task == complete)) and (../../family/0086/task == complete)) and (../../family/0087/task == complete)) and (../../family/0088/task == complete)) and (../../family/0089/task == complete)) and (../../family/0090/task == complete)) and (../../family/0093/task == complete)) and (../../family/0096/task == complete)) and (../../family/0099/task == complete)) and (../../family/0102/task == complete)) and (../../family/0105/task == complete)) and (../../family/0108/task == complete)) and (../../family/0111/task == complete)) and (../../family/0114/task == complete)) and (../../family/0117/task == complete)) and (../../family/0120/task == complete)) and (../../family/0123/task == complete)) and (../../family/0126/task == complete)) and (../../family/0129/task == complete)) and (../../family/0132/task == complete)) and (../../family/0135/task == complete)) and (../../family/0138/task == complete)) and (../../family/0141/task == complete)) and (../../family/0144/task == complete)) and (../../family/0150/task == complete)) and (../../family/0156/task == complete)) and (../../family/0162/task == complete)) and (../../family/0168/task == complete)) and (../../family/0174/task == complete)) and (../../family/0180/task == complete)) and (../../family/0186/task == complete)) and (../../family/0192/task == complete)) and (../../family/0198/task == complete)) and (../../family/0204/task == complete)) and (../../family/0210/task == complete)) and (../../family/0216/task == complete)) and (../../family/0222/task == complete)) and (../../family/0228/task == complete)) and (../../family/0234/task == complete)) and (../../family/0240/task == complete))"
+    },
+    {
+      "expression": "(((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((suite eq complete and ../../family/0000/task eq complete) and ../../family/0001/task eq complete) and ../../family/0002/task eq complete) and ../../family/0003/task eq complete) and ../../family/0004/task eq complete) and ../../family/0005/task eq complete) and ../../family/0006/task eq complete) and ../../family/0007/task eq complete) and ../../family/0008/task eq complete) and ../../family/0009/task eq complete) and ../../family/0010/task eq complete) and ../../family/0011/task eq complete) and ../../family/0012/task eq complete) and ../../family/0013/task eq complete) and ../../family/0014/task eq complete) and ../../family/0015/task eq complete) and ../../family/0016/task eq complete) and ../../family/0017/task eq complete) and ../../family/0018/task eq complete) and ../../family/0019/task eq complete) and ../../family/0020/task eq complete) and ../../family/0021/task eq complete) and ../../family/0022/task eq complete) and ../../family/0023/task eq complete) and ../../family/0024/task eq complete) and ../../family/0025/task eq complete) and ../../family/0026/task eq complete) and ../../family/0027/task eq complete) and ../../family/0028/task eq complete) and ../../family/0029/task eq complete) and ../../family/0030/task eq complete) and ../../family/0031/task eq complete) and ../../family/0032/task eq complete) and ../../family/0033/task eq complete) and ../../family/0034/task eq complete) and ../../family/0035/task eq complete) and ../../family/0036/task eq complete) and ../../family/0037/task eq complete) and ../../family/0038/task eq complete) and ../../family/0039/task eq complete) and ../../family/0040/task eq complete) and ../../family/0041/task eq complete) and ../../family/0042/task eq complete) and ../../family/0043/task eq complete) and ../../family/0044/task eq complete) and ../../family/0045/task eq complete) and ../../family/0046/task eq complete) and ../../family/0047/task eq complete) and ../../family/0048/task eq complete) and ../../family/0049/task eq complete) and ../../family/0050/task eq complete) and ../../family/0051/task eq complete) and ../../family/0052/task eq complete) and ../../family/0053/task eq complete) and ../../family/0054/task eq complete) and ../../family/0055/task eq complete) and ../../family/0056/task eq complete) and ../../family/0057/task eq complete) and ../../family/0058/task eq complete) and ../../family/0059/task eq complete) and ../../family/0060/task eq complete) and ../../family/0061/task eq complete) and ../../family/0062/task eq complete) and ../../family/0063/task eq complete) and ../../family/0064/task eq complete) and ../../family/0065/task eq complete) and ../../family/0066/task eq complete) and ../../family/0067/task eq complete) and ../../family/0068/task eq complete) and ../../family/0069/task eq complete) and ../../family/0070/task eq complete) and ../../family/0071/task eq complete) and ../../family/0072/task eq complete) and ../../family/0073/task eq complete) and ../../family/0074/task eq complete) and ../../family/0075/task eq complete) and ../../family/0076/task eq complete) and ../../family/0077/task eq complete) and ../../family/0078/task eq complete) and ../../family/0079/task eq complete) and ../../family/0080/task eq complete) and ../../family/0081/task eq complete) and ../../family/0082/task eq complete) and ../../family/0083/task eq complete) and ../../family/0084/task eq complete) and ../../family/0085/task eq complete) and ../../family/0086/task eq complete) and ../../family/0087/task eq complete) and ../../family/0088/task eq complete) and ../../family/0089/task eq complete) and ../../family/0090/task eq complete) and ../../family/0093/task eq complete) and ../../family/0096/task eq complete) and ../../family/0099/task eq complete) and ../../family/0102/task eq complete) and ../../family/0105/task eq complete) and ../../family/0108/task eq complete) and ../../family/0111/task eq complete) and ../../family/0114/task eq complete) and ../../family/0117/task eq complete) and ../../family/0120/task eq complete) and ../../family/0123/task eq complete) and ../../family/0126/task eq complete) and ../../family/0129/task eq complete) and ../../family/0132/task eq complete) and ../../family/0135/task eq complete) and ../../family/0138/task eq complete) and ../../family/0141/task eq complete) and ../../family/0144/task eq complete) and ../../family/0150/task eq complete) and ../../family/0156/task eq complete) and ../../family/0162/task eq complete) and ../../family/0168/task eq complete) and ../../family/0174/task eq complete) and ../../family/0180/task eq complete) and ../../family/0186/task eq complete) and ../../family/0192/task eq complete) and ../../family/0198/task eq complete) and ../../family/0204/task eq complete) and ../../family/0210/task eq complete) and ../../family/0216/task eq complete) and ../../family/0222/task eq complete) and ../../family/0228/task eq complete) and ../../family/0234/task eq complete) and ../../family/0240/task eq complete) and ../../family/0246/task eq complete) and ../../family/0252/task eq complete) and ../../family/0258/task eq complete) and ../../family/0264/task eq complete) and ../../family/0270/task eq complete) and ../../family/0276/task eq complete) and ../../family/0282/task eq complete) and ../../family/0288/task eq complete) and ../../family/0294/task eq complete) and ../../family/0300/task eq complete) and ../../family/0306/task eq complete) and ../../family/0312/task eq complete) and ../../family/0318/task eq complete) and ../../family/0324/task eq complete) and ../../family/0330/task eq complete) and ../../family/0336/task eq complete) and ../../family/0342/task eq complete) and ../../family/0348/task eq complete) and ../../family/0354/task eq complete) and ../../family/0360/task eq complete)",
+      "expected": "((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((suite == complete) and (../../family/0000/task == complete)) and (../../family/0001/task == complete)) and (../../family/0002/task == complete)) and (../../family/0003/task == complete)) and (../../family/0004/task == complete)) and (../../family/0005/task == complete)) and (../../family/0006/task == complete)) and (../../family/0007/task == complete)) and (../../family/0008/task == complete)) and (../../family/0009/task == complete)) and (../../family/0010/task == complete)) and (../../family/0011/task == complete)) and (../../family/0012/task == complete)) and (../../family/0013/task == complete)) and (../../family/0014/task == complete)) and (../../family/0015/task == complete)) and (../../family/0016/task == complete)) and (../../family/0017/task == complete)) and (../../family/0018/task == complete)) and (../../family/0019/task == complete)) and (../../family/0020/task == complete)) and (../../family/0021/task == complete)) and (../../family/0022/task == complete)) and (../../family/0023/task == complete)) and (../../family/0024/task == complete)) and (../../family/0025/task == complete)) and (../../family/0026/task == complete)) and (../../family/0027/task == complete)) and (../../family/0028/task == complete)) and (../../family/0029/task == complete)) and (../../family/0030/task == complete)) and (../../family/0031/task == complete)) and (../../family/0032/task == complete)) and (../../family/0033/task == complete)) and (../../family/0034/task == complete)) and (../../family/0035/task == complete)) and (../../family/0036/task == complete)) and (../../family/0037/task == complete)) and (../../family/0038/task == complete)) and (../../family/0039/task == complete)) and (../../family/0040/task == complete)) and (../../family/0041/task == complete)) and (../../family/0042/task == complete)) and (../../family/0043/task == complete)) and (../../family/0044/task == complete)) and (../../family/0045/task == complete)) and (../../family/0046/task == complete)) and (../../family/0047/task == complete)) and (../../family/0048/task == complete)) and (../../family/0049/task == complete)) and (../../family/0050/task == complete)) and (../../family/0051/task == complete)) and (../../family/0052/task == complete)) and (../../family/0053/task == complete)) and (../../family/0054/task == complete)) and (../../family/0055/task == complete)) and (../../family/0056/task == complete)) and (../../family/0057/task == complete)) and (../../family/0058/task == complete)) and (../../family/0059/task == complete)) and (../../family/0060/task == complete)) and (../../family/0061/task == complete)) and (../../family/0062/task == complete)) and (../../family/0063/task == complete)) and (../../family/0064/task == complete)) and (../../family/0065/task == complete)) and (../../family/0066/task == complete)) and (../../family/0067/task == complete)) and (../../family/0068/task == complete)) and (../../family/0069/task == complete)) and (../../family/0070/task == complete)) and (../../family/0071/task == complete)) and (../../family/0072/task == complete)) and (../../family/0073/task == complete)) and (../../family/0074/task == complete)) and (../../family/0075/task == complete)) and (../../family/0076/task == complete)) and (../../family/0077/task == complete)) and (../../family/0078/task == complete)) and (../../family/0079/task == complete)) and (../../family/0080/task == complete)) and (../../family/0081/task == complete)) and (../../family/0082/task == complete)) and (../../family/0083/task == complete)) and (../../family/0084/task == complete)) and (../../family/0085/task == complete)) and (../../family/0086/task == complete)) and (../../family/0087/task == complete)) and (../../family/0088/task == complete)) and (../../family/0089/task == complete)) and (../../family/0090/task == complete)) and (../../family/0093/task == complete)) and (../../family/0096/task == complete)) and (../../family/0099/task == complete)) and (../../family/0102/task == complete)) and (../../family/0105/task == complete)) and (../../family/0108/task == complete)) and (../../family/0111/task == complete)) and (../../family/0114/task == complete)) and (../../family/0117/task == complete)) and (../../family/0120/task == complete)) and (../../family/0123/task == complete)) and (../../family/0126/task == complete)) and (../../family/0129/task == complete)) and (../../family/0132/task == complete)) and (../../family/0135/task == complete)) and (../../family/0138/task == complete)) and (../../family/0141/task == complete)) and (../../family/0144/task == complete)) and (../../family/0150/task == complete)) and (../../family/0156/task == complete)) and (../../family/0162/task == complete)) and (../../family/0168/task == complete)) and (../../family/0174/task == complete)) and (../../family/0180/task == complete)) and (../../family/0186/task == complete)) and (../../family/0192/task == complete)) and (../../family/0198/task == complete)) and (../../family/0204/task == complete)) and (../../family/0210/task == complete)) and (../../family/0216/task == complete)) and (../../family/0222/task == complete)) and (../../family/0228/task == complete)) and (../../family/0234/task == complete)) and (../../family/0240/task == complete)) and (../../family/0246/task == complete)) and (../../family/0252/task == complete)) and (../../family/0258/task == complete)) and (../../family/0264/task == complete)) and (../../family/0270/task == complete)) and (../../family/0276/task == complete)) and (../../family/0282/task == complete)) and (../../family/0288/task == complete)) and (../../family/0294/task == complete)) and (../../family/0300/task == complete)) and (../../family/0306/task == complete)) and (../../family/0312/task == complete)) and (../../family/0318/task == complete)) and (../../family/0324/task == complete)) and (../../family/0330/task == complete)) and (../../family/0336/task == complete)) and (../../family/0342/task == complete)) and (../../family/0348/task == complete)) and (../../family/0354/task == complete)) and (../../family/0360/task == complete))"
+    },
+    {
+      "expression": "(../../suite:attrib1 gt ../../family:attrib1 and ../../task:attrib1 gt ../../family:attrib1)",
+      "expected": "((../../suite:attrib1 > ../../family:attrib1) and (../../task:attrib1 > ../../family:attrib1))"
+    },
+    {
+      "expression": "(../../suite:attrib1 gt ../../family:attrib1 and (../../task:attrib1 gt ../../family:attrib1 and node4 eq complete))",
+      "expected": "((../../suite:attrib1 > ../../family:attrib1) and ((../../task:attrib1 > ../../family:attrib1) and (node4 == complete)))"
+    },
+    {
+      "expression": "((((((((((((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and node6 eq complete) and node7 eq complete) and node8 eq complete) and node9 eq complete) and node10 eq complete) and node11 eq complete) and node12 eq complete) and node13 eq complete) and node14 eq complete) and node15 eq complete)",
+      "expected": "(((((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt ../../../task:attrib1 or (node4 eq complete and node5 eq complete and node6 eq complete and node7 eq complete and node8 eq complete and node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete and node13 eq complete and node14 eq complete))",
+      "expected": "((/suite/family:attrib1 > ../../../task:attrib1) or (((((((((((node4 == complete) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4 eq complete or ../node5 eq complete) and node6 eq complete)",
+      "expected": "(((/suite/family/12/task/node4 == complete) or (../node5 == complete)) and (node6 == complete))"
+    },
+    {
+      "expression": "((((/suite/family/12/task/node4:attrib1 ge 1 or /suite/family/12/task/node5:attrib1 ge 1) or /suite/family/12/task/node4 eq complete) or ../../node6 eq complete) and node7 eq complete)",
+      "expected": "(((((/suite/family/12/task/node4:attrib1 >= 1) or (/suite/family/12/task/node5:attrib1 >= 1)) or (/suite/family/12/task/node4 == complete)) or (../../node6 == complete)) and (node7 == complete))"
+    },
+    {
+      "expression": "(((/suite/family/12/task/node4 eq complete and (/suite/family:attrib1 ge /node5/node6/node7:attrib1)) or ../../node8 eq complete) and node9 eq complete)",
+      "expected": "((((/suite/family/12/task/node4 == complete) and (/suite/family:attrib1 >= /node5/node6/node7:attrib1)) or (../../node8 == complete)) and (node9 == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt ../../../task:attrib1 and /node4/family:attrib1 gt ../../../task:attrib1) or (node5 eq complete and node6 eq complete and node7 eq complete and node8 eq complete and node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete and node13 eq complete and node14 eq complete and node15 eq complete and node16 eq complete))",
+      "expected": "(((/suite/family:attrib1 > ../../../task:attrib1) and (/node4/family:attrib1 > ../../../task:attrib1)) or ((((((((((((node5 == complete) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/task/12/node4/node5/0000 eq complete and /suite/family/task/12/node4/node5/0006 eq complete and /suite/family/task/12/node4/node5/0012 eq complete and /suite/family/task/12/node4/node5/0018 eq complete and /suite/family/task/12/node4/node5/0024 eq complete and /suite/family/task/12/node4/node5/0030 eq complete and /suite/family/task/12/node4/node5/0036 eq complete and /suite/family/task/12/node4/node5/0042 eq complete and /suite/family/task/12/node4/node5/0048 eq complete))",
+      "expected": "(((((((((/suite/family/task/12/node4/node5/0000 == complete) and (/suite/family/task/12/node4/node5/0006 == complete)) and (/suite/family/task/12/node4/node5/0012 == complete)) and (/suite/family/task/12/node4/node5/0018 == complete)) and (/suite/family/task/12/node4/node5/0024 == complete)) and (/suite/family/task/12/node4/node5/0030 == complete)) and (/suite/family/task/12/node4/node5/0036 == complete)) and (/suite/family/task/12/node4/node5/0042 == complete)) and (/suite/family/task/12/node4/node5/0048 == complete))"
+    },
+    {
+      "expression": "((/suite/family/task/12/node4/node5/0054 eq complete and /suite/family/task/12/node4/node5/0060 eq complete and /suite/family/task/12/node4/node5/0066 eq complete and /suite/family/task/12/node4/node5/0072 eq complete and /suite/family/task/12/node4/node5/0078 eq complete and /suite/family/task/12/node4/node5/0084 eq complete and /suite/family/task/12/node4/node5/0090 eq complete))",
+      "expected": "(((((((/suite/family/task/12/node4/node5/0054 == complete) and (/suite/family/task/12/node4/node5/0060 == complete)) and (/suite/family/task/12/node4/node5/0066 == complete)) and (/suite/family/task/12/node4/node5/0072 == complete)) and (/suite/family/task/12/node4/node5/0078 == complete)) and (/suite/family/task/12/node4/node5/0084 == complete)) and (/suite/family/task/12/node4/node5/0090 == complete))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt ../../../node4:attrib1 or (node5 eq complete and node6 eq complete and node7 eq complete and node8 eq complete and node9 eq complete and node10 eq complete))",
+      "expected": "((/suite/family/task:attrib1 > ../../../node4:attrib1) or ((((((node5 == complete) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)))"
+    },
+    {
+      "expression": "((((/suite/family/task/12/family/node4/node5 eq complete and /node6/task/12/node7/node8 eq complete) and (/suite/family/task:attrib1 ge /node9/node10/node11:attrib1)) or ../../node12 eq complete) and node13 eq complete)",
+      "expected": "(((((/suite/family/task/12/family/node4/node5 == complete) and (/node6/task/12/node7/node8 == complete)) and (/suite/family/task:attrib1 >= /node9/node10/node11:attrib1)) or (../../node12 == complete)) and (node13 == complete))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt ../../../task:attrib1 or (node4 eq complete and node5 eq complete and node6 eq complete and node7 eq complete and node8 eq complete and node9 eq complete and node10 eq complete and node11 eq complete))",
+      "expected": "((/suite/family:attrib1 > ../../../task:attrib1) or ((((((((node4 == complete) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt ../../../task:attrib1 and /node4/family:attrib1 gt ../../../task:attrib1) or (node5 eq complete and node6 eq complete and node7 eq complete and node8 eq complete and node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete))",
+      "expected": "(((/suite/family:attrib1 > ../../../task:attrib1) and (/node4/family:attrib1 > ../../../task:attrib1)) or ((((((((node5 == complete) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)))"
+    },
+    {
+      "expression": "((suite/family:attrib1 and suite/task:attrib1) or (suite eq complete and node4 eq complete and node5 eq complete and node6 eq complete and node7 eq complete and node8 eq complete and node9 eq complete))",
+      "expected": "((suite/family:attrib1 and suite/task:attrib1) or (((((((suite == complete) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 ge /task/node4/node5:attrib1) or 1 == 1)",
+      "expected": "((/suite/family:attrib1 >= /task/node4/node5:attrib1) or (1 == 1))"
+    },
+    {
+      "expression": "(:attrib1 >= 1400 and :attrib1 <= 1700)",
+      "expected": "((:attrib1 >= 1400) and (:attrib1 <= 1700))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt ../../../task:attrib1 and /node4/family:attrib1 gt ../../../task:attrib1) or (node5 eq complete and node6 eq complete and node7 eq complete and node8 eq complete and node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete and node13 eq complete and node14 eq complete and node15 eq complete))",
+      "expected": "(((/suite/family:attrib1 > ../../../task:attrib1) and (/node4/family:attrib1 > ../../../task:attrib1)) or (((((((((((node5 == complete) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt ../../../node4:attrib1 or (node5 eq complete and node6 eq complete and node7 eq complete and node8 eq complete and node9 eq complete and node10 eq complete and node11 eq complete))",
+      "expected": "((/suite/family/task:attrib1 > ../../../node4:attrib1) or (((((((node5 == complete) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/12/node6/240 eq complete and /suite/family/task/node4/node5/12/node7/240 eq complete) or ../../node8 eq complete) and node9 eq complete)",
+      "expected": "((((/suite/family/task/node4/node5/12/node6/240 == complete) and (/suite/family/task/node4/node5/12/node7/240 == complete)) or (../../node8 == complete)) and (node9 == complete))"
+    },
+    {
+      "expression": "(:attrib1 >= 1700 and :attrib1 < 2100)",
+      "expected": "((:attrib1 >= 1700) and (:attrib1 < 2100))"
+    },
+    {
+      "expression": "((suite/family:attrib1 and suite/task:attrib1) or (suite eq complete and node4 eq complete and node5 eq complete and node6 eq complete and node7 eq complete and node8 eq complete and node9 eq complete and node10 eq complete))",
+      "expected": "((suite/family:attrib1 and suite/task:attrib1) or ((((((((suite == complete) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/task/12/node4/node5/0048 eq complete and /suite/family/task/12/node4/node5/0051 eq complete and /suite/family/task/12/node4/node5/0054 eq complete and /suite/family/task/12/node4/node5/0057 eq complete and /suite/family/task/12/node4/node5/0060 eq complete and /suite/family/task/12/node4/node5/0063 eq complete and /suite/family/task/12/node4/node5/0066 eq complete and /suite/family/task/12/node4/node5/0069 eq complete and /suite/family/task/12/node4/node5/0072 eq complete and /suite/family/task/12/node4/node5/0075 eq complete and /suite/family/task/12/node4/node5/0078 eq complete and /suite/family/task/12/node4/node5/0081 eq complete and /suite/family/task/12/node4/node5/0084 eq complete and /suite/family/task/12/node4/node5/0087 eq complete and /suite/family/task/12/node4/node5/0090 eq complete))",
+      "expected": "(((((((((((((((/suite/family/task/12/node4/node5/0048 == complete) and (/suite/family/task/12/node4/node5/0051 == complete)) and (/suite/family/task/12/node4/node5/0054 == complete)) and (/suite/family/task/12/node4/node5/0057 == complete)) and (/suite/family/task/12/node4/node5/0060 == complete)) and (/suite/family/task/12/node4/node5/0063 == complete)) and (/suite/family/task/12/node4/node5/0066 == complete)) and (/suite/family/task/12/node4/node5/0069 == complete)) and (/suite/family/task/12/node4/node5/0072 == complete)) and (/suite/family/task/12/node4/node5/0075 == complete)) and (/suite/family/task/12/node4/node5/0078 == complete)) and (/suite/family/task/12/node4/node5/0081 == complete)) and (/suite/family/task/12/node4/node5/0084 == complete)) and (/suite/family/task/12/node4/node5/0087 == complete)) and (/suite/family/task/12/node4/node5/0090 == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt ../../../task:attrib1 and /node4/family:attrib1 gt ../../../task:attrib1) or (node5 eq complete and node6 eq complete and node7 eq complete and node8 eq complete and node9 eq complete and node10 eq complete and node11 eq complete))",
+      "expected": "(((/suite/family:attrib1 > ../../../task:attrib1) and (/node4/family:attrib1 > ../../../task:attrib1)) or (((((((node5 == complete) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)))"
+    },
+    {
+      "expression": "(((suite eq complete or suite/family:attrib1) and (task eq complete or task/family:attrib1)) and node4 eq complete)",
+      "expected": "((((suite == complete) or suite/family:attrib1) and ((task == complete) or task/family:attrib1)) and (node4 == complete))"
+    },
+    {
+      "expression": "((suite eq complete and family eq complete) and (task/node4 eq complete or task/node4:attrib1))",
+      "expected": "(((suite == complete) and (family == complete)) and ((task/node4 == complete) or task/node4:attrib1))"
+    },
+    {
+      "expression": "((suite:attrib1 gt family:attrib1 or suite eq complete) and family:attrib1 le task:attrib1)",
+      "expected": "(((suite:attrib1 > family:attrib1) or (suite == complete)) and (family:attrib1 <= task:attrib1))"
+    },
+    {
+      "expression": "(../../suite:attrib1 gt ../../family:attrib1 or (../../suite:attrib1 eq ../../family:attrib1 and ((((../../suite/task eq complete and ../../suite/node4 eq complete) and ../../suite/node5 eq complete) and ../../suite/node6 eq complete) and ../../suite/node7 eq complete)))",
+      "expected": "((../../suite:attrib1 > ../../family:attrib1) or ((../../suite:attrib1 == ../../family:attrib1) and (((((../../suite/task == complete) and (../../suite/node4 == complete)) and (../../suite/node5 == complete)) and (../../suite/node6 == complete)) and (../../suite/node7 == complete))))"
+    },
+    {
+      "expression": "(../../../../suite:attrib1 gt ../../../../family:attrib1 or (../../../../suite:attrib1 eq ../../../../family:attrib1 and ../../../../suite/task/node4:attrib2))",
+      "expected": "((../../../../suite:attrib1 > ../../../../family:attrib1) or ((../../../../suite:attrib1 == ../../../../family:attrib1) and ../../../../suite/task/node4:attrib2))"
+    },
+    {
+      "expression": "(suite:attrib1 < /family/task/node4:attrib1)",
+      "expected": "(suite:attrib1 < /family/task/node4:attrib1)"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 > ../node4:attrib1 and node5 == complete and node6 == complete and node7 == complete and node8 == complete)",
+      "expected": "(((((/suite/family/task:attrib1 > ../node4:attrib1) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete))"
+    },
+    {
+      "expression": "(/suite/family/task/node4:attrib1 ge :attrib1 and /suite/family/task/node4/node5:attrib2 ge :attrib2 or /suite/family/task/node4/node5 eq aborted or /suite/family/task/node4/node5/node6 eq complete)",
+      "expected": "(((/suite/family/task/node4:attrib1 >= :attrib1) and (/suite/family/task/node4/node5:attrib2 >= :attrib2)) or ((/suite/family/task/node4/node5 == aborted) or (/suite/family/task/node4/node5/node6 == complete)))"
+    },
+    {
+      "expression": "(/suite/family/00/task/node4/node5 != active)",
+      "expected": "(/suite/family/00/task/node4/node5 != active)"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and :attrib1 le (:attrib2 + 14))",
+      "expected": "((((suite == complete) and (family == complete)) and (task == complete)) and (:attrib1 <= (:attrib2 + 14)))"
+    },
+    {
+      "expression": "((suite == complete) and (family == complete and suite == complete))",
+      "expected": "((suite == complete) and ((family == complete) and (suite == complete)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5/node6==complete and /suite/task/node7/12/node8==complete) and /suite/task/node7/12/node8 eq complete)",
+      "expected": "((/suite/family:attrib1 > /suite/task:attrib1) or ((((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/12/node4/node5/node6 == complete)) and (/suite/task/node7/12/node8 == complete)) and (/suite/task/node7/12/node8 == complete)))"
+    },
+    {
+      "expression": "(1==1 or /suite/family/12/task/node4/node5/050/node6:attrib1 gt 0 or /suite/family/12/task/node4/node5 eq complete)",
+      "expected": "((1 == 1) or ((/suite/family/12/task/node4/node5/050/node6:attrib1 > 0) or (/suite/family/12/task/node4/node5 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt :attrib1 or /suite/family/12/task/node4 eq complete) and (/node5/family/12//node6/task==complete or /node5/family/12/node7:attrib2 ge 240 or /node5/family/12/node8:attrib3 ge 240)) and (node9 == complete))",
+      "expected": "((((/suite/family:attrib1 > :attrib1) or (/suite/family/12/task/node4 == complete)) and ((/node5/family/12//node6/task == complete) or ((/node5/family/12/node7:attrib2 >= 240) or (/node5/family/12/node8:attrib3 >= 240)))) and (node9 == complete))"
+    },
+    {
+      "expression": "(((/suite/family/12//task/node4==complete or /suite/family/12/node5:attrib1 ge 360 or /suite/family/12/node6:attrib2 ge 360)) and (node7 == complete))",
+      "expected": "(((/suite/family/12//task/node4 == complete) or ((/suite/family/12/node5:attrib1 >= 360) or (/suite/family/12/node6:attrib2 >= 360))) and (node7 == complete))"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4 == complete or /suite/family:attrib1 gt :attrib1 or ../../node5/node6 eq complete)",
+      "expected": "((/suite/family/12/task/node4 == complete) or ((/suite/family:attrib1 > :attrib1) or (../../node5/node6 == complete)))"
+    },
+    {
+      "expression": "(:attrib1 lt :attrib2)",
+      "expected": "(:attrib1 < :attrib2)"
+    },
+    {
+      "expression": "(suite == complete and :attrib1 lt :attrib2)",
+      "expected": "((suite == complete) and (:attrib1 < :attrib2))"
+    },
+    {
+      "expression": "(:attrib1 lt :attrib2 and :attrib3 gt 1500)",
+      "expected": "((:attrib1 < :attrib2) and (:attrib3 > 1500))"
+    },
+    {
+      "expression": "(./12 == complete and ./suite == complete and ./00 == complete and ./family == complete and :attrib1 lt 20240531)",
+      "expected": "(((((./12 == complete) and (./suite == complete)) and (./00 == complete)) and (./family == complete)) and (:attrib1 < 20240531))"
+    },
+    {
+      "expression": "(:attrib1 % 2 == 1)",
+      "expected": "((:attrib1 % 2) == 1)"
+    },
+    {
+      "expression": "((:attrib1 * 100 + :attrib2) == 229 or (:attrib1 * 100 + :attrib2) == 231)",
+      "expected": "((((:attrib1 * 100) + :attrib2) == 229) or (((:attrib1 * 100) + :attrib2) == 231))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and (:attrib1 - :attrib2) < 18)",
+      "expected": "((((suite == complete) and (family == complete)) and (task == complete)) and ((:attrib1 - :attrib2) < 18))"
+    },
+    {
+      "expression": "(((suite == complete) and (family == complete and suite == complete)) and (:attrib1 le (:attrib2+14)))",
+      "expected": "(((suite == complete) and ((family == complete) and (suite == complete))) and (:attrib1 <= (:attrib2 + 14)))"
+    },
+    {
+      "expression": "(../suite:attrib1 < /family/task/node4:attrib1 and node5 == complete and node6 == complete)",
+      "expected": "(((../suite:attrib1 < /family/task/node4:attrib1) and (node5 == complete)) and (node6 == complete))"
+    },
+    {
+      "expression": "(../suite:attrib1 < /family/task:attrib1 and node4 == complete and node5 == complete and node6 == complete)",
+      "expected": "((((../suite:attrib1 < /family/task:attrib1) and (node4 == complete)) and (node5 == complete)) and (node6 == complete))"
+    },
+    {
+      "expression": "(/suite/family == complete and /suite/task/node4:attrib1 > node5:attrib1)",
+      "expected": "((/suite/family == complete) and (/suite/task/node4:attrib1 > node5:attrib1))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 > :attrib1 or (/suite/family:attrib1 == :attrib1 and /suite/family/task/node4/node5 == complete)))",
+      "expected": "((/suite/family:attrib1 > :attrib1) or ((/suite/family:attrib1 == :attrib1) and (/suite/family/task/node4/node5 == complete)))"
+    },
+    {
+      "expression": "((:attrib1 == 0 and (/suite/family:attrib2 > :attrib2 or (/suite/family:attrib2 == :attrib2 and /suite/family/task/node4/node5 == complete))) or (:attrib1 == 1 and (( :attrib3 ge (1240 + :attrib4) and :attrib5 eq :attrib6 ) or ( :attrib5 gt :attrib6 ))))",
+      "expected": "(((:attrib1 == 0) and ((/suite/family:attrib2 > :attrib2) or ((/suite/family:attrib2 == :attrib2) and (/suite/family/task/node4/node5 == complete)))) or ((:attrib1 == 1) and (((:attrib3 >= (1240 + :attrib4)) and (:attrib5 == :attrib6)) or (:attrib5 > :attrib6))))"
+    },
+    {
+      "expression": "((../../../../suite/family/task/node4:attrib1 and ../../../../suite/family/task/node4:attrib2) or ../../../../suite/family/task/node4 == complete)",
+      "expected": "((../../../../suite/family/task/node4:attrib1 and ../../../../suite/family/task/node4:attrib2) or (../../../../suite/family/task/node4 == complete))"
+    },
+    {
+      "expression": "(((../../../suite/family/task/node4:attrib1 and ../../../suite/family/task/node4:attrib2) or ../../../suite/family/task/node4 == complete) and (node5 == complete and node6 == complete))",
+      "expected": "(((../../../suite/family/task/node4:attrib1 and ../../../suite/family/task/node4:attrib2) or (../../../suite/family/task/node4 == complete)) and ((node5 == complete) and (node6 == complete)))"
+    },
+    {
+      "expression": "((:attrib1 == 0 and (/suite/family:attrib2 > :attrib2 or (/suite/family:attrib2 == :attrib2 and /suite/family/task/node4/node5 == complete))) or (:attrib1 == 1 and (( :attrib3 ge (40 + :attrib4) and :attrib5 eq :attrib6 + 1 ) or ( :attrib5 gt :attrib6 + 1 ))))",
+      "expected": "(((:attrib1 == 0) and ((/suite/family:attrib2 > :attrib2) or ((/suite/family:attrib2 == :attrib2) and (/suite/family/task/node4/node5 == complete)))) or ((:attrib1 == 1) and (((:attrib3 >= (40 + :attrib4)) and (:attrib5 == (:attrib6 + 1))) or (:attrib5 > (:attrib6 + 1)))))"
+    },
+    {
+      "expression": "((suite:attrib1 lt ../family/suite:attrib1))",
+      "expected": "(suite:attrib1 < ../family/suite:attrib1)"
+    },
+    {
+      "expression": "(../../../../../suite:attrib1 gt ../../../../family:attrib1 or (../../../../../suite:attrib1 eq ../../../../family:attrib1 and (../../../../../suite/task:attrib2 gt ../../../node4:attrib2 or (../../../../../suite/task:attrib2 eq ../../../node4:attrib2 and ../../../../../suite/task/node5 eq complete))))",
+      "expected": "((../../../../../suite:attrib1 > ../../../../family:attrib1) or ((../../../../../suite:attrib1 == ../../../../family:attrib1) and ((../../../../../suite/task:attrib2 > ../../../node4:attrib2) or ((../../../../../suite/task:attrib2 == ../../../node4:attrib2) and (../../../../../suite/task/node5 == complete)))))"
+    },
+    {
+      "expression": "(../../1/suite/family eq complete and (../../../../../task:attrib1 gt ../../../../node4:attrib1 or (../../../../../task:attrib1 eq ../../../../node4:attrib1 and (../../../../../task/node5:attrib2 gt ../../../node6:attrib2 or (../../../../../task/node5:attrib2 eq ../../../node6:attrib2 and ../../../../../task/node5/node7 eq complete)))))",
+      "expected": "((../../1/suite/family == complete) and ((../../../../../task:attrib1 > ../../../../node4:attrib1) or ((../../../../../task:attrib1 == ../../../../node4:attrib1) and ((../../../../../task/node5:attrib2 > ../../../node6:attrib2) or ((../../../../../task/node5:attrib2 == ../../../node6:attrib2) and (../../../../../task/node5/node7 == complete))))))"
+    },
+    {
+      "expression": "((../../../../../suite:attrib1 gt ../../../../family:attrib1 or (../../../../../suite:attrib1 eq ../../../../family:attrib1 and (../../../../../suite/task:attrib2 gt ../../../node4:attrib2 or (../../../../../suite/task:attrib2 eq ../../../node4:attrib2 and ../../../../../suite/task/node5 eq complete)))) and ../../1/node6/node7 eq complete)",
+      "expected": "(((../../../../../suite:attrib1 > ../../../../family:attrib1) or ((../../../../../suite:attrib1 == ../../../../family:attrib1) and ((../../../../../suite/task:attrib2 > ../../../node4:attrib2) or ((../../../../../suite/task:attrib2 == ../../../node4:attrib2) and (../../../../../suite/task/node5 == complete))))) and (../../1/node6/node7 == complete))"
+    },
+    {
+      "expression": "((../suite/12 eq complete and ../suite:attrib1 eq ../family:attrib1) or ../suite:attrib1 gt ../family:attrib1)",
+      "expected": "(((../suite/12 == complete) and (../suite:attrib1 == ../family:attrib1)) or (../suite:attrib1 > ../family:attrib1))"
+    },
+    {
+      "expression": "(:attrib1 != :attrib2)",
+      "expected": "(:attrib1 != :attrib2)"
+    },
+    {
+      "expression": "(((/suite/family/12/task:attrib1 ge 30 or /suite/family/12/node4/node5 eq complete) and ../../../../../family:attrib2 eq /suite/family:attrib2) or ../../../../../family:attrib2 lt /suite/family:attrib2)",
+      "expected": "((((/suite/family/12/task:attrib1 >= 30) or (/suite/family/12/node4/node5 == complete)) and (../../../../../family:attrib2 == /suite/family:attrib2)) or (../../../../../family:attrib2 < /suite/family:attrib2))"
+    },
+    {
+      "expression": "(((/suite/family/12/task:attrib1 ge ../../240:attrib2 or /suite/family/12/node4/node5 eq complete) and ../../../../family:attrib3 eq /suite/family:attrib3) or ../../../../family:attrib3 lt /suite/family:attrib3)",
+      "expected": "((((/suite/family/12/task:attrib1 >= ../../240:attrib2) or (/suite/family/12/node4/node5 == complete)) and (../../../../family:attrib3 == /suite/family:attrib3)) or (../../../../family:attrib3 < /suite/family:attrib3))"
+    },
+    {
+      "expression": "(((/suite/family/00/task/node4 eq complete and ../../../../../node5:attrib1 eq /suite/family/00:attrib1) or ../../../../../node5:attrib1 lt /suite/family/00:attrib1) and node6 eq complete)",
+      "expected": "((((/suite/family/00/task/node4 == complete) and (../../../../../node5:attrib1 == /suite/family/00:attrib1)) or (../../../../../node5:attrib1 < /suite/family/00:attrib1)) and (node6 == complete))"
+    },
+    {
+      "expression": "((suite eq complete) and (../family/00 eq complete or ../task:attrib1 lt ../family:attrib1))",
+      "expected": "((suite == complete) and ((../family/00 == complete) or (../task:attrib1 < ../family:attrib1)))"
+    },
+    {
+      "expression": "((/suite/family/12/task:attrib1 ge 240 or /suite/family/12/node4/node5 eq complete) and /node6/family/12/node5 eq complete)",
+      "expected": "(((/suite/family/12/task:attrib1 >= 240) or (/suite/family/12/node4/node5 == complete)) and (/node6/family/12/node5 == complete))"
+    },
+    {
+      "expression": "((/suite/family/12/task eq complete and /suite/family/12/node4/node5 eq complete) or ../../node6 eq complete)",
+      "expected": "(((/suite/family/12/task == complete) and (/suite/family/12/node4/node5 == complete)) or (../../node6 == complete))"
+    },
+    {
+      "expression": "(((/suite/family/12/task:attrib1 ge 72 or /suite/family/12/node4/node5 eq complete) or ../../../node6 eq complete) and (/node7/family/12/node5 eq complete or ../../../node6 eq complete))",
+      "expected": "((((/suite/family/12/task:attrib1 >= 72) or (/suite/family/12/node4/node5 == complete)) or (../../../node6 == complete)) and ((/node7/family/12/node5 == complete) or (../../../node6 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/12/task eq complete and /suite/family/12/node4/node5 eq complete) or ../../../node6 eq complete) and (/node7/family/12/node5 eq complete or ../../../node6 eq complete))",
+      "expected": "((((/suite/family/12/task == complete) and (/suite/family/12/node4/node5 == complete)) or (../../../node6 == complete)) and ((/node7/family/12/node5 == complete) or (../../../node6 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5 eq complete or ../../../node6 eq complete) and (/node7/family/task/node5 eq complete or ../../../node6 eq complete))",
+      "expected": "(((/suite/family/task/node4/node5 == complete) or (../../../node6 == complete)) and ((/node7/family/task/node5 == complete) or (../../../node6 == complete)))"
+    },
+    {
+      "expression": "(../suite:attrib1 gt 16 or ../suite:attrib1 gt 16 or ../suite:attrib1 gt 16 or ../family:attrib2 gt 16 or ../family:attrib2 gt 16 or ../family:attrib2 gt 16 or (../suite eq complete and ../family eq complete))",
+      "expected": "((../suite:attrib1 > 16) or ((../suite:attrib1 > 16) or ((../suite:attrib1 > 16) or ((../family:attrib2 > 16) or ((../family:attrib2 > 16) or ((../family:attrib2 > 16) or ((../suite == complete) and (../family == complete))))))))"
+    },
+    {
+      "expression": "((/suite/family/12/task/240/node4==complete and (/suite/family/12/task/360/node4==complete)) and (node5 == complete))",
+      "expected": "(((/suite/family/12/task/240/node4 == complete) and (/suite/family/12/task/360/node4 == complete)) and (node5 == complete))"
+    },
+    {
+      "expression": "(../suite/family==complete or ../task:attrib1 eq 360)",
+      "expected": "((../suite/family == complete) or (../task:attrib1 == 360))"
+    },
+    {
+      "expression": "(/suite:attrib1 eq 0)",
+      "expected": "(/suite:attrib1 == 0)"
+    },
+    {
+      "expression": "(((/suite:attrib1 gt /suite/family:attrib2) and (/suite:attrib3 ge 0655)) and (/task/family/00/node4/node5:attrib4 ge 240))",
+      "expected": "(((/suite:attrib1 > /suite/family:attrib2) and (/suite:attrib3 >= 655)) and (/task/family/00/node4/node5:attrib4 >= 240))"
+    },
+    {
+      "expression": "((/suite:attrib1 ge 1855) and (/family/task/12/node4/node5:attrib2 ge 240))",
+      "expected": "((/suite:attrib1 >= 1855) and (/family/task/12/node4/node5:attrib2 >= 240))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /task/family:attrib1) or (/suite/family:attrib1 eq /task/family:attrib1 and /suite/family/12/node4 eq complete and /suite/family/12/node5 eq complete))",
+      "expected": "((/suite/family:attrib1 > /task/family:attrib1) or (((/suite/family:attrib1 == /task/family:attrib1) and (/suite/family/12/node4 == complete)) and (/suite/family/12/node5 == complete)))"
+    },
+    {
+      "expression": "((suite eq complete) and (suite eq complete))",
+      "expected": "((suite == complete) and (suite == complete))"
+    },
+    {
+      "expression": "((../suite:attrib1 or ../suite == complete) and (../family:attrib1 or ../family == complete))",
+      "expected": "((../suite:attrib1 or (../suite == complete)) and (../family:attrib1 or (../family == complete)))"
+    },
+    {
+      "expression": "(( /suite/family:attrib1 gt /task/family:attrib1) or (/suite/family:attrib1==/task/family:attrib1 and /suite/family/00/node4==complete ) and /task/family/node5/node6==complete)",
+      "expected": "((/suite/family:attrib1 > /task/family:attrib1) or (((/suite/family:attrib1 == /task/family:attrib1) and (/suite/family/00/node4 == complete)) and (/task/family/node5/node6 == complete)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 >= :attrib1 or (/suite/family:attrib1 == :attrib1-1 and /suite/family/00/task/node4 == complete)))",
+      "expected": "((/suite/family:attrib1 >= :attrib1) or ((/suite/family:attrib1 == (:attrib1 - 1)) and (/suite/family/00/task/node4 == complete)))"
+    },
+    {
+      "expression": "((:attrib1 == 0 and (/suite/family:attrib2 >= :attrib2 or (/suite/family:attrib2 == :attrib2-1 and /suite/family/00/task/node4 == complete))) or (:attrib1 == 1 and (( :attrib3 ge (330 + :attrib4) and :attrib5 eq :attrib6 ) or ( :attrib5 gt :attrib6 ))))",
+      "expected": "(((:attrib1 == 0) and ((/suite/family:attrib2 >= :attrib2) or ((/suite/family:attrib2 == (:attrib2 - 1)) and (/suite/family/00/task/node4 == complete)))) or ((:attrib1 == 1) and (((:attrib3 >= (330 + :attrib4)) and (:attrib5 == :attrib6)) or (:attrib5 > :attrib6))))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and 12 == complete and 00 == complete)",
+      "expected": "((((suite == complete) and (family == complete)) and (12 == complete)) and (00 == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 == ../family:attrib1 and /suite/family/12/task/node4 == complete or node5 == complete) and ../node6 == complete)",
+      "expected": "((((/suite/family:attrib1 == ../family:attrib1) and (/suite/family/12/task/node4 == complete)) or (node5 == complete)) and (../node6 == complete))"
+    },
+    {
+      "expression": "(:attrib1 < ../suite:attrib1 or ../suite/12 == complete)",
+      "expected": "((:attrib1 < ../suite:attrib1) or (../suite/12 == complete))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete)",
+      "expected": "((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete))"
+    },
+    {
+      "expression": "(not suite == complete)",
+      "expected": "not ((suite == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 > /task/node4:attrib1) and 12 == complete and 06 == complete and 00 == complete and node5 == complete)",
+      "expected": "((/suite/family:attrib1 > /task/node4:attrib1) and ((((12 == complete) and (06 == complete)) and (00 == complete)) and (node5 == complete)))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 <= /suite/task:attrib1 + 1)",
+      "expected": "(/suite/family:attrib1 <= (/suite/task:attrib1 + 1))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 < /suite/task:attrib1 or /suite/family:attrib1 == /suite/task:attrib1 and (/suite/task/12/node4/node5:attrib2 or /suite/task/12/node4/node5 == complete))",
+      "expected": "((/suite/family:attrib1 < /suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/task/12/node4/node5:attrib2 or (/suite/task/12/node4/node5 == complete))))"
+    },
+    {
+      "expression": "(suite/00/suite/family == active and suite/01/suite/family == active and suite/02/suite/family == active and suite/03/suite/family == active and suite/04/suite/family == active and suite/05/suite/family == active and suite/06/suite/family == active and suite/07/suite/family == active and suite/08/suite/family == active and suite/09/suite/family == active and suite/10/suite/family == active and suite/11/suite/family == active and suite/12/suite/family == active and suite/13/suite/family == active and suite/14/suite/family == active and suite/15/suite/family == active and suite/16/suite/family == active and suite/17/suite/family == active and suite/18/suite/family == active and suite/19/suite/family == active and suite/20/suite/family == active and suite/21/suite/family == active and suite/22/suite/family == active and suite/23/suite/family == active and suite/24/suite/family == active and suite/25/suite/family == active and suite/26/suite/family == active and suite/27/suite/family == active and suite/28/suite/family == active and suite/29/suite/family == active and suite/30/suite/family == active and suite/31/suite/family == active and suite/32/suite/family == active and suite/33/suite/family == active and suite/34/suite/family == active and suite/35/suite/family == active and suite/36/suite/family == active and suite/37/suite/family == active and suite/38/suite/family == active and suite/39/suite/family == active and suite/40/suite/family == active and suite/41/suite/family == active and suite/42/suite/family == active and suite/43/suite/family == active and suite/44/suite/family == active and suite/45/suite/family == active and suite/46/suite/family == active and suite/47/suite/family == active and suite/48/suite/family == active and suite/49/suite/family == active and suite/50/suite/family == active)",
+      "expected": "(((((((((((((((((((((((((((((((((((((((((((((((((((suite/00/suite/family == active) and (suite/01/suite/family == active)) and (suite/02/suite/family == active)) and (suite/03/suite/family == active)) and (suite/04/suite/family == active)) and (suite/05/suite/family == active)) and (suite/06/suite/family == active)) and (suite/07/suite/family == active)) and (suite/08/suite/family == active)) and (suite/09/suite/family == active)) and (suite/10/suite/family == active)) and (suite/11/suite/family == active)) and (suite/12/suite/family == active)) and (suite/13/suite/family == active)) and (suite/14/suite/family == active)) and (suite/15/suite/family == active)) and (suite/16/suite/family == active)) and (suite/17/suite/family == active)) and (suite/18/suite/family == active)) and (suite/19/suite/family == active)) and (suite/20/suite/family == active)) and (suite/21/suite/family == active)) and (suite/22/suite/family == active)) and (suite/23/suite/family == active)) and (suite/24/suite/family == active)) and (suite/25/suite/family == active)) and (suite/26/suite/family == active)) and (suite/27/suite/family == active)) and (suite/28/suite/family == active)) and (suite/29/suite/family == active)) and (suite/30/suite/family == active)) and (suite/31/suite/family == active)) and (suite/32/suite/family == active)) and (suite/33/suite/family == active)) and (suite/34/suite/family == active)) and (suite/35/suite/family == active)) and (suite/36/suite/family == active)) and (suite/37/suite/family == active)) and (suite/38/suite/family == active)) and (suite/39/suite/family == active)) and (suite/40/suite/family == active)) and (suite/41/suite/family == active)) and (suite/42/suite/family == active)) and (suite/43/suite/family == active)) and (suite/44/suite/family == active)) and (suite/45/suite/family == active)) and (suite/46/suite/family == active)) and (suite/47/suite/family == active)) and (suite/48/suite/family == active)) and (suite/49/suite/family == active)) and (suite/50/suite/family == active))"
+    },
+    {
+      "expression": "(suite/01/suite/family == active and suite/02/suite/family == active and suite/03/suite/family == active and suite/04/suite/family == active and suite/05/suite/family == active and suite/06/suite/family == active and suite/07/suite/family == active and suite/08/suite/family == active and suite/09/suite/family == active and suite/10/suite/family == active and suite/11/suite/family == active and suite/12/suite/family == active and suite/13/suite/family == active and suite/14/suite/family == active and suite/15/suite/family == active and suite/16/suite/family == active and suite/17/suite/family == active and suite/18/suite/family == active and suite/19/suite/family == active and suite/20/suite/family == active)",
+      "expected": "((((((((((((((((((((suite/01/suite/family == active) and (suite/02/suite/family == active)) and (suite/03/suite/family == active)) and (suite/04/suite/family == active)) and (suite/05/suite/family == active)) and (suite/06/suite/family == active)) and (suite/07/suite/family == active)) and (suite/08/suite/family == active)) and (suite/09/suite/family == active)) and (suite/10/suite/family == active)) and (suite/11/suite/family == active)) and (suite/12/suite/family == active)) and (suite/13/suite/family == active)) and (suite/14/suite/family == active)) and (suite/15/suite/family == active)) and (suite/16/suite/family == active)) and (suite/17/suite/family == active)) and (suite/18/suite/family == active)) and (suite/19/suite/family == active)) and (suite/20/suite/family == active))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 or /suite/family/task:attrib2 or /suite/node4/12/node5:attrib3)",
+      "expected": "(/suite/family/task:attrib1 or (/suite/family/task:attrib2 or /suite/node4/12/node5:attrib3))"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4/node5/task/task == complete or /suite/family/12/task/node4/node5/task/task/00/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/01/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/02/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/03/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/04/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/05/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/06/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/07/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/08/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/09/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/10/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/11/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/12/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/13/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/14/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/15/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/16/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/17/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/18/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/19/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/20/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/21/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/22/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/23/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/24/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/25/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/26/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/27/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/28/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/29/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/30/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/31/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/32/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/33/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/34/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/35/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/36/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/37/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/38/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/39/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/40/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/41/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/42/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/43/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/44/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/45/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/46/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/47/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/48/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/49/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/50/task/node6 == complete)",
+      "expected": "((/suite/family/12/task/node4/node5/task/task == complete) or (((((((((((((((((((((((((((((((((((((((((((((((((((/suite/family/12/task/node4/node5/task/task/00/task/node6 == complete) and (/suite/family/12/task/node4/node5/task/task/01/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/02/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/03/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/04/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/05/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/06/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/07/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/08/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/09/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/10/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/11/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/12/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/13/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/14/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/15/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/16/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/17/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/18/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/19/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/20/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/21/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/22/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/23/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/24/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/25/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/26/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/27/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/28/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/29/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/30/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/31/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/32/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/33/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/34/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/35/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/36/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/37/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/38/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/39/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/40/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/41/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/42/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/43/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/44/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/45/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/46/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/47/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/48/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/49/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/50/task/node6 == complete)))"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4/node5/task/task == complete or /suite/family/12/task/node4/node5/task/task/01/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/02/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/03/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/04/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/05/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/06/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/07/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/08/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/09/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/10/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/11/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/12/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/13/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/14/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/15/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/16/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/17/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/18/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/19/task/node6 == complete and /suite/family/12/task/node4/node5/task/task/20/task/node6 == complete)",
+      "expected": "((/suite/family/12/task/node4/node5/task/task == complete) or ((((((((((((((((((((/suite/family/12/task/node4/node5/task/task/01/task/node6 == complete) and (/suite/family/12/task/node4/node5/task/task/02/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/03/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/04/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/05/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/06/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/07/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/08/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/09/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/10/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/11/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/12/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/13/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/14/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/15/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/16/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/17/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/18/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/19/task/node6 == complete)) and (/suite/family/12/task/node4/node5/task/task/20/task/node6 == complete)))"
+    },
+    {
+      "expression": "(12 == complete and suite/family == complete and suite/task == complete and suite/node4 == complete)",
+      "expected": "((((12 == complete) and (suite/family == complete)) and (suite/task == complete)) and (suite/node4 == complete))"
+    },
+    {
+      "expression": "(/suite/family/06/task/node4:attrib1 or /suite/family/06/task/node4:attrib2 or /suite/node5:attrib3 < /suite/family:attrib3 or /suite/node5:attrib3 == /suite/family:attrib3 and /suite/family/06/task == complete)",
+      "expected": "(/suite/family/06/task/node4:attrib1 or (/suite/family/06/task/node4:attrib2 or ((/suite/node5:attrib3 < /suite/family:attrib3) or ((/suite/node5:attrib3 == /suite/family:attrib3) and (/suite/family/06/task == complete)))))"
+    },
+    {
+      "expression": "(../suite/family == complete and not ../suite/family:attrib1 and (/task/node4/06/node5/node6:attrib2 or /task/node4/06/node5/node6:attrib3 or /task/node7:attrib4 < /task/node4:attrib4 or /task/node7:attrib4 == /task/node4:attrib4 and /task/node4/06/node5 == complete))",
+      "expected": "(((../suite/family == complete) and not (../suite/family:attrib1)) and (/task/node4/06/node5/node6:attrib2 or (/task/node4/06/node5/node6:attrib3 or ((/task/node7:attrib4 < /task/node4:attrib4) or ((/task/node7:attrib4 == /task/node4:attrib4) and (/task/node4/06/node5 == complete))))))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 or node4/node5:attrib2 or node6/node5:attrib2 or node7/node5:attrib2)",
+      "expected": "(/suite/family/task:attrib1 or (node4/node5:attrib2 or (node6/node5:attrib2 or node7/node5:attrib2)))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 or ../3/node4/node5:attrib2 or ../3/node6/node5:attrib2 or ../3/node7/node5:attrib2 or node8/node5:attrib2)",
+      "expected": "(/suite/family/task:attrib1 or (../3/node4/node5:attrib2 or (../3/node6/node5:attrib2 or (../3/node7/node5:attrib2 or node8/node5:attrib2))))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 or ../3/node4/node5:attrib2 or ../3/node6/node5:attrib2 or ../3/node7/node5:attrib2 or node8/node5:attrib2 or node4/node5:attrib2)",
+      "expected": "(/suite/family/task:attrib1 or (../3/node4/node5:attrib2 or (../3/node6/node5:attrib2 or (../3/node7/node5:attrib2 or (node8/node5:attrib2 or node4/node5:attrib2)))))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 or ../3/node4/node5:attrib2 or ../3/node6/node5:attrib2 or ../3/node7/node5:attrib2 or node8/node5:attrib2 or node4/node5:attrib2 or node6/node5:attrib2)",
+      "expected": "(/suite/family/task:attrib1 or (../3/node4/node5:attrib2 or (../3/node6/node5:attrib2 or (../3/node7/node5:attrib2 or (node8/node5:attrib2 or (node4/node5:attrib2 or node6/node5:attrib2))))))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 or ../3/node4/node5:attrib2 or ../3/node6/node5:attrib2 or ../3/node7/node5:attrib2 or node8/node5:attrib2 or node4/node5:attrib2 or node6/node5:attrib2 or node7/node5:attrib2)",
+      "expected": "(/suite/family/task:attrib1 or (../3/node4/node5:attrib2 or (../3/node6/node5:attrib2 or (../3/node7/node5:attrib2 or (node8/node5:attrib2 or (node4/node5:attrib2 or (node6/node5:attrib2 or node7/node5:attrib2)))))))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 or ../3/node4/node5:attrib2 or ../3/node6/node5:attrib2 or ../3/node7/node5:attrib2 or ../2/node8/node5:attrib2 or ../2/node4/node5:attrib2 or ../2/node6/node5:attrib2 or ../2/node7/node5:attrib2 or node8/node5:attrib2)",
+      "expected": "(/suite/family/task:attrib1 or (../3/node4/node5:attrib2 or (../3/node6/node5:attrib2 or (../3/node7/node5:attrib2 or (../2/node8/node5:attrib2 or (../2/node4/node5:attrib2 or (../2/node6/node5:attrib2 or (../2/node7/node5:attrib2 or node8/node5:attrib2))))))))"
+    },
+    {
+      "expression": "(../3/suite/family:attrib1 or ../3/task/family:attrib1 or ../3/node4/family:attrib1 or ../2/node5/family:attrib1 or ../2/suite/family:attrib1 or ../2/task/family:attrib1 or ../2/node4/family:attrib1 or node5/family:attrib1 or suite/family:attrib1 or task/family:attrib1)",
+      "expected": "(../3/suite/family:attrib1 or (../3/task/family:attrib1 or (../3/node4/family:attrib1 or (../2/node5/family:attrib1 or (../2/suite/family:attrib1 or (../2/task/family:attrib1 or (../2/node4/family:attrib1 or (node5/family:attrib1 or (suite/family:attrib1 or task/family:attrib1)))))))))"
+    },
+    {
+      "expression": "(../3/suite/family:attrib1 or ../3/task/family:attrib1 or ../3/node4/family:attrib1 or ../2/node5/family:attrib1 or ../2/suite/family:attrib1 or ../2/task/family:attrib1 or ../2/node4/family:attrib1 or node5/family:attrib1 or suite/family:attrib1 or task/family:attrib1 or node4/family:attrib1)",
+      "expected": "(../3/suite/family:attrib1 or (../3/task/family:attrib1 or (../3/node4/family:attrib1 or (../2/node5/family:attrib1 or (../2/suite/family:attrib1 or (../2/task/family:attrib1 or (../2/node4/family:attrib1 or (node5/family:attrib1 or (suite/family:attrib1 or (task/family:attrib1 or node4/family:attrib1))))))))))"
+    },
+    {
+      "expression": "(../3/suite/family:attrib1 or ../3/task/family:attrib1 or ../3/node4/family:attrib1 or ../2/node5/family:attrib1 or ../2/suite/family:attrib1 or ../2/task/family:attrib1 or ../2/node4/family:attrib1 or ../1/node5/family:attrib1 or ../1/suite/family:attrib1 or ../1/task/family:attrib1 or ../1/node4/family:attrib1 or node5/family:attrib1)",
+      "expected": "(../3/suite/family:attrib1 or (../3/task/family:attrib1 or (../3/node4/family:attrib1 or (../2/node5/family:attrib1 or (../2/suite/family:attrib1 or (../2/task/family:attrib1 or (../2/node4/family:attrib1 or (../1/node5/family:attrib1 or (../1/suite/family:attrib1 or (../1/task/family:attrib1 or (../1/node4/family:attrib1 or node5/family:attrib1)))))))))))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 > ../task:attrib1 and node4 == complete and 12 == complete and 06 == complete and 00 == complete and node5 == complete)",
+      "expected": "((((((/suite/family:attrib1 > ../task:attrib1) and (node4 == complete)) and (12 == complete)) and (06 == complete)) and (00 == complete)) and (node5 == complete))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 > ../task:attrib1 and 12 == complete and 06 == complete and 00 == complete and node4 == complete)",
+      "expected": "(((((/suite/family:attrib1 > ../task:attrib1) and (12 == complete)) and (06 == complete)) and (00 == complete)) and (node4 == complete))"
+    },
+    {
+      "expression": "(( suite eq complete or suite eq unknown) and ( family eq complete or family eq unknown) and ( task eq complete or task eq unknown))",
+      "expected": "(((suite == complete) or (suite == unknown)) and (((family == complete) or (family == unknown)) and ((task == complete) or (task == unknown))))"
+    },
+    {
+      "expression": "(( ../suite eq complete or ../suite eq unknown) and ( ../family eq complete or ../family eq unknown) and ( ../task eq complete or ../task eq unknown) and ( ../node4/node5 eq complete or ../node4/node5 eq unknown) and ( ../node4/node6 eq complete or ../node4/node6 eq unknown))",
+      "expected": "(((../suite == complete) or (../suite == unknown)) and (((../family == complete) or (../family == unknown)) and (((../task == complete) or (../task == unknown)) and (((../node4/node5 == complete) or (../node4/node5 == unknown)) and ((../node4/node6 == complete) or (../node4/node6 == unknown))))))"
+    },
+    {
+      "expression": "(( suite eq complete or suite eq unknown))",
+      "expected": "((suite == complete) or (suite == unknown))"
+    },
+    {
+      "expression": "(suite/family eq complete and ( task:attrib1 lt ( node4:attrib1 + 2)))",
+      "expected": "((suite/family == complete) and (task:attrib1 < (node4:attrib1 + 2)))"
+    },
+    {
+      "expression": "(./00 eq complete and ./12 eq complete and ((../suite:attrib1 + 1) lt /family/task:attrib1) and /family/task/node4/node5/suite eq complete)",
+      "expected": "(((./00 == complete) and (./12 == complete)) and (((../suite:attrib1 + 1) < /family/task:attrib1) and (/family/task/node4/node5/suite == complete)))"
+    },
+    {
+      "expression": "(( ../suite/00/suite eq complete and ../suite:attrib1 eq ../family:attrib1) or ( ../suite:attrib1 gt ../family:attrib1))",
+      "expected": "(((../suite/00/suite == complete) and (../suite:attrib1 == ../family:attrib1)) or (../suite:attrib1 > ../family:attrib1))"
+    },
+    {
+      "expression": "(suite eq complete and family eq complete and task eq complete and node4 eq complete)",
+      "expected": "((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete))"
+    },
+    {
+      "expression": "(../suite/family/task eq complete and ( ../node4:attrib1 lt ../node5:attrib1 + 6))",
+      "expected": "((../suite/family/task == complete) and (../node4:attrib1 < (../node5:attrib1 + 6)))"
+    },
+    {
+      "expression": "(( ( ../../suite:attrib1 gt ../../family:attrib1) or ( ../../suite:attrib1 eq ../../family:attrib1 and ../../suite/00 eq complete)) and ( ( ../../task:attrib1 gt ../../family:attrib1) or ( ../../task:attrib1 eq ../../family:attrib1 and ../../task/00 eq complete)))",
+      "expected": "(((../../suite:attrib1 > ../../family:attrib1) or ((../../suite:attrib1 == ../../family:attrib1) and (../../suite/00 == complete))) and ((../../task:attrib1 > ../../family:attrib1) or ((../../task:attrib1 == ../../family:attrib1) and (../../task/00 == complete))))"
+    },
+    {
+      "expression": "(( ../../../../suite:attrib1 eq ../../../../family:attrib1) or ( ../../../../suite:attrib1 + 1 eq ../../../../family:attrib1 and ../../../../suite/12/task/node4:attrib2 gt 3 and ../../../12/node5/task eq complete))",
+      "expected": "((../../../../suite:attrib1 == ../../../../family:attrib1) or ((((../../../../suite:attrib1 + 1) == ../../../../family:attrib1) and (../../../../suite/12/task/node4:attrib2 > 3)) and (../../../12/node5/task == complete)))"
+    },
+    {
+      "expression": "(( ../../../../suite:attrib1 eq ../../../../family:attrib1) or ( ../../../../suite:attrib1 + 1 eq ../../../../family:attrib1 and ../../../../suite/12/task eq complete))",
+      "expected": "((../../../../suite:attrib1 == ../../../../family:attrib1) or (((../../../../suite:attrib1 + 1) == ../../../../family:attrib1) and (../../../../suite/12/task == complete)))"
+    },
+    {
+      "expression": "(suite eq complete and ./family/task/node4 eq complete and node5 eq complete and node6:attrib1)",
+      "expected": "((((suite == complete) and (./family/task/node4 == complete)) and (node5 == complete)) and node6:attrib1)"
+    },
+    {
+      "expression": "(( suite eq complete or suite eq unknown) and ( family eq complete or family eq unknown) and ( task eq complete or task eq unknown) and ( node4 eq complete or node4 eq unknown) and ( node5 eq complete or node5 eq unknown) and ( node6 eq complete or node6 eq unknown))",
+      "expected": "(((suite == complete) or (suite == unknown)) and (((family == complete) or (family == unknown)) and (((task == complete) or (task == unknown)) and (((node4 == complete) or (node4 == unknown)) and (((node5 == complete) or (node5 == unknown)) and ((node6 == complete) or (node6 == unknown)))))))"
+    },
+    {
+      "expression": "(suite eq complete and ( ( ../../../../../../family:attrib1 eq ../../../../../../task:attrib1) or ( ../../../../../../family:attrib1 + 1 eq ../../../../../../task:attrib1 and ../../../../../../family/12/node4 eq complete)))",
+      "expected": "((suite == complete) and ((../../../../../../family:attrib1 == ../../../../../../task:attrib1) or (((../../../../../../family:attrib1 + 1) == ../../../../../../task:attrib1) and (../../../../../../family/12/node4 == complete))))"
+    },
+    {
+      "expression": "(./suite/family/task eq complete and node4 eq complete and node5:attrib1)",
+      "expected": "(((./suite/family/task == complete) and (node4 == complete)) and node5:attrib1)"
+    },
+    {
+      "expression": "(( suite eq complete or suite eq unknown) and ( family eq complete or family eq unknown) and ( task eq complete or task eq unknown) and ( node4 eq complete or node4 eq unknown))",
+      "expected": "(((suite == complete) or (suite == unknown)) and (((family == complete) or (family == unknown)) and (((task == complete) or (task == unknown)) and ((node4 == complete) or (node4 == unknown)))))"
+    },
+    {
+      "expression": "(( ../../../../suite:attrib1 eq ../../../../family:attrib1 and ../../../../suite/00/task/node4:attrib2 gt 3 and ../../../00/node5/task eq complete))",
+      "expected": "(((../../../../suite:attrib1 == ../../../../family:attrib1) and (../../../../suite/00/task/node4:attrib2 > 3)) and (../../../00/node5/task == complete))"
+    },
+    {
+      "expression": "(suite eq complete and ( ( ../../../../../../family:attrib1 gt ../../../../../../task:attrib1) or ( ../../../../../../family:attrib1 eq ../../../../../../task:attrib1 and ../../../../../../family/00/node4 eq complete)))",
+      "expected": "((suite == complete) and ((../../../../../../family:attrib1 > ../../../../../../task:attrib1) or ((../../../../../../family:attrib1 == ../../../../../../task:attrib1) and (../../../../../../family/00/node4 == complete))))"
+    },
+    {
+      "expression": "(( ../../../../../suite:attrib1 gt ../../../../../family:attrib1) or ( ../../../../../suite:attrib1 eq ../../../../../family:attrib1 and ../../../../../suite/00/task/node4:attrib2 ge 3))",
+      "expected": "((../../../../../suite:attrib1 > ../../../../../family:attrib1) or ((../../../../../suite:attrib1 == ../../../../../family:attrib1) and (../../../../../suite/00/task/node4:attrib2 >= 3)))"
+    },
+    {
+      "expression": "(( ../suite:attrib1 lt ../family:attrib1 + 15))",
+      "expected": "(../suite:attrib1 < (../family:attrib1 + 15))"
+    },
+    {
+      "expression": "(( ../../../suite:attrib1 gt ../../../family:attrib1))",
+      "expected": "(../../../suite:attrib1 > ../../../family:attrib1)"
+    },
+    {
+      "expression": "(./00 eq complete and ./12 eq complete and ./suite eq complete and ( ../family:attrib1 gt ../task:attrib1 or ( ../family:attrib1 eq ../task:attrib1 and ../family/node4 eq complete)) and ( ../node5:attrib1 gt ../task:attrib1 or ( ../node5:attrib1 eq ../task:attrib1 and ../node5/node4 eq complete)))",
+      "expected": "((((./00 == complete) and (./12 == complete)) and (./suite == complete)) and (((../family:attrib1 > ../task:attrib1) or ((../family:attrib1 == ../task:attrib1) and (../family/node4 == complete))) and ((../node5:attrib1 > ../task:attrib1) or ((../node5:attrib1 == ../task:attrib1) and (../node5/node4 == complete)))))"
+    },
+    {
+      "expression": "(( ../suite eq complete or ../suite:attrib1 gt ../family:attrib1))",
+      "expected": "((../suite == complete) or (../suite:attrib1 > ../family:attrib1))"
+    },
+    {
+      "expression": "(( ../suite eq complete or ../suite:attrib1 gt ( ../family:attrib1 + 1)))",
+      "expected": "((../suite == complete) or (../suite:attrib1 > (../family:attrib1 + 1)))"
+    },
+    {
+      "expression": "(../suite/00 eq complete and ( ../suite:attrib1 gt ( ../family:attrib1 + 1) or ( ../suite:attrib1 eq ( ../family:attrib1 + 1) and ../suite/00/task/node4 eq complete)))",
+      "expected": "((../suite/00 == complete) and ((../suite:attrib1 > (../family:attrib1 + 1)) or ((../suite:attrib1 == (../family:attrib1 + 1)) and (../suite/00/task/node4 == complete))))"
+    },
+    {
+      "expression": "(suite eq complete and (/family/0005/task/node4:attrib1 ge /family/0005/task/node5:attrib1 + 4))",
+      "expected": "((suite == complete) and (/family/0005/task/node4:attrib1 >= (/family/0005/task/node5:attrib1 + 4)))"
+    },
+    {
+      "expression": "(suite eq complete and family eq complete and (/task/0005/node4/node5:attrib1 ge /task/0005/node4/node6:attrib1 + 4))",
+      "expected": "(((suite == complete) and (family == complete)) and (/task/0005/node4/node5:attrib1 >= (/task/0005/node4/node6:attrib1 + 4)))"
+    },
+    {
+      "expression": "(( ../../suite:attrib1 gt ../../family:attrib1 or ( ../../suite:attrib1 eq ../../family:attrib1 and ../../suite/task/node4 eq complete)))",
+      "expected": "((../../suite:attrib1 > ../../family:attrib1) or ((../../suite:attrib1 == ../../family:attrib1) and (../../suite/task/node4 == complete)))"
+    },
+    {
+      "expression": "(suite eq complete and family eq complete and (:attrib1 < (/task/0005/suite/node4:attrib1 - 10)))",
+      "expected": "(((suite == complete) and (family == complete)) and (:attrib1 < (/task/0005/suite/node4:attrib1 - 10)))"
+    },
+    {
+      "expression": "(( ( ../../../suite/00/family eq complete and ../../../suite:attrib1 - 12 eq ../task:attrib1) or ( ../../../suite:attrib1 - 12 gt ../task:attrib1)))",
+      "expected": "(((../../../suite/00/family == complete) and ((../../../suite:attrib1 - 12) == ../task:attrib1)) or ((../../../suite:attrib1 - 12) > ../task:attrib1))"
+    },
+    {
+      "expression": "(( ../../../suite:attrib1 gt ../family:attrib1 ) or (( ../../../suite:attrib1 eq ../family:attrib1 ) and ../../../suite/12 eq complete))",
+      "expected": "((../../../suite:attrib1 > ../family:attrib1) or ((../../../suite:attrib1 == ../family:attrib1) and (../../../suite/12 == complete)))"
+    },
+    {
+      "expression": "(../../suite:attrib1 != 5)",
+      "expected": "(../../suite:attrib1 != 5)"
+    },
+    {
+      "expression": "((../../../suite/family/00/task eq complete and ../../../suite/family/12/task eq complete and ../../../suite/family:attrib1 eq ../../node4:attrib1) or (../../../suite/family:attrib1 gt ../../node4:attrib1))",
+      "expected": "((((../../../suite/family/00/task == complete) and (../../../suite/family/12/task == complete)) and (../../../suite/family:attrib1 == ../../node4:attrib1)) or (../../../suite/family:attrib1 > ../../node4:attrib1))"
+    },
+    {
+      "expression": "(( ../suite:attrib1 - 1 gt ../family:attrib1 and ../task eq complete))",
+      "expected": "(((../suite:attrib1 - 1) > ../family:attrib1) and (../task == complete))"
+    },
+    {
+      "expression": "(( ../suite:attrib1 gt ../family:attrib1) or ( ../suite:attrib1 eq ../family:attrib1 and ../suite/00/task/node4 eq complete and ../suite/00/task/node5/node6:attrib2))",
+      "expected": "((../suite:attrib1 > ../family:attrib1) or (((../suite:attrib1 == ../family:attrib1) and (../suite/00/task/node4 == complete)) and ../suite/00/task/node5/node6:attrib2))"
+    },
+    {
+      "expression": "(( ../../suite:attrib1 le ( ../../family:attrib1 - 1)))",
+      "expected": "(../../suite:attrib1 <= (../../family:attrib1 - 1))"
+    },
+    {
+      "expression": "(( ../../suite/00 eq complete and ../../suite:attrib1 le ( ../../family:attrib1 - 1)))",
+      "expected": "((../../suite/00 == complete) and (../../suite:attrib1 <= (../../family:attrib1 - 1)))"
+    },
+    {
+      "expression": "(suite:attrib1 <= /family/task/node4/node5:attrib1 and suite:attrib1 < /family/node6/node7:attrib1 and suite:attrib1 < /family/node6/node8:attrib1)",
+      "expected": "(((suite:attrib1 <= /family/task/node4/node5:attrib1) and (suite:attrib1 < /family/node6/node7:attrib1)) and (suite:attrib1 < /family/node6/node8:attrib1))"
+    },
+    {
+      "expression": "((/suite/family/task/12/node4/node5/0093 eq complete and /suite/family/task/12/node4/node5/0094 eq complete and /suite/family/task/12/node4/node5/0095 eq complete and /suite/family/task/12/node4/node5/0096 eq complete and /suite/family/task/12/node4/node5/0097 eq complete and /suite/family/task/12/node4/node5/0098 eq complete and /suite/family/task/12/node4/node5/0099 eq complete and /suite/family/task/12/node4/node5/0100 eq complete and /suite/family/task/12/node4/node5/0101 eq complete and /suite/family/task/12/node4/node5/0102 eq complete and /suite/family/task/12/node4/node5/0103 eq complete and /suite/family/task/12/node4/node5/0104 eq complete and /suite/family/task/12/node4/node5/0105 eq complete and /suite/family/task/12/node4/node5/0106 eq complete and /suite/family/task/12/node4/node5/0107 eq complete and /suite/family/task/12/node4/node5/0108 eq complete and /suite/family/task/12/node4/node5/0109 eq complete and /suite/family/task/12/node4/node5/0110 eq complete and /suite/family/task/12/node4/node5/0111 eq complete and /suite/family/task/12/node4/node5/0112 eq complete and /suite/family/task/12/node4/node5/0113 eq complete and /suite/family/task/12/node4/node5/0114 eq complete and /suite/family/task/12/node4/node5/0115 eq complete and /suite/family/task/12/node4/node5/0116 eq complete and /suite/family/task/12/node4/node5/0117 eq complete and /suite/family/task/12/node4/node5/0118 eq complete and /suite/family/task/12/node4/node5/0119 eq complete and /suite/family/task/12/node4/node5/0120 eq complete))",
+      "expected": "((((((((((((((((((((((((((((/suite/family/task/12/node4/node5/0093 == complete) and (/suite/family/task/12/node4/node5/0094 == complete)) and (/suite/family/task/12/node4/node5/0095 == complete)) and (/suite/family/task/12/node4/node5/0096 == complete)) and (/suite/family/task/12/node4/node5/0097 == complete)) and (/suite/family/task/12/node4/node5/0098 == complete)) and (/suite/family/task/12/node4/node5/0099 == complete)) and (/suite/family/task/12/node4/node5/0100 == complete)) and (/suite/family/task/12/node4/node5/0101 == complete)) and (/suite/family/task/12/node4/node5/0102 == complete)) and (/suite/family/task/12/node4/node5/0103 == complete)) and (/suite/family/task/12/node4/node5/0104 == complete)) and (/suite/family/task/12/node4/node5/0105 == complete)) and (/suite/family/task/12/node4/node5/0106 == complete)) and (/suite/family/task/12/node4/node5/0107 == complete)) and (/suite/family/task/12/node4/node5/0108 == complete)) and (/suite/family/task/12/node4/node5/0109 == complete)) and (/suite/family/task/12/node4/node5/0110 == complete)) and (/suite/family/task/12/node4/node5/0111 == complete)) and (/suite/family/task/12/node4/node5/0112 == complete)) and (/suite/family/task/12/node4/node5/0113 == complete)) and (/suite/family/task/12/node4/node5/0114 == complete)) and (/suite/family/task/12/node4/node5/0115 == complete)) and (/suite/family/task/12/node4/node5/0116 == complete)) and (/suite/family/task/12/node4/node5/0117 == complete)) and (/suite/family/task/12/node4/node5/0118 == complete)) and (/suite/family/task/12/node4/node5/0119 == complete)) and (/suite/family/task/12/node4/node5/0120 == complete))"
+    },
+    {
+      "expression": "((suite eq complete and family eq complete and task eq complete and node4 eq complete and node5 eq complete and node6 eq complete))",
+      "expected": "((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete))"
+    },
+    {
+      "expression": "(suite eq complete and family:attrib1)",
+      "expected": "((suite == complete) and family:attrib1)"
+    },
+    {
+      "expression": "(:attrib1 lt 20260601)",
+      "expected": "(:attrib1 < 20260601)"
+    },
+    {
+      "expression": "(suite == complete AND family == complete)",
+      "expected": "((suite == complete) and (family == complete))"
+    },
+    {
+      "expression": "((:attrib1 <= /suite/family:attrib1 -2 OR (:attrib1 == /suite/family:attrib1 -1 AND /suite/family/00/task/node4 == complete)) AND (/suite/family:attrib1 % 100 != 1) or :attrib1 lt 20260601)",
+      "expected": "(((:attrib1 <= (/suite/family:attrib1 - 2)) or ((:attrib1 == (/suite/family:attrib1 - 1)) and (/suite/family/00/task/node4 == complete))) and (((/suite/family:attrib1 % 100) != 1) or (:attrib1 < 20260601)))"
+    },
+    {
+      "expression": "(suite == complete AND family == complete AND (../../task/node4 == complete))",
+      "expected": "(((suite == complete) and (family == complete)) and (../../task/node4 == complete))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 ge /suite/task:attrib1 and /suite/node4:attrib1 ge /suite/task:attrib1 AND family:attrib1 ge task:attrib1 or 1==1 and :attrib1 lt 20260601)",
+      "expected": "((((/suite/family:attrib1 >= /suite/task:attrib1) and (/suite/node4:attrib1 >= /suite/task:attrib1)) and (family:attrib1 >= task:attrib1)) or ((1 == 1) and (:attrib1 < 20260601)))"
+    },
+    {
+      "expression": "(( /suite/family/task eq complete and /suite/node4/task eq complete) or 1==1)",
+      "expected": "(((/suite/family/task == complete) and (/suite/node4/task == complete)) or (1 == 1))"
+    },
+    {
+      "expression": "(((/suite/family/12//task/node4==complete or /suite/family/12/node5:attrib1 ge 360 or /suite/family/12/node6:attrib2 ge 360) and /suite/family/12//node7/node8 eq complete) and (node9 == complete))",
+      "expected": "((((/suite/family/12//task/node4 == complete) or ((/suite/family/12/node5:attrib1 >= 360) or (/suite/family/12/node6:attrib2 >= 360))) and (/suite/family/12//node7/node8 == complete)) and (node9 == complete))"
+    },
+    {
+      "expression": "(/suite/family/00/task/node4 == complete or /suite/family/00/node5:attrib1 ge 240 and ./240/node6 == complete and node7/node6 == complete)",
+      "expected": "((/suite/family/00/task/node4 == complete) or (((/suite/family/00/node5:attrib1 >= 240) and (./240/node6 == complete)) and (node7/node6 == complete)))"
+    },
+    {
+      "expression": "(/suite/family/00/task/node4 == complete or /suite/family/00/node5:attrib1 ge 240 or /suite/family/00/node6:attrib2 ge 240 or (/suite/family/00/node5 eq complete and /suite/family/00/task/node4 == complete))",
+      "expected": "((/suite/family/00/task/node4 == complete) or ((/suite/family/00/node5:attrib1 >= 240) or ((/suite/family/00/node6:attrib2 >= 240) or ((/suite/family/00/node5 == complete) and (/suite/family/00/task/node4 == complete)))))"
+    },
+    {
+      "expression": "(:attrib1 le (:attrib2+14) and suite eq complete and family eq complete)",
+      "expected": "(((:attrib1 <= (:attrib2 + 14)) and (suite == complete)) and (family == complete))"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4 == complete OR :attrib1 < /suite/family:attrib1)",
+      "expected": "((/suite/family/12/task/node4 == complete) or (:attrib1 < /suite/family:attrib1))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 lt /task/family:attrib1) or (/suite/family:attrib1 eq /task/family:attrib1 and /task/family/12/node4 eq complete))",
+      "expected": "((/suite/family:attrib1 < /task/family:attrib1) or ((/suite/family:attrib1 == /task/family:attrib1) and (/task/family/12/node4 == complete)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 lt /task/family:attrib1) or (/suite/family:attrib1 eq /task/family:attrib1 and /task/family/node4/node5 eq complete and /task/family/12/node6 eq complete))",
+      "expected": "((/suite/family:attrib1 < /task/family:attrib1) or (((/suite/family:attrib1 == /task/family:attrib1) and (/task/family/node4/node5 == complete)) and (/task/family/12/node6 == complete)))"
+    },
+    {
+      "expression": "(((./12 == complete and ./18 == complete and ./00 == complete and ./06 == complete) and (:attrib1 gt 1402)) or ((/suite/family:attrib2 gt :attrib2 and /task/family:attrib2 gt :attrib2)))",
+      "expected": "((((((./12 == complete) and (./18 == complete)) and (./00 == complete)) and (./06 == complete)) and (:attrib1 > 1402)) or ((/suite/family:attrib2 > :attrib2) and (/task/family:attrib2 > :attrib2)))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 eq :attrib1)",
+      "expected": "(/suite/family:attrib1 == :attrib1)"
+    },
+    {
+      "expression": "((((/suite/family/12/task/node4:attrib1 ge 78 or /suite/family/12/task/node5:attrib1 ge 78 or /suite/family/12/task eq complete or :attrib2)) and /suite/family:attrib3 eq /suite/family:attrib3) or /suite/family:attrib3 lt /suite/family:attrib3)",
+      "expected": "((((/suite/family/12/task/node4:attrib1 >= 78) or ((/suite/family/12/task/node5:attrib1 >= 78) or ((/suite/family/12/task == complete) or :attrib2))) and (/suite/family:attrib3 == /suite/family:attrib3)) or (/suite/family:attrib3 < /suite/family:attrib3))"
+    },
+    {
+      "expression": "(((/suite/family/12/task:attrib1 ge 78 or :attrib2) and /suite/family:attrib3 eq /suite/family:attrib3) or /suite/family:attrib3 lt /suite/family:attrib3)",
+      "expected": "((((/suite/family/12/task:attrib1 >= 78) or :attrib2) and (/suite/family:attrib3 == /suite/family:attrib3)) or (/suite/family:attrib3 < /suite/family:attrib3))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt :attrib1 and /task/family:attrib1 gt :attrib1)",
+      "expected": "((/suite/family:attrib1 > :attrib1) and (/task/family:attrib1 > :attrib1))"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4 eq complete or /suite/family/12/node5:attrib1 ge 360) and /suite/family:attrib2==:attrib2)",
+      "expected": "(((/suite/family/12/task/node4 == complete) or (/suite/family/12/node5:attrib1 >= 360)) and (/suite/family:attrib2 == :attrib2))"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4==complete and /suite/family:attrib1==:attrib1)",
+      "expected": "((/suite/family/12/task/node4 == complete) and (/suite/family:attrib1 == :attrib1))"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4:attrib1 ge 0 or /suite/family/12/task/node5:attrib1 ge 0 or /suite/family/12/task eq complete or :attrib2))",
+      "expected": "((/suite/family/12/task/node4:attrib1 >= 0) or ((/suite/family/12/task/node5:attrib1 >= 0) or ((/suite/family/12/task == complete) or :attrib2)))"
+    },
+    {
+      "expression": "((./000/suite == complete) and ((/family/task/12/node4/node5:attrib1 ge 1 or /family/task/12/node4/node6:attrib1 ge 1 or /family/task/12/node4 eq complete or :attrib2)))",
+      "expected": "((./000/suite == complete) and ((/family/task/12/node4/node5:attrib1 >= 1) or ((/family/task/12/node4/node6:attrib1 >= 1) or ((/family/task/12/node4 == complete) or :attrib2))))"
+    },
+    {
+      "expression": "(/suite/family/12/task:attrib1 ge 0 or :attrib2)",
+      "expected": "((/suite/family/12/task:attrib1 >= 0) or :attrib2)"
+    },
+    {
+      "expression": "((suite == complete) and (/family/task/12/node4/000/suite eq complete))",
+      "expected": "((suite == complete) and (/family/task/12/node4/000/suite == complete))"
+    },
+    {
+      "expression": "(((/suite/family/12/task:attrib1 ge 0 or :attrib2) and (/node4/family/12/node5/000/node6 eq complete)) and (/node4/family/12/node5/000/node7 eq complete))",
+      "expected": "((((/suite/family/12/task:attrib1 >= 0) or :attrib2) and (/node4/family/12/node5/000/node6 == complete)) and (/node4/family/12/node5/000/node7 == complete))"
+    },
+    {
+      "expression": "(:attrib1 gt 2000)",
+      "expected": "(:attrib1 > 2000)"
+    },
+    {
+      "expression": "(/suite/family/12/task:attrib1 gt 144 OR /suite/family/12/task==complete AND /suite/family:attrib2 ge :attrib2)",
+      "expected": "((/suite/family/12/task:attrib1 > 144) or ((/suite/family/12/task == complete) and (/suite/family:attrib2 >= :attrib2)))"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4:attrib1 gt 180 or /suite/family/12/task/node4 eq complete) or /suite/family:attrib2 gt :attrib2)",
+      "expected": "(((/suite/family/12/task/node4:attrib1 > 180) or (/suite/family/12/task/node4 == complete)) or (/suite/family:attrib2 > :attrib2))"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4:attrib1 ge 90 or /suite/family/12/task/node4==complete)",
+      "expected": "((/suite/family/12/task/node4:attrib1 >= 90) or (/suite/family/12/task/node4 == complete))"
+    },
+    {
+      "expression": "(:attrib1 ge 0042 and :attrib2 gt :attrib3)",
+      "expected": "((:attrib1 >= 42) and (:attrib2 > :attrib3))"
+    },
+    {
+      "expression": "(:attrib1 gt :attrib2 and :attrib3 gt 800)",
+      "expected": "((:attrib1 > :attrib2) and (:attrib3 > 800))"
+    },
+    {
+      "expression": "((./12 == complete and ./18 == complete and ./00 == complete and ./06 == complete) and (/suite/family:attrib1 ge /suite/task:attrib1))",
+      "expected": "(((((./12 == complete) and (./18 == complete)) and (./00 == complete)) and (./06 == complete)) and (/suite/family:attrib1 >= /suite/task:attrib1))"
+    },
+    {
+      "expression": "((((../../../../../../../../suite:attrib1 eq 1 and /family/task/12/node4/node5:attrib2 ge 45) or /family/task/12/node4 eq complete) and ../../../../../task:attrib3 eq /family/task:attrib3) or ../../../../../task:attrib3 lt /family/task:attrib3)",
+      "expected": "(((((../../../../../../../../suite:attrib1 == 1) and (/family/task/12/node4/node5:attrib2 >= 45)) or (/family/task/12/node4 == complete)) and (../../../../../task:attrib3 == /family/task:attrib3)) or (../../../../../task:attrib3 < /family/task:attrib3))"
+    },
+    {
+      "expression": "(suite==complete and ((:attrib1==1 and (:attrib2>:attrib3 or (:attrib2==:attrib3 and :attrib4>1910))) or (:attrib1==0 and (:attrib2>:attrib3 + 1 or (:attrib2==:attrib3 + 1 and :attrib4>600)))) and :attrib3 < /family/task:attrib3)",
+      "expected": "((suite == complete) and ((((:attrib1 == 1) and ((:attrib2 > :attrib3) or ((:attrib2 == :attrib3) and (:attrib4 > 1910)))) or ((:attrib1 == 0) and ((:attrib2 > (:attrib3 + 1)) or ((:attrib2 == (:attrib3 + 1)) and (:attrib4 > 600))))) and (:attrib3 < /family/task:attrib3)))"
+    },
+    {
+      "expression": "(:attrib1!=0)",
+      "expected": "(:attrib1 != 0)"
+    },
+    {
+      "expression": "(suite == complete and ( ../family/task:attrib1 or ../family/task == complete ))",
+      "expected": "((suite == complete) and (../family/task:attrib1 or (../family/task == complete)))"
+    },
+    {
+      "expression": "(../../../suite/family==complete or ../../../suite/family:attrib1>=0)",
+      "expected": "((../../../suite/family == complete) or (../../../suite/family:attrib1 >= 0))"
+    },
+    {
+      "expression": "(000==complete and 003==complete and 006==complete and 009==complete and 012==complete and 015==complete and 018==complete and 021==complete)",
+      "expected": "((((((((000 == complete) and (003 == complete)) and (006 == complete)) and (009 == complete)) and (012 == complete)) and (015 == complete)) and (018 == complete)) and (021 == complete))"
+    },
+    {
+      "expression": "(096==complete and 099==complete and 102==complete and 105==complete and 108==complete and 111==complete and 114==complete and 117==complete and 120==complete)",
+      "expected": "(((((((((096 == complete) and (099 == complete)) and (102 == complete)) and (105 == complete)) and (108 == complete)) and (111 == complete)) and (114 == complete)) and (117 == complete)) and (120 == complete))"
+    },
+    {
+      "expression": "(suite==complete and ((:attrib1==1 and (:attrib2>:attrib3 + 1 or (:attrib2==:attrib3 + 1 and :attrib4>710))) or (:attrib1==0 and (:attrib2>:attrib3 + 1 or (:attrib2==:attrib3 + 1 and :attrib4>1800)))) and :attrib3 < /family/task:attrib3)",
+      "expected": "((suite == complete) and ((((:attrib1 == 1) and ((:attrib2 > (:attrib3 + 1)) or ((:attrib2 == (:attrib3 + 1)) and (:attrib4 > 710)))) or ((:attrib1 == 0) and ((:attrib2 > (:attrib3 + 1)) or ((:attrib2 == (:attrib3 + 1)) and (:attrib4 > 1800))))) and (:attrib3 < /family/task:attrib3)))"
+    },
+    {
+      "expression": "(suite==complete and ( ../../12/family/task==complete or ../../12/family/task:attrib1>=12) and ../../12/node4==complete and ../../12/family/node5==complete)",
+      "expected": "((suite == complete) and (((../../12/family/task == complete) or (../../12/family/task:attrib1 >= 12)) and ((../../12/node4 == complete) and (../../12/family/node5 == complete))))"
+    },
+    {
+      "expression": "(00==complete and 12==complete and suite==complete)",
+      "expected": "(((00 == complete) and (12 == complete)) and (suite == complete))"
+    },
+    {
+      "expression": "((../../suite:attrib1>../../family:attrib1)or(../../suite:attrib1==../../family:attrib1 and ../../suite/12/task==complete))",
+      "expected": "((../../suite:attrib1 > ../../family:attrib1) or ((../../suite:attrib1 == ../../family:attrib1) and (../../suite/12/task == complete)))"
+    },
+    {
+      "expression": "(:attrib1<=/suite/family/task:attrib1)",
+      "expected": "(:attrib1 <= /suite/family/task:attrib1)"
+    },
+    {
+      "expression": "(:attrib1<../../../suite:attrib1 or ../../../suite/12/family/task==complete or ../../../suite/12/family/task:attrib2>=21)",
+      "expected": "((:attrib1 < ../../../suite:attrib1) or ((../../../suite/12/family/task == complete) or (../../../suite/12/family/task:attrib2 >= 21)))"
+    },
+    {
+      "expression": "(:attrib1<../../../../../suite:attrib1 or (../../../../../suite/12/family/task==complete and ../../../../../suite/12/family/node4==complete and ../../../../../suite/12/family/node5==complete))",
+      "expected": "((:attrib1 < ../../../../../suite:attrib1) or (((../../../../../suite/12/family/task == complete) and (../../../../../suite/12/family/node4 == complete)) and (../../../../../suite/12/family/node5 == complete)))"
+    },
+    {
+      "expression": "((../../suite:attrib1>../../family:attrib1)or(../../suite:attrib1==../../family:attrib1 and ../../suite/12/task==complete and ../../suite/12/node4==complete))",
+      "expected": "((../../suite:attrib1 > ../../family:attrib1) or (((../../suite:attrib1 == ../../family:attrib1) and (../../suite/12/task == complete)) and (../../suite/12/node4 == complete)))"
+    },
+    {
+      "expression": "((../../../suite:attrib1>../../../family:attrib1)or(../../../suite:attrib1==../../../family:attrib1 and (../../../suite/12/task/node4:attrib2>=006 or ../../../suite/12/task/node4==complete)))",
+      "expected": "((../../../suite:attrib1 > ../../../family:attrib1) or ((../../../suite:attrib1 == ../../../family:attrib1) and ((../../../suite/12/task/node4:attrib2 >= 6) or (../../../suite/12/task/node4 == complete))))"
+    },
+    {
+      "expression": "(12==complete and (../suite:attrib1>../family:attrib1 or (../suite:attrib1==../family:attrib1 and ../suite/00/task==complete)))",
+      "expected": "((12 == complete) and ((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and (../suite/00/task == complete))))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 ge :attrib1)",
+      "expected": "(/suite/family:attrib1 >= :attrib1)"
+    },
+    {
+      "expression": "(/suite/family/00:attrib1 gt :attrib1 or (/suite/family/00:attrib1 eq :attrib1 and /suite/family/00/task==complete))",
+      "expected": "((/suite/family/00:attrib1 > :attrib1) or ((/suite/family/00:attrib1 == :attrib1) and (/suite/family/00/task == complete)))"
+    },
+    {
+      "expression": "(/suite/family/12/task eq complete or /suite/family:attrib1 gt :attrib1)",
+      "expected": "((/suite/family/12/task == complete) or (/suite/family:attrib1 > :attrib1))"
+    },
+    {
+      "expression": "(suite eq complete and (/family/task:attrib1 gt :attrib1 or (/family/task:attrib1 gt :attrib1 and (/family/task/12/node4/node5 eq complete or (1==1 and /family/task/12/node6:attrib2 gt 12)))))",
+      "expected": "((suite == complete) and ((/family/task:attrib1 > :attrib1) or ((/family/task:attrib1 > :attrib1) and ((/family/task/12/node4/node5 == complete) or ((1 == 1) and (/family/task/12/node6:attrib2 > 12))))))"
+    },
+    {
+      "expression": "(suite eq complete and (/family/task:attrib1 gt :attrib1 or (/family/task:attrib1 gt :attrib1 and ( (/family/task/00/node4/node5 eq complete or (1==1 and /family/task/00/node6:attrib2 gt 12))))))",
+      "expected": "((suite == complete) and ((/family/task:attrib1 > :attrib1) or ((/family/task:attrib1 > :attrib1) and ((/family/task/00/node4/node5 == complete) or ((1 == 1) and (/family/task/00/node6:attrib2 > 12))))))"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4 eq complete) and (/suite/family/12/node5:attrib1 gt node6:attrib2 or /suite/family/12/node5 eq complete) or /suite/family:attrib3 gt :attrib3)",
+      "expected": "((/suite/family/12/task/node4 == complete) and (((/suite/family/12/node5:attrib1 > node6:attrib2) or (/suite/family/12/node5 == complete)) or (/suite/family:attrib3 > :attrib3)))"
+    },
+    {
+      "expression": "(suite eq complete and (/family:attrib1 ge 1940 or :attrib2 gt :attrib3))",
+      "expected": "((suite == complete) and ((/family:attrib1 >= 1940) or (:attrib2 > :attrib3)))"
+    },
+    {
+      "expression": "(((/suite/family/00/task/node4 eq complete) and (/suite/family/00/node5:attrib1 gt node6:attrib2 or /suite/family/00/node5 eq complete) and /suite/family:attrib3 eq :attrib3) or /suite/family:attrib3 gt :attrib3)",
+      "expected": "(((/suite/family/00/task/node4 == complete) and (((/suite/family/00/node5:attrib1 > node6:attrib2) or (/suite/family/00/node5 == complete)) and (/suite/family:attrib3 == :attrib3))) or (/suite/family:attrib3 > :attrib3))"
+    },
+    {
+      "expression": "(suite eq complete and (/family:attrib1 ge 740 or (:attrib2 gt (:attrib3+1))))",
+      "expected": "((suite == complete) and ((/family:attrib1 >= 740) or (:attrib2 > (:attrib3 + 1))))"
+    },
+    {
+      "expression": "(suite:1 and (../family/task==active and ../family/task:1))",
+      "expected": "(suite:1 and ((../family/task == active) and ../family/task:1))"
+    },
+    {
+      "expression": "(suite:1 and (../family==queued or ../family==aborted))",
+      "expected": "(suite:1 and ((../family == queued) or (../family == aborted)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt :attrib1) or (/suite/family:attrib1 eq :attrib1 and /suite/family/task/node4/node5 eq complete))",
+      "expected": "((/suite/family:attrib1 > :attrib1) or ((/suite/family:attrib1 == :attrib1) and (/suite/family/task/node4/node5 == complete)))"
+    },
+    {
+      "expression": "(../suite/family eq complete and (/task/node4:attrib1 gt :attrib1) or (/task/node4:attrib1 eq :attrib1 and /task/node4/node5/node6/node7 eq complete))",
+      "expected": "((../suite/family == complete) and ((/task/node4:attrib1 > :attrib1) or ((/task/node4:attrib1 == :attrib1) and (/task/node4/node5/node6/node7 == complete))))"
+    },
+    {
+      "expression": "(../12 eq complete and (/suite/family:attrib1 gt /task/node4:attrib1) or (/suite/family:attrib1 eq /task/node4:attrib1 and /suite/family/00/node5/node6 eq complete))",
+      "expected": "((../12 == complete) and ((/suite/family:attrib1 > /task/node4:attrib1) or ((/suite/family:attrib1 == /task/node4:attrib1) and (/suite/family/00/node5/node6 == complete))))"
+    },
+    {
+      "expression": "((1==1 and /suite/family/00/task/node4==complete))",
+      "expected": "((1 == 1) and (/suite/family/00/task/node4 == complete))"
+    },
+    {
+      "expression": "(suite==complete and ../family eq complete or ../family eq aborted)",
+      "expected": "(((suite == complete) and (../family == complete)) or (../family == aborted))"
+    },
+    {
+      "expression": "(/suite/family/task/node4/node5/12/360 eq complete and /suite/family/task/node4/node5:attrib1 eq :attrib1 or /suite/family/task/node4/node5:attrib1 gt :attrib1)",
+      "expected": "(((/suite/family/task/node4/node5/12/360 == complete) and (/suite/family/task/node4/node5:attrib1 == :attrib1)) or (/suite/family/task/node4/node5:attrib1 > :attrib1))"
+    },
+    {
+      "expression": "(suite == complete and not suite:30 and family == complete and not family:30)",
+      "expected": "((((suite == complete) and not (suite:30)) and (family == complete)) and not (family:30))"
+    },
+    {
+      "expression": "(suite == complete and suite:30 and family == complete and family:30 and task == complete and task:30)",
+      "expected": "((((((suite == complete) and suite:30) and (family == complete)) and family:30) and (task == complete)) and task:30)"
+    },
+    {
+      "expression": "(../../suite/family/task == complete and ../../node4/family/task == complete and ../../node5/family/task == complete and ../../node6/family/task == complete and ../../node7/family/task == complete and ../../node8/family/task == complete and ../../node9/family/task == complete and ../../node10/family/task == complete and ../../node11/family/task == complete and ../../node12/family/task == complete and ../../node13/family/task == complete and ../../node14/family/task == complete and ../../node15/family/task == complete and ../../node16/family/task == complete and ../../node17/family/task == complete and ../../node18/family/task == complete and ../../node19/family/task == complete and ../../node20/family/task == complete and ../../node21/family/task == complete and ../../node22/family/task == complete and ../../node23/family/task == complete and ../../node24/family/task == complete and ../../node25/family/task == complete and ../../node26/family/task == complete and ../../node27/family/task == complete and ../../node28/family/task == complete and ../../node29/family/task == complete and ../../node30/family/task == complete and ../../node31/family/task == complete and ../../node32/family/task == complete)",
+      "expected": "((((((((((((((((((((((((((((((../../suite/family/task == complete) and (../../node4/family/task == complete)) and (../../node5/family/task == complete)) and (../../node6/family/task == complete)) and (../../node7/family/task == complete)) and (../../node8/family/task == complete)) and (../../node9/family/task == complete)) and (../../node10/family/task == complete)) and (../../node11/family/task == complete)) and (../../node12/family/task == complete)) and (../../node13/family/task == complete)) and (../../node14/family/task == complete)) and (../../node15/family/task == complete)) and (../../node16/family/task == complete)) and (../../node17/family/task == complete)) and (../../node18/family/task == complete)) and (../../node19/family/task == complete)) and (../../node20/family/task == complete)) and (../../node21/family/task == complete)) and (../../node22/family/task == complete)) and (../../node23/family/task == complete)) and (../../node24/family/task == complete)) and (../../node25/family/task == complete)) and (../../node26/family/task == complete)) and (../../node27/family/task == complete)) and (../../node28/family/task == complete)) and (../../node29/family/task == complete)) and (../../node30/family/task == complete)) and (../../node31/family/task == complete)) and (../../node32/family/task == complete))"
+    },
+    {
+      "expression": "((/suite/family/task eq complete) and (/node4/family:attrib1 eq /suite/family:attrib1) or (/node4/family:attrib1 lt /suite/family:attrib1))",
+      "expected": "((/suite/family/task == complete) and ((/node4/family:attrib1 == /suite/family:attrib1) or (/node4/family:attrib1 < /suite/family:attrib1)))"
+    },
+    {
+      "expression": "((:attrib1 == 0 and (/suite/family:attrib2 > :attrib2 or (/suite/family:attrib2 == :attrib2 and /suite/family/task/node4/node5 == complete))) or (:attrib1 == 1 and (( :attrib3 ge (1240 + :attrib4) and :attrib5 eq :attrib6 ))))",
+      "expected": "(((:attrib1 == 0) and ((/suite/family:attrib2 > :attrib2) or ((/suite/family:attrib2 == :attrib2) and (/suite/family/task/node4/node5 == complete)))) or ((:attrib1 == 1) and ((:attrib3 >= (1240 + :attrib4)) and (:attrib5 == :attrib6))))"
+    },
+    {
+      "expression": "(suite/family/task eq complete and suite/node4/task eq complete and suite/node5/task eq complete and suite/node6/task eq complete and suite/node7/task eq complete and suite/node8/task eq complete and suite/node9/task eq complete and suite/node10/task eq complete and suite/node11/task eq complete and suite/node12/task eq complete and suite/node13/task eq complete and suite/node14/task eq complete and suite/node15/task eq complete and suite/node16/task eq complete and suite/node17/task eq complete and suite/node18/task eq complete and suite/node19/task eq complete and suite/node20/task eq complete and suite/node21/task eq complete and suite/node22/task eq complete and suite/node23/task eq complete and suite/node24/task eq complete and suite/node25/task eq complete and suite/node26/task eq complete and suite/node27/task eq complete and suite/node28/task eq complete and suite/node29/task eq complete and suite/node30/task eq complete and suite/node31/task eq complete and suite/node32/task eq complete and suite/node33/task eq complete and suite/node34/task eq complete and suite/node35/task eq complete and suite/node36/task eq complete and suite/node37/task eq complete and suite/node38/task eq complete and suite/node39/task eq complete and suite/node40/task eq complete and suite/node41/task eq complete and suite/node42/task eq complete and suite/node43/task eq complete and suite/node44/task eq complete and suite/node45/task eq complete and suite/node46/task eq complete and suite/node47/task eq complete and suite/node48/task eq complete and suite/node49/task eq complete and suite/node50/task eq complete and suite/node51/task eq complete and suite/node52/task eq complete and suite/node53/task eq complete)",
+      "expected": "(((((((((((((((((((((((((((((((((((((((((((((((((((suite/family/task == complete) and (suite/node4/task == complete)) and (suite/node5/task == complete)) and (suite/node6/task == complete)) and (suite/node7/task == complete)) and (suite/node8/task == complete)) and (suite/node9/task == complete)) and (suite/node10/task == complete)) and (suite/node11/task == complete)) and (suite/node12/task == complete)) and (suite/node13/task == complete)) and (suite/node14/task == complete)) and (suite/node15/task == complete)) and (suite/node16/task == complete)) and (suite/node17/task == complete)) and (suite/node18/task == complete)) and (suite/node19/task == complete)) and (suite/node20/task == complete)) and (suite/node21/task == complete)) and (suite/node22/task == complete)) and (suite/node23/task == complete)) and (suite/node24/task == complete)) and (suite/node25/task == complete)) and (suite/node26/task == complete)) and (suite/node27/task == complete)) and (suite/node28/task == complete)) and (suite/node29/task == complete)) and (suite/node30/task == complete)) and (suite/node31/task == complete)) and (suite/node32/task == complete)) and (suite/node33/task == complete)) and (suite/node34/task == complete)) and (suite/node35/task == complete)) and (suite/node36/task == complete)) and (suite/node37/task == complete)) and (suite/node38/task == complete)) and (suite/node39/task == complete)) and (suite/node40/task == complete)) and (suite/node41/task == complete)) and (suite/node42/task == complete)) and (suite/node43/task == complete)) and (suite/node44/task == complete)) and (suite/node45/task == complete)) and (suite/node46/task == complete)) and (suite/node47/task == complete)) and (suite/node48/task == complete)) and (suite/node49/task == complete)) and (suite/node50/task == complete)) and (suite/node51/task == complete)) and (suite/node52/task == complete)) and (suite/node53/task == complete))"
+    },
+    {
+      "expression": "((/suite/family/00/task/node4/node5:attrib1 ge 12 or /suite/family/00/task/node4/node5==complete) and /suite/family/00/task/node4/node6==complete and /suite/family/00/task/node4/node7==complete and /suite/family/00/node8/node9==complete)",
+      "expected": "(((/suite/family/00/task/node4/node5:attrib1 >= 12) or (/suite/family/00/task/node4/node5 == complete)) and (((/suite/family/00/task/node4/node6 == complete) and (/suite/family/00/task/node4/node7 == complete)) and (/suite/family/00/node8/node9 == complete)))"
+    },
+    {
+      "expression": "(( :attrib1 ge (1400 + :attrib2) and :attrib3 eq :attrib4 ) or ( :attrib3 gt :attrib4 ))",
+      "expected": "(((:attrib1 >= (1400 + :attrib2)) and (:attrib3 == :attrib4)) or (:attrib3 > :attrib4))"
+    },
+    {
+      "expression": "(/suite:attrib1 gt /suite/family:attrib2 AND (/suite/family/task/node4/node5:attrib3 ge 96 or /suite/family/task/node4/node5 eq complete))",
+      "expected": "((/suite:attrib1 > /suite/family:attrib2) and ((/suite/family/task/node4/node5:attrib3 >= 96) or (/suite/family/task/node4/node5 == complete)))"
+    },
+    {
+      "expression": "((:attrib1 == 0 and (/suite/family:attrib2 >= :attrib2 or (/suite/family:attrib2 == :attrib2-1 and /suite/family/00/task/node4 == complete))) or (:attrib1 == 1 and (( :attrib3 ge (340 + :attrib4) and :attrib5 gt :attrib6 ))))",
+      "expected": "(((:attrib1 == 0) and ((/suite/family:attrib2 >= :attrib2) or ((/suite/family:attrib2 == (:attrib2 - 1)) and (/suite/family/00/task/node4 == complete)))) or ((:attrib1 == 1) and ((:attrib3 >= (340 + :attrib4)) and (:attrib5 > :attrib6))))"
+    },
+    {
+      "expression": "(/suite:attrib1 gt /suite/family:attrib2 AND /suite/family/00/task/node4:attrib3 ge 240)",
+      "expected": "((/suite:attrib1 > /suite/family:attrib2) and (/suite/family/00/task/node4:attrib3 >= 240))"
+    },
+    {
+      "expression": "((suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete) and (node8 == complete))",
+      "expected": "((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete))"
+    },
+    {
+      "expression": "(:attrib1 < /suite/family:attrib1 or (:attrib1 == /suite/family:attrib1 and /suite/family == complete))",
+      "expected": "((:attrib1 < /suite/family:attrib1) or ((:attrib1 == /suite/family:attrib1) and (/suite/family == complete)))"
+    },
+    {
+      "expression": "(suite == complete and ../../family/task == complete and ((:attrib1==1 and (:attrib2>:attrib3 or (:attrib2==:attrib3 and :attrib4>1910))) or :attrib1==0))",
+      "expected": "(((suite == complete) and (../../family/task == complete)) and (((:attrib1 == 1) and ((:attrib2 > :attrib3) or ((:attrib2 == :attrib3) and (:attrib4 > 1910)))) or (:attrib1 == 0)))"
+    },
+    {
+      "expression": "(1 == 1 or (:attrib1 < /suite/family:attrib1 or (:attrib1 == /suite/family:attrib1 and /suite/family/task/2/node4/node5/node6/node7/node8/node9 == complete)))",
+      "expected": "((1 == 1) or ((:attrib1 < /suite/family:attrib1) or ((:attrib1 == /suite/family:attrib1) and (/suite/family/task/2/node4/node5/node6/node7/node8/node9 == complete))))"
+    },
+    {
+      "expression": "(suite == complete and ../../family/task == complete and ((:attrib1==1 and (:attrib2>:attrib3 + 1 or (:attrib2==:attrib3 + 1 and :attrib4>710))) or :attrib1==0))",
+      "expected": "(((suite == complete) and (../../family/task == complete)) and (((:attrib1 == 1) and ((:attrib2 > (:attrib3 + 1)) or ((:attrib2 == (:attrib3 + 1)) and (:attrib4 > 710)))) or (:attrib1 == 0)))"
+    },
+    {
+      "expression": "(( ../../12/suite/family==complete or ../../12/suite/family:attrib1>=12) and ../../12/task==complete and ../../12/suite/node4==complete)",
+      "expected": "(((../../12/suite/family == complete) or (../../12/suite/family:attrib1 >= 12)) and ((../../12/task == complete) and (../../12/suite/node4 == complete)))"
+    },
+    {
+      "expression": "(:attrib1<../../../suite:attrib1 or (../../../suite/12/family==complete and ../../../suite/12/task/node4==complete))",
+      "expected": "((:attrib1 < ../../../suite:attrib1) or ((../../../suite/12/family == complete) and (../../../suite/12/task/node4 == complete)))"
+    },
+    {
+      "expression": "(../suite eq complete and :attrib1 < /family/task:attrib1)",
+      "expected": "((../suite == complete) and (:attrib1 < /family/task:attrib1))"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 eq ../family:attrib1 and /suite/family/12 eq complete) or task eq complete) and ../node4 eq complete)",
+      "expected": "((((/suite/family:attrib1 == ../family:attrib1) and (/suite/family/12 == complete)) or (task == complete)) and (../node4 == complete))"
+    },
+    {
+      "expression": "(suite eq complete and :attrib1 gt 2015)",
+      "expected": "((suite == complete) and (:attrib1 > 2015))"
+    },
+    {
+      "expression": "(/suite/family == complete and /suite/task:attrib1 + 30 > node4:attrib1 and node4:attrib1 <= /suite/node5/node6:attrib1)",
+      "expected": "(((/suite/family == complete) and ((/suite/task:attrib1 + 30) > node4:attrib1)) and (node4:attrib1 <= /suite/node5/node6:attrib1))"
+    },
+    {
+      "expression": "(/suite/family == complete and (task:attrib1 < /suite/node4:attrib1 or task:attrib1 == /suite/node4:attrib1 and /suite/node4 == complete))",
+      "expected": "((/suite/family == complete) and ((task:attrib1 < /suite/node4:attrib1) or ((task:attrib1 == /suite/node4:attrib1) and (/suite/node4 == complete))))"
+    },
+    {
+      "expression": "(:attrib1 - :attrib2 <= ../suite/family:attrib1 and (:attrib1 + :attrib3 < :attrib4 or (:attrib1 + :attrib3 == :attrib4 and :attrib5 <= :attrib6)))",
+      "expected": "(((:attrib1 - :attrib2) <= ../suite/family:attrib1) and (((:attrib1 + :attrib3) < :attrib4) or (((:attrib1 + :attrib3) == :attrib4) and (:attrib5 <= :attrib6))))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and (../task/node4:attrib1 or ../task/node4 == complete))",
+      "expected": "(((suite == complete) and (family == complete)) and (../task/node4:attrib1 or (../task/node4 == complete)))"
+    },
+    {
+      "expression": "((:attrib1 <= ../suite/00:attrib1 + 1 or ../suite == complete) and (:attrib1 <= ../suite/00:attrib1 + 2 or ../suite/00 == complete) and (:attrib1 - 1 < /family/task:attrib1 or (:attrib1 - 1 == /family/task:attrib1 and /family/task/00/node4 == complete)))",
+      "expected": "(((:attrib1 <= (../suite/00:attrib1 + 1)) or (../suite == complete)) and (((:attrib1 <= (../suite/00:attrib1 + 2)) or (../suite/00 == complete)) and (((:attrib1 - 1) < /family/task:attrib1) or (((:attrib1 - 1) == /family/task:attrib1) and (/family/task/00/node4 == complete)))))"
+    },
+    {
+      "expression": "((../../../../../suite/family/task/node4:attrib1 + 4 > :attrib1 or (../../../../../suite/family/task/node4:attrib1 + 4 == :attrib1 and ../../../../../suite/family/task/node4/node5 == complete)) and (:attrib1 <= ../../node6/00:attrib1 or ../../node6/00 == complete))",
+      "expected": "((((../../../../../suite/family/task/node4:attrib1 + 4) > :attrib1) or (((../../../../../suite/family/task/node4:attrib1 + 4) == :attrib1) and (../../../../../suite/family/task/node4/node5 == complete))) and ((:attrib1 <= ../../node6/00:attrib1) or (../../node6/00 == complete)))"
+    },
+    {
+      "expression": "((../00:attrib1 <= ../../suite/00:attrib1 or ../../suite/00 == complete) and (:attrib1 <= /family/task:attrib1 or (:attrib1 - 1 == /family/task:attrib1 and /family/task/00/node4/node5/node6 == complete)))",
+      "expected": "(((../00:attrib1 <= ../../suite/00:attrib1) or (../../suite/00 == complete)) and ((:attrib1 <= /family/task:attrib1) or (((:attrib1 - 1) == /family/task:attrib1) and (/family/task/00/node4/node5/node6 == complete))))"
+    },
+    {
+      "expression": "((((((suite == complete and family == complete) and task == complete) and node4 == complete) and node5 == complete) and node6 == complete) and node7 == complete)",
+      "expected": "(((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete))"
+    },
+    {
+      "expression": "(((((((((suite == complete and family == complete) and task == complete) and node4 == complete) and node5 == complete) and node6 == complete) and node7 == complete) and node8 == complete) and node9 == complete) and node10 == complete)",
+      "expected": "((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete))"
+    },
+    {
+      "expression": "(:attrib1 ge (1246 + :attrib2 + :attrib3))",
+      "expected": "(:attrib1 >= ((1246 + :attrib2) + :attrib3))"
+    },
+    {
+      "expression": "(/suite/family/00/task/node4/node5/0 ne queued or /suite:attrib1)",
+      "expected": "((/suite/family/00/task/node4/node5/0 != queued) or /suite:attrib1)"
+    },
+    {
+      "expression": "((:attrib1 ge (046 + :attrib2 + :attrib3)) and (:attrib4 gt :attrib5))",
+      "expected": "((:attrib1 >= ((46 + :attrib2) + :attrib3)) and (:attrib4 > :attrib5))"
+    },
+    {
+      "expression": "(((suite == complete) and (../family/task == complete)) and (../node4/task == complete))",
+      "expected": "(((suite == complete) and (../family/task == complete)) and (../node4/task == complete))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete and node15 == complete and node16 == complete and node17 == complete and node18 == complete)",
+      "expected": "((((((((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)) and (node17 == complete)) and (node18 == complete))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete and node15 == complete and node16 == complete and node17 == complete and node18 == complete and node19 == complete)",
+      "expected": "(((((((((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)) and (node17 == complete)) and (node18 == complete)) and (node19 == complete))"
+    },
+    {
+      "expression": "(suite == complete and (family==queued or (family==complete and not family:1)))",
+      "expected": "((suite == complete) and ((family == queued) or ((family == complete) and not (family:1))))"
+    },
+    {
+      "expression": "((/suite/family/00/task/node4/node5/node6 eq complete and /suite/family/00/task/node4/node5/node7/node8 eq complete) and (node9:attrib1))",
+      "expected": "(((/suite/family/00/task/node4/node5/node6 == complete) and (/suite/family/00/task/node4/node5/node7/node8 == complete)) and node9:attrib1)"
+    },
+    {
+      "expression": "((../suite:attrib1) and (../../family == complete))",
+      "expected": "(../suite:attrib1 and (../../family == complete))"
+    },
+    {
+      "expression": "((:attrib1 eq 0 or (suite/family/task/node4/node5/node6 eq complete)) AND node7 == complete)",
+      "expected": "(((:attrib1 == 0) or (suite/family/task/node4/node5/node6 == complete)) and (node7 == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /task/family:attrib1) or (/suite/family:attrib1==/task/family:attrib1) or 1==1)",
+      "expected": "((/suite/family:attrib1 > /task/family:attrib1) or ((/suite/family:attrib1 == /task/family:attrib1) or (1 == 1)))"
+    },
+    {
+      "expression": "(( /suite/family:attrib1 gt /task/family:attrib1) or (/suite/family:attrib1==/task/family:attrib1 and /suite/family/00/node4==complete and /suite/family/00/node5/node6==complete or 1==1) and /task/family/node7/node8==complete)",
+      "expected": "((/suite/family:attrib1 > /task/family:attrib1) or (((((/suite/family:attrib1 == /task/family:attrib1) and (/suite/family/00/node4 == complete)) and (/suite/family/00/node5/node6 == complete)) or (1 == 1)) and (/task/family/node7/node8 == complete)))"
+    },
+    {
+      "expression": "((:attrib1 eq 0 or (suite/family/task/node4/task/node5 ne queued)) AND node6 == complete and (/node7/node8/12 eq complete or /node9/node8/12 eq complete))",
+      "expected": "(((:attrib1 == 0) or (suite/family/task/node4/task/node5 != queued)) and ((node6 == complete) and ((/node7/node8/12 == complete) or (/node9/node8/12 == complete))))"
+    },
+    {
+      "expression": "(suite == complete and /family/task/node4/node5 == complete and :attrib1 gt :attrib2)",
+      "expected": "(((suite == complete) and (/family/task/node4/node5 == complete)) and (:attrib1 > :attrib2))"
+    },
+    {
+      "expression": "((:attrib1 eq 0 or (suite/family/task/node4/task/node5 eq complete)) AND ../../12/node6/node7 == complete AND node8 == complete)",
+      "expected": "(((:attrib1 == 0) or (suite/family/task/node4/task/node5 == complete)) and ((../../12/node6/node7 == complete) and (node8 == complete)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt :attrib1) or ((/suite/family:attrib1 eq :attrib1) and (/suite/family/00/task/node4:attrib2 gt 9 or /suite/family/00/task/node4 eq complete) and not /suite/node5/06/node6/node7:0))",
+      "expected": "((/suite/family:attrib1 > :attrib1) or ((/suite/family:attrib1 == :attrib1) and (((/suite/family/00/task/node4:attrib2 > 9) or (/suite/family/00/task/node4 == complete)) and not (/suite/node5/06/node6/node7:0))))"
+    },
+    {
+      "expression": "(/suite:attrib1 gt 640 and /suite:attrib2 gt /suite/family:attrib3)",
+      "expected": "((/suite:attrib1 > 640) and (/suite:attrib2 > /suite/family:attrib3))"
+    },
+    {
+      "expression": "(1==1 or (:attrib1 eq 0 or (suite/family/task eq complete)))",
+      "expected": "((1 == 1) or ((:attrib1 == 0) or (suite/family/task == complete)))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5:attrib1 gt 15 or /suite/family/task/node4/node5==complete) and (/suite/family/task/node6/node7 eq complete and /suite/family/task/node6/node8 eq complete and /suite/family/task/node6/node9 eq complete or /suite/family/task/node6==complete))",
+      "expected": "(((/suite/family/task/node4/node5:attrib1 > 15) or (/suite/family/task/node4/node5 == complete)) and ((((/suite/family/task/node6/node7 == complete) and (/suite/family/task/node6/node8 == complete)) and (/suite/family/task/node6/node9 == complete)) or (/suite/family/task/node6 == complete)))"
+    },
+    {
+      "expression": "((/suite:attrib1 ge 1740) and (/suite/family/12/task == complete and /suite/family/12/node4/node5:attrib2 gt 9))",
+      "expected": "((/suite:attrib1 >= 1740) and ((/suite/family/12/task == complete) and (/suite/family/12/node4/node5:attrib2 > 9)))"
+    },
+    {
+      "expression": "((/suite:attrib1 ge 1855) and (/suite/family/12/task/node4 == complete))",
+      "expected": "((/suite:attrib1 >= 1855) and (/suite/family/12/task/node4 == complete))"
+    },
+    {
+      "expression": "((/suite:attrib1 gt /suite/family:attrib2 or /suite:attrib3 ge 2349) AND /suite/family/task/node4/node5:attrib4 ge 012)",
+      "expected": "(((/suite:attrib1 > /suite/family:attrib2) or (/suite:attrib3 >= 2349)) and (/suite/family/task/node4/node5:attrib4 >= 12))"
+    },
+    {
+      "expression": "(((/suite:attrib1 gt /suite/family:attrib2) and (/suite:attrib3 ge 0540)) and (/suite/family/00/task == complete and /suite/family/00/node4/node5:attrib4 gt 9))",
+      "expected": "(((/suite:attrib1 > /suite/family:attrib2) and (/suite:attrib3 >= 540)) and ((/suite/family/00/task == complete) and (/suite/family/00/node4/node5:attrib4 > 9)))"
+    },
+    {
+      "expression": "(((/suite:attrib1 gt /suite/family:attrib2) and (/suite:attrib3 ge 0655)) and (/suite/family/00/task/node4 == complete))",
+      "expected": "(((/suite:attrib1 > /suite/family:attrib2) and (/suite:attrib3 >= 655)) and (/suite/family/00/task/node4 == complete))"
+    },
+    {
+      "expression": "((/suite/family/12//task/node4==complete or /suite/family/12/node5:attrib1 ge 240 or /suite/family/12/node6:attrib2 ge 240) and /suite/family/12//node7/node8 eq complete AND node9 == complete)",
+      "expected": "(((/suite/family/12//task/node4 == complete) or ((/suite/family/12/node5:attrib1 >= 240) or (/suite/family/12/node6:attrib2 >= 240))) and ((/suite/family/12//node7/node8 == complete) and (node9 == complete)))"
+    },
+    {
+      "expression": "(/suite/family/12/task/240/node4==complete and (/suite/family/12/task/360/node4==complete) AND node5 == complete and (/node6/node7/node8/node9/family/12/360/node10 eq complete and /node6/node7/node8/node9/family/12/240/node10 eq complete or /node6/node7/node8/node9/family:attrib1 gt :attrib1))",
+      "expected": "((/suite/family/12/task/240/node4 == complete) and ((/suite/family/12/task/360/node4 == complete) and ((node5 == complete) and (((/node6/node7/node8/node9/family/12/360/node10 == complete) and (/node6/node7/node8/node9/family/12/240/node10 == complete)) or (/node6/node7/node8/node9/family:attrib1 > :attrib1)))))"
+    },
+    {
+      "expression": "((((/suite/family/12/task/240==complete))) and (../node4/node5==complete))",
+      "expected": "((/suite/family/12/task/240 == complete) and (../node4/node5 == complete))"
+    },
+    {
+      "expression": "((((/suite/family/12/task/node4/node5/240/node6==complete and /suite/family/12/task/node4/node5/node7/node6==complete and /suite/family/12/node8/240==complete))) and (../node9/node10==complete))",
+      "expected": "((((/suite/family/12/task/node4/node5/240/node6 == complete) and (/suite/family/12/task/node4/node5/node7/node6 == complete)) and (/suite/family/12/node8/240 == complete)) and (../node9/node10 == complete))"
+    },
+    {
+      "expression": "((((/suite/family/12/task/node4/node5/node6/node7==complete and /suite/family/12/task/node4/node5/node8/node7==complete and /suite/family/12/task/node4/node5/360/node7==complete and /suite/family/12/node9/360==complete))) and (../node10/node11==complete))",
+      "expected": "(((((/suite/family/12/task/node4/node5/node6/node7 == complete) and (/suite/family/12/task/node4/node5/node8/node7 == complete)) and (/suite/family/12/task/node4/node5/360/node7 == complete)) and (/suite/family/12/node9/360 == complete)) and (../node10/node11 == complete))"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4:attrib1 gt 0 or /suite/family:attrib2 gt :attrib2)",
+      "expected": "((/suite/family/12/task/node4:attrib1 > 0) or (/suite/family:attrib2 > :attrib2))"
+    },
+    {
+      "expression": "(:attrib1 ge 1645 or :attrib2 gt :attrib3 or 0==1)",
+      "expected": "((:attrib1 >= 1645) or ((:attrib2 > :attrib3) or (0 == 1)))"
+    },
+    {
+      "expression": "(suite == complete AND (family == complete or family/task:attrib1))",
+      "expected": "((suite == complete) and ((family == complete) or family/task:attrib1))"
+    },
+    {
+      "expression": "(:attrib1 ge 1645 or :attrib2 gt :attrib3)",
+      "expected": "((:attrib1 >= 1645) or (:attrib2 > :attrib3))"
+    },
+    {
+      "expression": "((:attrib1 <= /suite/family:attrib1 -2 OR (:attrib1 == /suite/family:attrib1 -1 AND /suite/family/00/task/node4 == complete)) AND (/suite/family:attrib1 % 100 != 1))",
+      "expected": "(((:attrib1 <= (/suite/family:attrib1 - 2)) or ((:attrib1 == (/suite/family:attrib1 - 1)) and (/suite/family/00/task/node4 == complete))) and ((/suite/family:attrib1 % 100) != 1))"
+    },
+    {
+      "expression": "(suite == complete AND family == complete AND task == complete AND ((/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 19 OR (/node4/node5/node6:attrib1 - :attrib2) < 19))",
+      "expected": "((((suite == complete) and (family == complete)) and (task == complete)) and (((/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 19) or ((/node4/node5/node6:attrib1 - :attrib2) < 19)))"
+    },
+    {
+      "expression": "(:attrib1 le (:attrib2+14) and suite == complete AND family == complete)",
+      "expected": "(((:attrib1 <= (:attrib2 + 14)) and (suite == complete)) and (family == complete))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and ((:attrib1 gt :attrib2 -1) or :attrib3 gt 1530))",
+      "expected": "((((suite == complete) and (family == complete)) and (task == complete)) and ((:attrib1 > (:attrib2 - 1)) or (:attrib3 > 1530)))"
+    },
+    {
+      "expression": "((/suite/family/00/task eq complete and /suite/family:attrib1 eq :attrib1) or /suite/family:attrib1 gt :attrib1)",
+      "expected": "(((/suite/family/00/task == complete) and (/suite/family:attrib1 == :attrib1)) or (/suite/family:attrib1 > :attrib1))"
+    },
+    {
+      "expression": "(/suite/family/00/task/node4 == complete and /suite/family:attrib1 eq :attrib1 and ../../node5/node6 == complete or /suite/family:attrib1 gt :attrib1)",
+      "expected": "((((/suite/family/00/task/node4 == complete) and (/suite/family:attrib1 == :attrib1)) and (../../node5/node6 == complete)) or (/suite/family:attrib1 > :attrib1))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and /task/node4/node5/node6/node7/00/1104/node8 eq complete and /task/node4/node5/node6/node7/00/1104/node9 eq complete or /task/node4/node5/node6/node7:attrib1 gt :attrib1)",
+      "expected": "(((((suite == complete) and (family == complete)) and (/task/node4/node5/node6/node7/00/1104/node8 == complete)) and (/task/node4/node5/node6/node7/00/1104/node9 == complete)) or (/task/node4/node5/node6/node7:attrib1 > :attrib1))"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4 == complete or :attrib1 lt /suite/family:attrib1)",
+      "expected": "((/suite/family/12/task/node4 == complete) or (:attrib1 < /suite/family:attrib1))"
+    },
+    {
+      "expression": "(:attrib1 % 2 ne 1)",
+      "expected": "((:attrib1 % 2) != 1)"
+    },
+    {
+      "expression": "(:attrib1 % 4 ne 0 and :attrib1 % 100 ne 31 and :attrib1 % 10000 ne 430 and :attrib1 % 10000 ne 630 and :attrib1 % 10000 ne 930 and :attrib1 % 10000 ne 1130)",
+      "expected": "(((((((:attrib1 % 4) != 0) and ((:attrib1 % 100) != 31)) and ((:attrib1 % 10000) != 430)) and ((:attrib1 % 10000) != 630)) and ((:attrib1 % 10000) != 930)) and ((:attrib1 % 10000) != 1130))"
+    },
+    {
+      "expression": "(suite == complete and family == complete AND task == complete AND ((/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 20 OR (/node4/node5/node6:attrib1 - :attrib2) < 20))",
+      "expected": "((((suite == complete) and (family == complete)) and (task == complete)) and (((/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 20) or ((/node4/node5/node6:attrib1 - :attrib2) < 20)))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 ge /suite/task:attrib1 and /suite/node4:attrib1 ge /suite/task:attrib1 AND family:attrib1 ge task:attrib1)",
+      "expected": "(((/suite/family:attrib1 >= /suite/task:attrib1) and (/suite/node4:attrib1 >= /suite/task:attrib1)) and (family:attrib1 >= task:attrib1))"
+    },
+    {
+      "expression": "(((((/suite/family/12/task/node4:attrib1 ge 45) or (/suite/family/12/task eq complete)) and (/node5/node6/node7/task/family:attrib2 eq /suite/family:attrib2)) or (/node5/node6/node7/task/family:attrib2 lt /suite/family:attrib2)))",
+      "expected": "((((/suite/family/12/task/node4:attrib1 >= 45) or (/suite/family/12/task == complete)) and (/node5/node6/node7/task/family:attrib2 == /suite/family:attrib2)) or (/node5/node6/node7/task/family:attrib2 < /suite/family:attrib2))"
+    },
+    {
+      "expression": "(((((/suite/family/12/task:attrib1 ge 240) or (/suite/family/12/node4/node5 eq complete)) and (/node6/node7/node8/node9/family:attrib2 eq /suite/family:attrib2)) or (/node6/node7/node8/node9/family:attrib2 lt /suite/family:attrib2)) and node10 eq complete)",
+      "expected": "(((((/suite/family/12/task:attrib1 >= 240) or (/suite/family/12/node4/node5 == complete)) and (/node6/node7/node8/node9/family:attrib2 == /suite/family:attrib2)) or (/node6/node7/node8/node9/family:attrib2 < /suite/family:attrib2)) and (node10 == complete))"
+    },
+    {
+      "expression": "(((((/suite/family/12/task:attrib1 ge 360) or (/suite/family/12/node4/node5 eq complete)) and (/node6/node7/node8/node9/family:attrib2 eq /suite/family:attrib2)) or (/node6/node7/node8/node9/family:attrib2 lt /suite/family:attrib2)) and ((/node6/node7/node8/node5/family/12/360/node10 eq complete and /node6/node7/node8/node5/family:attrib2 eq :attrib2) or (/node6/node7/node8/node5/family:attrib2 gt :attrib2)))",
+      "expected": "(((((/suite/family/12/task:attrib1 >= 360) or (/suite/family/12/node4/node5 == complete)) and (/node6/node7/node8/node9/family:attrib2 == /suite/family:attrib2)) or (/node6/node7/node8/node9/family:attrib2 < /suite/family:attrib2)) and (((/node6/node7/node8/node5/family/12/360/node10 == complete) and (/node6/node7/node8/node5/family:attrib2 == :attrib2)) or (/node6/node7/node8/node5/family:attrib2 > :attrib2)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/12/node6/node7 eq complete and /suite/family/task/node4/node5:attrib1 eq :attrib1) or (/suite/family/task/node4/node5:attrib1 gt :attrib1)) and /suite/family/task/node8/node5/12/node6/node7 eq complete)",
+      "expected": "((((/suite/family/task/node4/node5/12/node6/node7 == complete) and (/suite/family/task/node4/node5:attrib1 == :attrib1)) or (/suite/family/task/node4/node5:attrib1 > :attrib1)) and (/suite/family/task/node8/node5/12/node6/node7 == complete))"
+    },
+    {
+      "expression": "(suite eq complete and (((/family/task/node4/node5/node6/node7 eq complete) and (/node8/node9/node10/node11/node12:attrib1 eq /family/task/node13:attrib1)) or (/node8/node9/node10/node11/node12:attrib1 lt /family/task/node13:attrib1)))",
+      "expected": "((suite == complete) and (((/family/task/node4/node5/node6/node7 == complete) and (/node8/node9/node10/node11/node12:attrib1 == /family/task/node13:attrib1)) or (/node8/node9/node10/node11/node12:attrib1 < /family/task/node13:attrib1)))"
+    },
+    {
+      "expression": "(suite eq complete and ((../family/00 eq complete and ../family:attrib1 eq ../task:attrib1) or ../task:attrib1 lt ../family:attrib1))",
+      "expected": "((suite == complete) and (((../family/00 == complete) and (../family:attrib1 == ../task:attrib1)) or (../task:attrib1 < ../family:attrib1)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt ../../../task:attrib1 and /node4/node5/node6/node7/family:attrib1 ge ../../../task:attrib1) or (node8 eq complete and node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete and node7 eq complete and node13 eq complete and node4 eq complete and node14 eq complete and node15 eq complete))",
+      "expected": "(((/suite/family:attrib1 > ../../../task:attrib1) and (/node4/node5/node6/node7/family:attrib1 >= ../../../task:attrib1)) or ((((((((((node8 == complete) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node7 == complete)) and (node13 == complete)) and (node4 == complete)) and (node14 == complete)) and (node15 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/12/360/node6/node7 eq complete or (/suite/family/task/node4/node5:attrib1 gt /node8/node9/node10:attrib1)) or ../../node11 eq complete) and node12 eq complete)",
+      "expected": "((((/suite/family/task/node4/node5/12/360/node6/node7 == complete) or (/suite/family/task/node4/node5:attrib1 > /node8/node9/node10:attrib1)) or (../../node11 == complete)) and (node12 == complete))"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt ../../../task:attrib1 and /node4/family:attrib1 gt ../../../task:attrib1) and /node5/node6/node7/node8/family:attrib1 gt ../../../task:attrib1) or (node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete and node13 eq complete and node14 eq complete and node15 eq complete and node16 eq complete and node5 eq complete and node17 eq complete and node18 eq complete))",
+      "expected": "((((/suite/family:attrib1 > ../../../task:attrib1) and (/node4/family:attrib1 > ../../../task:attrib1)) and (/node5/node6/node7/node8/family:attrib1 > ../../../task:attrib1)) or (((((((((((node9 == complete) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)) and (node5 == complete)) and (node17 == complete)) and (node18 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/task:attrib1 gt ../../../node4:attrib1 and /node5/node6/node7/node8/task:attrib1 ge ../../../node4:attrib1) or (node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete and node8 eq complete and node13 eq complete and node14 eq complete))",
+      "expected": "(((/suite/family/task:attrib1 > ../../../node4:attrib1) and (/node5/node6/node7/node8/task:attrib1 >= ../../../node4:attrib1)) or (((((((node9 == complete) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node8 == complete)) and (node13 == complete)) and (node14 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/task:attrib1 gt ../../../node4:attrib1 and /node5/node6/node7/node8/task:attrib1 ge ../../../node4:attrib1) or (node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete and node13 eq complete and node14 eq complete and node15 eq complete and node16 eq complete))",
+      "expected": "(((/suite/family/task:attrib1 > ../../../node4:attrib1) and (/node5/node6/node7/node8/task:attrib1 >= ../../../node4:attrib1)) or ((((((((node9 == complete) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt ../../../task:attrib1 and /node4/node5/node6/node7/family:attrib1 ge ../../../task:attrib1) or (node8 eq complete and node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete and node7 eq complete and node13 eq complete and node4 eq complete and node14 eq complete))",
+      "expected": "(((/suite/family:attrib1 > ../../../task:attrib1) and (/node4/node5/node6/node7/family:attrib1 >= ../../../task:attrib1)) or (((((((((node8 == complete) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node7 == complete)) and (node13 == complete)) and (node4 == complete)) and (node14 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt ../../../task:attrib1 and /node4/family:attrib1 gt ../../../task:attrib1) and /node5/node6/node7/node8/family:attrib1 gt ../../../task:attrib1) or (node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete and node13 eq complete and node14 eq complete and node15 eq complete and node16 eq complete and node5 eq complete and node17 eq complete))",
+      "expected": "((((/suite/family:attrib1 > ../../../task:attrib1) and (/node4/family:attrib1 > ../../../task:attrib1)) and (/node5/node6/node7/node8/family:attrib1 > ../../../task:attrib1)) or ((((((((((node9 == complete) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)) and (node5 == complete)) and (node17 == complete)))"
+    },
+    {
+      "expression": "(((((/suite/family/task/node4/node5:attrib1 ge 1 and /suite/family/task/node4/node5:attrib2 ge 1) or /suite/family/task/node4/node5 eq complete)) or ../../node6 eq complete) and node7 eq complete)",
+      "expected": "(((((/suite/family/task/node4/node5:attrib1 >= 1) and (/suite/family/task/node4/node5:attrib2 >= 1)) or (/suite/family/task/node4/node5 == complete)) or (../../node6 == complete)) and (node7 == complete))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5/node6/144 eq complete or (/suite/family/task/node4/node5:attrib1 gt /node7/node8/node9:attrib1) or ../../node10 eq complete) and node11 eq complete)",
+      "expected": "(((/suite/family/task/node4/node5/node6/144 == complete) or ((/suite/family/task/node4/node5:attrib1 > /node7/node8/node9:attrib1) or (../../node10 == complete))) and (node11 == complete))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/360/node7/node8 eq complete or /suite/family/task/node4/node5:attrib1 gt ../../../../../node9:attrib1) or ../../node10 eq complete) and node11 eq complete)",
+      "expected": "((((/suite/family/task/node4/node5/node6/360/node7/node8 == complete) or (/suite/family/task/node4/node5:attrib1 > ../../../../../node9:attrib1)) or (../../node10 == complete)) and (node11 == complete))"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt ../../../task:attrib1 and /node4/family:attrib1 gt ../../../task:attrib1) and /node5/node6/node7/node8/family:attrib1 gt ../../../task:attrib1) or (node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete and node13 eq complete and node14 eq complete and node15 eq complete and node16 eq complete))",
+      "expected": "((((/suite/family:attrib1 > ../../../task:attrib1) and (/node4/family:attrib1 > ../../../task:attrib1)) and (/node5/node6/node7/node8/family:attrib1 > ../../../task:attrib1)) or ((((((((node9 == complete) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)))"
+    },
+    {
+      "expression": "(suite == complete and ((:attrib1==1 and (:attrib2>:attrib3 or (:attrib2==:attrib3 and :attrib4>1904))) or :attrib1==0))",
+      "expected": "((suite == complete) and (((:attrib1 == 1) and ((:attrib2 > :attrib3) or ((:attrib2 == :attrib3) and (:attrib4 > 1904)))) or (:attrib1 == 0)))"
+    },
+    {
+      "expression": "(suite == complete and ((:attrib1==1 and (:attrib2 > :attrib3 + 1 or ( :attrib2 == :attrib3 + 1 and :attrib4 > 704))) or :attrib1==0))",
+      "expected": "((suite == complete) and (((:attrib1 == 1) and ((:attrib2 > (:attrib3 + 1)) or ((:attrib2 == (:attrib3 + 1)) and (:attrib4 > 704)))) or (:attrib1 == 0)))"
+    },
+    {
+      "expression": "(../suite:attrib1 ge :attrib1 or ../suite eq complete)",
+      "expected": "((../suite:attrib1 >= :attrib1) or (../suite == complete))"
+    },
+    {
+      "expression": "((../../suite:attrib1 gt ../../family:attrib1 or (../../suite:attrib1 eq ../../family:attrib1 and ../../suite/task/node4 eq complete)) or ../../suite eq complete or 1==1)",
+      "expected": "(((../../suite:attrib1 > ../../family:attrib1) or ((../../suite:attrib1 == ../../family:attrib1) and (../../suite/task/node4 == complete))) or ((../../suite == complete) or (1 == 1)))"
+    },
+    {
+      "expression": "(:attrib1 eq 1400 or ./1/suite eq complete or :attrib2 ge (:attrib3 +11))",
+      "expected": "((:attrib1 == 1400) or ((./1/suite == complete) or (:attrib2 >= (:attrib3 + 11))))"
+    },
+    {
+      "expression": "(suite eq complete and (../family:attrib1 ge :attrib1 or 1==1))",
+      "expected": "((suite == complete) and ((../family:attrib1 >= :attrib1) or (1 == 1)))"
+    },
+    {
+      "expression": "(((((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and node6 eq complete) and node7 eq complete) and (../node8:attrib1 gt ../node9:attrib1 or ../node8 eq complete))",
+      "expected": "((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and ((../node8:attrib1 > ../node9:attrib1) or (../node8 == complete)))"
+    },
+    {
+      "expression": "((suite eq complete and family eq complete) and ../task:attrib1 + 5 ge ../node4:attrib1)",
+      "expected": "(((suite == complete) and (family == complete)) and ((../task:attrib1 + 5) >= ../node4:attrib1))"
+    },
+    {
+      "expression": "((suite:attrib1 gt family:attrib1 or (suite:attrib1 eq family:attrib1 and (suite/task eq complete and suite/node4 eq complete))) or suite eq complete)",
+      "expected": "(((suite:attrib1 > family:attrib1) or ((suite:attrib1 == family:attrib1) and ((suite/task == complete) and (suite/node4 == complete)))) or (suite == complete))"
+    },
+    {
+      "expression": "(suite/family eq complete and /task/node4:attrib1 ge :attrib1)",
+      "expected": "((suite/family == complete) and (/task/node4:attrib1 >= :attrib1))"
+    },
+    {
+      "expression": "(suite == complete AND ../174/suite eq complete)",
+      "expected": "((suite == complete) and (../174/suite == complete))"
+    },
+    {
+      "expression": "((/suite/family/12/task:attrib1 gt 144 OR /suite/family/12/task==complete) AND /suite/family:attrib2 ge :attrib2)",
+      "expected": "(((/suite/family/12/task:attrib1 > 144) or (/suite/family/12/task == complete)) and (/suite/family:attrib2 >= :attrib2))"
+    },
+    {
+      "expression": "(:attrib1 gt :attrib2 and :attrib3 gt 800 and not /suite/family:attrib2 ge :attrib2)",
+      "expected": "(((:attrib1 > :attrib2) and (:attrib3 > 800)) and not ((/suite/family:attrib2 >= :attrib2)))"
+    },
+    {
+      "expression": "(suite eq complete and (/family/task:attrib1 gt :attrib1 or (/family/task:attrib1 eq :attrib1 and (/family/task/12/node4/node5 eq complete or (/family/task/12/node6:attrib2 gt 12)))))",
+      "expected": "((suite == complete) and ((/family/task:attrib1 > :attrib1) or ((/family/task:attrib1 == :attrib1) and ((/family/task/12/node4/node5 == complete) or (/family/task/12/node6:attrib2 > 12)))))"
+    },
+    {
+      "expression": "(suite eq complete and (/family/task:attrib1 gt :attrib1 or (/family/task:attrib1 eq :attrib1 and ( (/family/task/00/node4/node5 eq complete or (/family/task/00/node6:attrib2 gt 12))))))",
+      "expected": "((suite == complete) and ((/family/task:attrib1 > :attrib1) or ((/family/task:attrib1 == :attrib1) and ((/family/task/00/node4/node5 == complete) or (/family/task/00/node6:attrib2 > 12)))))"
+    },
+    {
+      "expression": "((1==1 or /suite/family/00/task/node4==complete))",
+      "expected": "((1 == 1) or (/suite/family/00/task/node4 == complete))"
+    },
+    {
+      "expression": "(:attrib1 > 1)",
+      "expected": "(:attrib1 > 1)"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5 eq complete) and (/node6/family/task/node5/node7 eq complete) or (/suite/family:attrib1 gt :attrib1 and /node6/family:attrib1 gt :attrib1))",
+      "expected": "((/suite/family/task/node4/node5 == complete) and ((/node6/family/task/node5/node7 == complete) or ((/suite/family:attrib1 > :attrib1) and (/node6/family:attrib1 > :attrib1))))"
+    },
+    {
+      "expression": "((1==1 or /suite/family/12/task/node4 eq complete) and (/suite/family/12/node5:attrib1 gt node6:attrib2 or /suite/family/12/node5 eq complete))",
+      "expected": "(((1 == 1) or (/suite/family/12/task/node4 == complete)) and ((/suite/family/12/node5:attrib1 > node6:attrib2) or (/suite/family/12/node5 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/00/task/node4 eq complete) and (/suite/family/00/node5:attrib1 gt node6:attrib2 or /suite/family/00/node5 eq complete))",
+      "expected": "((/suite/family/00/task/node4 == complete) and ((/suite/family/00/node5:attrib1 > node6:attrib2) or (/suite/family/00/node5 == complete)))"
+    },
+    {
+      "expression": "(suite eq complete and /family:attrib1 ge 740)",
+      "expected": "((suite == complete) and (/family:attrib1 >= 740))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt :attrib1) or (/suite/family/12/task/node4 == complete) or /suite/family/12/task/node4:attrib2 gt 0)",
+      "expected": "((/suite/family:attrib1 > :attrib1) or ((/suite/family/12/task/node4 == complete) or (/suite/family/12/task/node4:attrib2 > 0)))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt /node4/node5:attrib1 or /suite/family/task/node6:attrib2 gt /node4/node5/00:attrib3 or (/suite/family/task:attrib1 eq /node4/node5:attrib1 and /suite/family/task/node6:attrib2 eq /node4/node5/00:attrib3 and /suite/family/task/node6/2/node7 eq complete))",
+      "expected": "((/suite/family/task:attrib1 > /node4/node5:attrib1) or ((/suite/family/task/node6:attrib2 > /node4/node5/00:attrib3) or (((/suite/family/task:attrib1 == /node4/node5:attrib1) and (/suite/family/task/node6:attrib2 == /node4/node5/00:attrib3)) and (/suite/family/task/node6/2/node7 == complete))))"
+    },
+    {
+      "expression": "((1==1))",
+      "expected": "(1 == 1)"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5/node6/144/node7 eq complete and /suite/family/task/node8/node5/node6/144/node7 eq complete and /suite/family/task/node8/node5:attrib1 eq :attrib1) or (/suite/family/task/node4/node5:attrib1 gt :attrib1 and /suite/family/task/node8/node5:attrib1 gt :attrib1))",
+      "expected": "((((/suite/family/task/node4/node5/node6/144/node7 == complete) and (/suite/family/task/node8/node5/node6/144/node7 == complete)) and (/suite/family/task/node8/node5:attrib1 == :attrib1)) or ((/suite/family/task/node4/node5:attrib1 > :attrib1) and (/suite/family/task/node8/node5:attrib1 > :attrib1)))"
+    },
+    {
+      "expression": "(suite eq complete and (:attrib1 ge 2330 or (:attrib1 gt 830 and :attrib2 gt :attrib3 +1)))",
+      "expected": "((suite == complete) and ((:attrib1 >= 2330) or ((:attrib1 > 830) and (:attrib2 > (:attrib3 + 1)))))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /task/node4:attrib1) or (/suite/family:attrib1 eq /task/node4:attrib1 and /suite/family/12/node5/240==complete and /suite/family/12/node6/node7==complete) and (/node8/node9/node10/node11/family/12 eq complete and /node8/node9/node10/node11/family:attrib1 eq :attrib1 or /node8/node9/node10/node11/family:attrib1 gt :attrib1))",
+      "expected": "((/suite/family:attrib1 > /task/node4:attrib1) or ((((/suite/family:attrib1 == /task/node4:attrib1) and (/suite/family/12/node5/240 == complete)) and (/suite/family/12/node6/node7 == complete)) and (((/node8/node9/node10/node11/family/12 == complete) and (/node8/node9/node10/node11/family:attrib1 == :attrib1)) or (/node8/node9/node10/node11/family:attrib1 > :attrib1))))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5/00/240 eq complete and /suite/family/task/node4/node5:attrib1 eq :attrib1 or /suite/family/task/node4/node5:attrib1 gt :attrib1))",
+      "expected": "(((/suite/family/task/node4/node5/00/240 == complete) and (/suite/family/task/node4/node5:attrib1 == :attrib1)) or (/suite/family/task/node4/node5:attrib1 > :attrib1))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /task/node4:attrib1) or (/suite/family:attrib1 eq /task/node4:attrib1 and /suite/family/00/node5==complete) and (/node6/node7/node8/node9/family/00/360/node10 eq complete and /node6/node7/node8/node9/family:attrib1 eq :attrib1 or /node6/node7/node8/node9/family:attrib1 gt :attrib1))",
+      "expected": "((/suite/family:attrib1 > /task/node4:attrib1) or (((/suite/family:attrib1 == /task/node4:attrib1) and (/suite/family/00/node5 == complete)) and (((/node6/node7/node8/node9/family/00/360/node10 == complete) and (/node6/node7/node8/node9/family:attrib1 == :attrib1)) or (/node6/node7/node8/node9/family:attrib1 > :attrib1))))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /task/node4:attrib1) or (/suite/family:attrib1 eq /task/node4:attrib1 and /suite/family/00/node5/360==complete) and ((/node6/node7/node8/node9/family/12/360 eq complete and /node6/node7/node8/node9/family:attrib1 eq :attrib1) or /node6/node7/node8/node9/family:attrib1 gt :attrib1))",
+      "expected": "((/suite/family:attrib1 > /task/node4:attrib1) or (((/suite/family:attrib1 == /task/node4:attrib1) and (/suite/family/00/node5/360 == complete)) and (((/node6/node7/node8/node9/family/12/360 == complete) and (/node6/node7/node8/node9/family:attrib1 == :attrib1)) or (/node6/node7/node8/node9/family:attrib1 > :attrib1))))"
+    },
+    {
+      "expression": "(:attrib1 ge 1100 and :attrib1 le 1500)",
+      "expected": "((:attrib1 >= 1100) and (:attrib1 <= 1500))"
+    },
+    {
+      "expression": "(0==1 or ((/suite:attrib1 le /family/task:attrib2 ) and /family/task/node4/node5/node6 eq complete))",
+      "expected": "((0 == 1) or ((/suite:attrib1 <= /family/task:attrib2) and (/family/task/node4/node5/node6 == complete)))"
+    },
+    {
+      "expression": "(/suite/family/00:attrib1+19 gt :attrib1 and /suite/family/00/task eq complete)",
+      "expected": "(((/suite/family/00:attrib1 + 19) > :attrib1) and (/suite/family/00/task == complete))"
+    },
+    {
+      "expression": "(((/suite/family/task:attrib1 - /suite/node4:attrib1) < 21 or (/suite/family/task:attrib1 - :attrib2) < 21) or (:attrib3 * 10000 + :attrib4 * 100 + :attrib5) lt (/suite/node4:attrib6 + 22))",
+      "expected": "((((/suite/family/task:attrib1 - /suite/node4:attrib1) < 21) or ((/suite/family/task:attrib1 - :attrib2) < 21)) or (((((:attrib3 * 10000) + :attrib4) * 100) + :attrib5) < (/suite/node4:attrib6 + 22)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 > /task/node4:attrib1))",
+      "expected": "(/suite/family:attrib1 > /task/node4:attrib1)"
+    },
+    {
+      "expression": "((/suite/family:attrib1 < /suite/task:attrib1 or /suite/family:attrib1 == /suite/task:attrib1 and /suite/task/00/node4 == complete) and (/suite/family:attrib1 < /suite/task:attrib1 or /suite/family:attrib1 == /suite/task:attrib1 and /suite/task/00/node5 == complete))",
+      "expected": "(((/suite/family:attrib1 < /suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/task/00/node4 == complete))) and ((/suite/family:attrib1 < /suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/task/00/node5 == complete))))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 < /suite/task:attrib1 or /suite/family:attrib1 == /suite/task:attrib1 and /suite/task/00/node4 == complete and /suite/task/00/node5 == complete)",
+      "expected": "((/suite/family:attrib1 < /suite/task:attrib1) or (((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/task/00/node4 == complete)) and (/suite/task/00/node5 == complete)))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 > ../task:attrib1 and node4 == complete and 12 == complete and 06 == complete and 00 == complete)",
+      "expected": "(((((/suite/family:attrib1 > ../task:attrib1) and (node4 == complete)) and (12 == complete)) and (06 == complete)) and (00 == complete))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 > ../task:attrib1 and 06 == complete and 00 == complete)",
+      "expected": "(((/suite/family:attrib1 > ../task:attrib1) and (06 == complete)) and (00 == complete))"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 == /task/node4:attrib1 and /suite/family/12/node5/node6 == complete) or (/suite/family:attrib1 > /task/node4:attrib1)) and ((/node7/node8/family:attrib1 == /task/node4:attrib1 and /node7/node8/family/12/node8 == complete) or (/node7/node8/family:attrib1 > /task/node4:attrib1)))",
+      "expected": "((((/suite/family:attrib1 == /task/node4:attrib1) and (/suite/family/12/node5/node6 == complete)) or (/suite/family:attrib1 > /task/node4:attrib1)) and (((/node7/node8/family:attrib1 == /task/node4:attrib1) and (/node7/node8/family/12/node8 == complete)) or (/node7/node8/family:attrib1 > /task/node4:attrib1)))"
+    },
+    {
+      "expression": "((cal::date_to_julian(/suite/family:attrib1)+1 > cal::date_to_julian(/task/node4:attrib1) or cal::date_to_julian(/suite/family:attrib1)+1 == cal::date_to_julian(/task/node4:attrib1) and /suite/family/00/node5/node6 == complete))",
+      "expected": "(((date_to_julian(arg:0) = 0 + 1) > date_to_julian(arg:0) = 0) or (((date_to_julian(arg:0) = 0 + 1) == date_to_julian(arg:0) = 0) and (/suite/family/00/node5/node6 == complete)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 > /task/node4:attrib1 or /suite/family:attrib1 == /task/node4:attrib1 and (/suite/family/00/node5/node6:attrib2 == 360 or /suite/family/00/node5/node6 == complete)) and /task/node4/node7 == complete)",
+      "expected": "(((/suite/family:attrib1 > /task/node4:attrib1) or ((/suite/family:attrib1 == /task/node4:attrib1) and ((/suite/family/00/node5/node6:attrib2 == 360) or (/suite/family/00/node5/node6 == complete)))) and (/task/node4/node7 == complete))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 > ../task:attrib1 and node4 == complete and 00 == complete)",
+      "expected": "(((/suite/family:attrib1 > ../task:attrib1) and (node4 == complete)) and (00 == complete))"
+    },
+    {
+      "expression": "((1==1) and /suite/family != active and /suite/family != submitted)",
+      "expected": "((1 == 1) and ((/suite/family != active) and (/suite/family != submitted)))"
+    },
+    {
+      "expression": "((1==1) and /suite/family != active and /suite/family != submitted and /family ne active and /family ne submitted)",
+      "expected": "((1 == 1) and ((((/suite/family != active) and (/suite/family != submitted)) and (/family != active)) and (/family != submitted)))"
+    },
+    {
+      "expression": "(((:attrib1 eq /suite/family:attrib2 and :attrib3 ge 1230) and (:attrib1 eq /task/family:attrib2 and :attrib3 ge 1230) and (:attrib1 eq /node4/family:attrib2 and :attrib3 ge 1330) and (:attrib1 eq /node5/family:attrib2 and :attrib3 ge 1330) and (:attrib1 gt /node4/node6/00:attrib2 and :attrib3 ge 1630) and (:attrib1 gt /node4/node6/family:attrib2 and :attrib3 ge 2115)) or :attrib2 lt :attrib1)",
+      "expected": "((((:attrib1 == /suite/family:attrib2) and (:attrib3 >= 1230)) and (((:attrib1 == /task/family:attrib2) and (:attrib3 >= 1230)) and (((:attrib1 == /node4/family:attrib2) and (:attrib3 >= 1330)) and (((:attrib1 == /node5/family:attrib2) and (:attrib3 >= 1330)) and (((:attrib1 > /node4/node6/00:attrib2) and (:attrib3 >= 1630)) and ((:attrib1 > /node4/node6/family:attrib2) and (:attrib3 >= 2115))))))) or (:attrib2 < :attrib1))"
+    },
+    {
+      "expression": "((:attrib1 gt /suite/family:attrib2 and :attrib3 ge 1230) or (:attrib1 gt /task/family:attrib2 and :attrib3 ge 1230) or (:attrib1 gt /node4/family:attrib2 and :attrib3 ge 1330) or (:attrib1 gt /node5/family:attrib2 and :attrib3 ge 1330) or (:attrib1 gt /node4/node6/00:attrib2 and :attrib3 ge 1630) or (:attrib1 gt /node4/node6/family:attrib2 and :attrib3 ge 2115))",
+      "expected": "(((:attrib1 > /suite/family:attrib2) and (:attrib3 >= 1230)) or (((:attrib1 > /task/family:attrib2) and (:attrib3 >= 1230)) or (((:attrib1 > /node4/family:attrib2) and (:attrib3 >= 1330)) or (((:attrib1 > /node5/family:attrib2) and (:attrib3 >= 1330)) or (((:attrib1 > /node4/node6/00:attrib2) and (:attrib3 >= 1630)) or ((:attrib1 > /node4/node6/family:attrib2) and (:attrib3 >= 2115)))))))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5:attrib1 gt /node6/node7/node8:attrib1) or (node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete and suite eq complete and node13 eq complete))",
+      "expected": "((/suite/family/task/node4/node5:attrib1 > /node6/node7/node8:attrib1) or ((((((node9 == complete) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (suite == complete)) and (node13 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5/node6/family:attrib1 < /node6/family:attrib1) or (/suite/family/task/node4/node5/node6/family:attrib1 == /node6/family:attrib1 and /node6/family/12 == complete) or complete:attrib2)",
+      "expected": "((/suite/family/task/node4/node5/node6/family:attrib1 < /node6/family:attrib1) or (((/suite/family/task/node4/node5/node6/family:attrib1 == /node6/family:attrib1) and (/node6/family/12 == complete)) or complete:attrib2))"
+    },
+    {
+      "expression": "(complete:attrib1)",
+      "expected": "complete:attrib1"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5/node6/family:attrib1 < /node6/family:attrib1) or (/suite/family/task/node4/node5/node6/family:attrib1 == /node6/family:attrib1 and (/node6/family/node7/node8/node9/node10 == complete or /node6/family/node7/node8/node9/node10 == active)) or active:attrib2)",
+      "expected": "((/suite/family/task/node4/node5/node6/family:attrib1 < /node6/family:attrib1) or (((/suite/family/task/node4/node5/node6/family:attrib1 == /node6/family:attrib1) and ((/node6/family/node7/node8/node9/node10 == complete) or (/node6/family/node7/node8/node9/node10 == active))) or active:attrib2))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5/node6/family:attrib1 < /node6/family:attrib1) or (/suite/family/task/node4/node5/node6/family:attrib1 == /node6/family:attrib1 and /node6/family/12/node7/node8:attrib2 gt 48) or complete:attrib3)",
+      "expected": "((/suite/family/task/node4/node5/node6/family:attrib1 < /node6/family:attrib1) or (((/suite/family/task/node4/node5/node6/family:attrib1 == /node6/family:attrib1) and (/node6/family/12/node7/node8:attrib2 > 48)) or complete:attrib3))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 == /task/family/node4/node5:attrib1 and /suite/family/12/node6/node7/node8 != queued) or (/suite/family:attrib1 > /task/family/node4/node5:attrib1))",
+      "expected": "(((/suite/family:attrib1 == /task/family/node4/node5:attrib1) and (/suite/family/12/node6/node7/node8 != queued)) or (/suite/family:attrib1 > /task/family/node4/node5:attrib1))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 == /task/family/node4/node5:attrib1 and ((/suite/family/12/node6/node7/node8/node9 != queued) or (/suite/family/12/node6/node10/node8/node11 != queued))) or (/suite/family:attrib1 > /task/family/node4/node5:attrib1))",
+      "expected": "(((/suite/family:attrib1 == /task/family/node4/node5:attrib1) and ((/suite/family/12/node6/node7/node8/node9 != queued) or (/suite/family/12/node6/node10/node8/node11 != queued))) or (/suite/family:attrib1 > /task/family/node4/node5:attrib1))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 == /task/family/node4/node5:attrib1 and ((/suite/family/12 == complete))) or (/suite/family:attrib1 > /task/family/node4/node5:attrib1))",
+      "expected": "(((/suite/family:attrib1 == /task/family/node4/node5:attrib1) and (/suite/family/12 == complete)) or (/suite/family:attrib1 > /task/family/node4/node5:attrib1))"
+    },
+    {
+      "expression": "(((/suite/family/task:attrib1 gt /suite/node4/node5/node6:attrib1) or (/suite/family/task:attrib1 eq /suite/node4/node5/node6:attrib1 and /suite/family/task/node7 eq complete)) or (/suite/family:attrib2 gt /suite/node4/node5:attrib2))",
+      "expected": "(((/suite/family/task:attrib1 > /suite/node4/node5/node6:attrib1) or ((/suite/family/task:attrib1 == /suite/node4/node5/node6:attrib1) and (/suite/family/task/node7 == complete))) or (/suite/family:attrib2 > /suite/node4/node5:attrib2))"
+    },
+    {
+      "expression": "((/suite/family/task:attrib1 gt /suite/family/node4:attrib1) or (/suite/family/task:attrib1 eq /suite/family/node4:attrib1 and ((/suite/family/task/node5:attrib2 gt /suite/family/node4/node5:attrib2) or (/suite/family/task/node5:attrib2 eq /suite/family/node4/node5:attrib2 and /suite/family/task/node5/1 eq complete and /suite/family/task/node5/2 eq complete))))",
+      "expected": "((/suite/family/task:attrib1 > /suite/family/node4:attrib1) or ((/suite/family/task:attrib1 == /suite/family/node4:attrib1) and ((/suite/family/task/node5:attrib2 > /suite/family/node4/node5:attrib2) or (((/suite/family/task/node5:attrib2 == /suite/family/node4/node5:attrib2) and (/suite/family/task/node5/1 == complete)) and (/suite/family/task/node5/2 == complete)))))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt ../../../task:attrib1 or (node4 eq complete and node5 eq complete and node6 eq complete and node7 eq complete and node8 eq complete and node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete and node13 eq complete))",
+      "expected": "((/suite/family:attrib1 > ../../../task:attrib1) or ((((((((((node4 == complete) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/task/12 eq complete) or 1 == 1)",
+      "expected": "((/suite/family/task/12 == complete) or (1 == 1))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt ../../../task:attrib1 or (node4 eq complete and node5 eq complete and node6 eq complete and node7 eq complete and node8 eq complete and node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete))",
+      "expected": "((/suite/family:attrib1 > ../../../task:attrib1) or (((((((((node4 == complete) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /task/node4:attrib1) or (/suite/family:attrib1 eq /task/node4:attrib1 and /suite/family/12/node5/360/node6==complete and /suite/family/12/node5/360/node7==complete and /suite/family/12/node5/240/node7==complete))",
+      "expected": "((/suite/family:attrib1 > /task/node4:attrib1) or ((((/suite/family:attrib1 == /task/node4:attrib1) and (/suite/family/12/node5/360/node6 == complete)) and (/suite/family/12/node5/360/node7 == complete)) and (/suite/family/12/node5/240/node7 == complete)))"
+    },
+    {
+      "expression": "((suite eq complete) and (/family/task/12/node4/node5 == complete and ../../suite/node6/node7 == complete))",
+      "expected": "((suite == complete) and ((/family/task/12/node4/node5 == complete) and (../../suite/node6/node7 == complete)))"
+    },
+    {
+      "expression": "(suite:attrib1 lt family:attrib1 or suite==complete)",
+      "expected": "((suite:attrib1 < family:attrib1) or (suite == complete))"
+    },
+    {
+      "expression": "(suite eq complete and (family:attrib1 or family==complete))",
+      "expected": "((suite == complete) and (family:attrib1 or (family == complete)))"
+    },
+    {
+      "expression": "((suite == complete) and ((family:attrib1 or family==complete)))",
+      "expected": "((suite == complete) and (family:attrib1 or (family == complete)))"
+    },
+    {
+      "expression": "((suite == complete and family == complete and task == complete) and (/node4/family:attrib1 gt /node4/node5:attrib1))",
+      "expected": "((((suite == complete) and (family == complete)) and (task == complete)) and (/node4/family:attrib1 > /node4/node5:attrib1))"
+    },
+    {
+      "expression": "(/suite/family/01:attrib1 ge /suite/family/task:attrib1 and /node4/node5/node6/node7:attrib1 gt /suite/family/task:attrib1)",
+      "expected": "((/suite/family/01:attrib1 >= /suite/family/task:attrib1) and (/node4/node5/node6/node7:attrib1 > /suite/family/task:attrib1))"
+    },
+    {
+      "expression": "(((/suite/family/12/task/node4/node5==complete or /suite/family/12/node6:attrib1 ge 240 or /suite/family/12/node7:attrib2 ge 240)) and ((/node8/family:attrib3 gt /suite/family:attrib3 -1) or (/node8/family:attrib3 eq /suite/family:attrib3) and (/node8/family/12/node4/node9==complete)))",
+      "expected": "(((/suite/family/12/task/node4/node5 == complete) or ((/suite/family/12/node6:attrib1 >= 240) or (/suite/family/12/node7:attrib2 >= 240))) and ((/node8/family:attrib3 > (/suite/family:attrib3 - 1)) or ((/node8/family:attrib3 == /suite/family:attrib3) and (/node8/family/12/node4/node9 == complete))))"
+    },
+    {
+      "expression": "(suite == complete or family eq complete)",
+      "expected": "((suite == complete) or (family == complete))"
+    },
+    {
+      "expression": "(((/suite/family/12/task/node4==complete or /suite/family/12/node5:attrib1 ge 360 or /suite/family/12/node6:attrib2 ge 360) and (/node7/family/12/node4/node8:attrib2 ge 240 or /node7/family/12/node4/node8 eq complete)) and (node9 == complete))",
+      "expected": "((((/suite/family/12/task/node4 == complete) or ((/suite/family/12/node5:attrib1 >= 360) or (/suite/family/12/node6:attrib2 >= 360))) and ((/node7/family/12/node4/node8:attrib2 >= 240) or (/node7/family/12/node4/node8 == complete))) and (node9 == complete))"
+    },
+    {
+      "expression": "((/suite/family/12/task:attrib1 ge 12 or /suite/family/12/node4:attrib2 ge 12 or /suite/family/12/node5/node6 eq complete) and (/node7/family/12/node6/node8:attrib2 ge 12))",
+      "expected": "(((/suite/family/12/task:attrib1 >= 12) or ((/suite/family/12/node4:attrib2 >= 12) or (/suite/family/12/node5/node6 == complete))) and (/node7/family/12/node6/node8:attrib2 >= 12))"
+    },
+    {
+      "expression": "((((./12 == complete and ./18 == complete and ./00 == complete and ./06 == complete) and (:attrib1 gt 1402)) and (/suite/family:attrib2 gt :attrib2)) and (/task/family:attrib2 gt :attrib2))",
+      "expected": "(((((((./12 == complete) and (./18 == complete)) and (./00 == complete)) and (./06 == complete)) and (:attrib1 > 1402)) and (/suite/family:attrib2 > :attrib2)) and (/task/family:attrib2 > :attrib2))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 eq /task/family:attrib1)",
+      "expected": "(/suite/family:attrib1 == /task/family:attrib1)"
+    },
+    {
+      "expression": "((((/suite/family/12/task/node4:attrib1 ge 72 or /suite/family/12/task/node5:attrib1 ge 72 or /suite/family/12/task eq complete) or :attrib2) and /node6/family:attrib3 eq /suite/family:attrib3) or /node6/family:attrib3 lt /suite/family:attrib3)",
+      "expected": "(((((/suite/family/12/task/node4:attrib1 >= 72) or ((/suite/family/12/task/node5:attrib1 >= 72) or (/suite/family/12/task == complete))) or :attrib2) and (/node6/family:attrib3 == /suite/family:attrib3)) or (/node6/family:attrib3 < /suite/family:attrib3))"
+    },
+    {
+      "expression": "(((/suite/family/12/task:attrib1 ge 18 or /suite/family/12/node4:attrib2 ge 18 or :attrib3 or /suite/family/12 eq complete) and /node5/family:attrib4 eq /suite/family:attrib4) or /node5/family:attrib4 lt /suite/family:attrib4)",
+      "expected": "((((/suite/family/12/task:attrib1 >= 18) or ((/suite/family/12/node4:attrib2 >= 18) or (:attrib3 or (/suite/family/12 == complete)))) and (/node5/family:attrib4 == /suite/family:attrib4)) or (/node5/family:attrib4 < /suite/family:attrib4))"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4:attrib1 ge 0 or /suite/family/12/task/node5:attrib1 ge 0 or /suite/family/12/task eq complete) or :attrib2)",
+      "expected": "(((/suite/family/12/task/node4:attrib1 >= 0) or ((/suite/family/12/task/node5:attrib1 >= 0) or (/suite/family/12/task == complete))) or :attrib2)"
+    },
+    {
+      "expression": "(((../../suite/000/family eq complete) and (/task/node4/12/suite/000/family == complete)) and (family == complete))",
+      "expected": "(((../../suite/000/family == complete) and (/task/node4/12/suite/000/family == complete)) and (family == complete))"
+    },
+    {
+      "expression": "((./000/suite == complete) and ((/family/task/12/node4/node5:attrib1 ge 3 or /family/task/12/node4/node6:attrib1 ge 3 or /family/task/12/node4 eq complete) or :attrib2))",
+      "expected": "((./000/suite == complete) and (((/family/task/12/node4/node5:attrib1 >= 3) or ((/family/task/12/node4/node6:attrib1 >= 3) or (/family/task/12/node4 == complete))) or :attrib2))"
+    },
+    {
+      "expression": "(/suite/family/12/task:attrib1 ge 0 or /suite/family/12/node4:attrib2 ge 0 or :attrib3 or /suite/family/12 eq complete)",
+      "expected": "((/suite/family/12/task:attrib1 >= 0) or ((/suite/family/12/node4:attrib2 >= 0) or (:attrib3 or (/suite/family/12 == complete))))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt /task/family:attrib1 AND :attrib2 gt 1300)",
+      "expected": "((/suite/family:attrib1 > /task/family:attrib1) and (:attrib2 > 1300))"
+    },
+    {
+      "expression": "((./12 == complete and ./18 == complete and ./00 == complete and ./06 == complete) and (/suite/family:attrib1 gt /task/node4:attrib1))",
+      "expected": "(((((./12 == complete) and (./18 == complete)) and (./00 == complete)) and (./06 == complete)) and (/suite/family:attrib1 > /task/node4:attrib1))"
+    },
+    {
+      "expression": "(:attrib1 eq 1345 or :attrib2 eq 1)",
+      "expected": "((:attrib1 == 1345) or (:attrib2 == 1))"
+    },
+    {
+      "expression": "((((/suite/family/task:attrib1 gt /suite/node4/node5/node6:attrib1) or (/suite/family/task:attrib1 eq /suite/node4/node5/node6:attrib1 and /suite/family/task/node7 eq complete)) or (/suite/family:attrib2 gt /suite/node4/node5:attrib2)) and (:attrib3 eq 1345 or :attrib4 eq 1))",
+      "expected": "((((/suite/family/task:attrib1 > /suite/node4/node5/node6:attrib1) or ((/suite/family/task:attrib1 == /suite/node4/node5/node6:attrib1) and (/suite/family/task/node7 == complete))) or (/suite/family:attrib2 > /suite/node4/node5:attrib2)) and ((:attrib3 == 1345) or (:attrib4 == 1)))"
+    },
+    {
+      "expression": "(((/suite/family/task:attrib1 gt /suite/family/node4:attrib1) or (/suite/family/task:attrib1 eq /suite/family/node4:attrib1 and ((/suite/family/task/node5:attrib2 gt /suite/family/node4/node5:attrib2) or (/suite/family/task/node5:attrib2 eq /suite/family/node4/node5:attrib2 and /suite/family/task/node5/1 eq complete and /suite/family/task/node5/2 eq complete)))) and (:attrib3 eq 1345 or :attrib4 eq 1))",
+      "expected": "(((/suite/family/task:attrib1 > /suite/family/node4:attrib1) or ((/suite/family/task:attrib1 == /suite/family/node4:attrib1) and ((/suite/family/task/node5:attrib2 > /suite/family/node4/node5:attrib2) or (((/suite/family/task/node5:attrib2 == /suite/family/node4/node5:attrib2) and (/suite/family/task/node5/1 == complete)) and (/suite/family/task/node5/2 == complete))))) and ((:attrib3 == 1345) or (:attrib4 == 1)))"
+    },
+    {
+      "expression": "(../../suite/family/task == complete and ../../suite/family:attrib1 == :attrib1 or (../../suite/family:attrib1 > :attrib1) and (:attrib1 <= ../../node4/family:attrib1 + :attrib2))",
+      "expected": "(((../../suite/family/task == complete) and (../../suite/family:attrib1 == :attrib1)) or ((../../suite/family:attrib1 > :attrib1) and (:attrib1 <= (../../node4/family:attrib1 + :attrib2))))"
+    },
+    {
+      "expression": "((../../suite:attrib1 >= ../../family:attrib1) or ((../../suite:attrib1 == ../../family:attrib1 - 1) and ../../suite/task/node4:attrib2 >= 12 and ../../suite/node5==complete))",
+      "expected": "((../../suite:attrib1 >= ../../family:attrib1) or ((../../suite:attrib1 == (../../family:attrib1 - 1)) and ((../../suite/task/node4:attrib2 >= 12) and (../../suite/node5 == complete))))"
+    },
+    {
+      "expression": "(((../../suite:attrib1 >= ../../family:attrib1) or ((../../suite:attrib1 == ../../family:attrib1 - 1) and ../../suite/task/node4:attrib2 >= 12 and ../../suite/node5==complete)) and node6 == complete and node7 == complete)",
+      "expected": "(((../../suite:attrib1 >= ../../family:attrib1) or ((../../suite:attrib1 == (../../family:attrib1 - 1)) and ((../../suite/task/node4:attrib2 >= 12) and (../../suite/node5 == complete)))) and ((node6 == complete) and (node7 == complete)))"
+    },
+    {
+      "expression": "((../../suite:attrib1 > ../../family:attrib1) or ((../../suite:attrib1 == ../../family:attrib1) and ../../suite/task/node4:attrib2 >= 12 and ../../suite/node5==complete))",
+      "expected": "((../../suite:attrib1 > ../../family:attrib1) or ((../../suite:attrib1 == ../../family:attrib1) and ((../../suite/task/node4:attrib2 >= 12) and (../../suite/node5 == complete))))"
+    },
+    {
+      "expression": "(((../../suite:attrib1 > ../../family:attrib1) or ((../../suite:attrib1 == ../../family:attrib1) and ../../suite/task/node4:attrib2 >= 12 and ../../suite/node5==complete)) and node6 == complete and node7 == complete)",
+      "expected": "(((../../suite:attrib1 > ../../family:attrib1) or ((../../suite:attrib1 == ../../family:attrib1) and ((../../suite/task/node4:attrib2 >= 12) and (../../suite/node5 == complete)))) and ((node6 == complete) and (node7 == complete)))"
+    },
+    {
+      "expression": "((:attrib1 <= suite:attrib1 + 1 or suite == complete) and (:attrib1 - 1 < /family/task:attrib1 or (:attrib1 - 1 == /family/task:attrib1 and /family/task/00/node4 == complete)))",
+      "expected": "(((:attrib1 <= (suite:attrib1 + 1)) or (suite == complete)) and (((:attrib1 - 1) < /family/task:attrib1) or (((:attrib1 - 1) == /family/task:attrib1) and (/family/task/00/node4 == complete))))"
+    },
+    {
+      "expression": "((../../../../0011/suite/family/task:attrib1 + 4 > :attrib1 or (../../../../0011/suite/family/task:attrib1 + 4 == :attrib1 and ../../../../0011/suite/family/task/node4 == complete)) and (../node5:attrib1 <= ../node6:attrib1 or ../node6 == complete))",
+      "expected": "((((../../../../0011/suite/family/task:attrib1 + 4) > :attrib1) or (((../../../../0011/suite/family/task:attrib1 + 4) == :attrib1) and (../../../../0011/suite/family/task/node4 == complete))) and ((../node5:attrib1 <= ../node6:attrib1) or (../node6 == complete)))"
+    },
+    {
+      "expression": "((:attrib1 < suite:attrib1 or suite/family == complete) and (:attrib1 <= ../task:attrib1 + 1 or ../task == complete))",
+      "expected": "(((:attrib1 < suite:attrib1) or (suite/family == complete)) and ((:attrib1 <= (../task:attrib1 + 1)) or (../task == complete)))"
+    },
+    {
+      "expression": "(/suite:attrib1 == 01 and /suite:attrib2 gt 0930 and /suite:attrib3 ge /suite/family/task:attrib4)",
+      "expected": "(((/suite:attrib1 == 1) and (/suite:attrib2 > 930)) and (/suite:attrib3 >= /suite/family/task:attrib4))"
+    },
+    {
+      "expression": "(( suite/family:attrib1 or suite/family eq complete) and ( task/family:attrib1 or task/family eq complete) and ( node4 eq complete))",
+      "expected": "((suite/family:attrib1 or (suite/family == complete)) and ((task/family:attrib1 or (task/family == complete)) and (node4 == complete)))"
+    },
+    {
+      "expression": "(( ../../suite/family eq complete and ../../suite/task eq complete and ../../node4 eq complete))",
+      "expected": "(((../../suite/family == complete) and (../../suite/task == complete)) and (../../node4 == complete))"
+    },
+    {
+      "expression": "(../suite eq complete and /family:attrib1 == 5 and /family:attrib2 ge 1200)",
+      "expected": "(((../suite == complete) and (/family:attrib1 == 5)) and (/family:attrib2 >= 1200))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 % 3 != 2)",
+      "expected": "((/suite/family/task:attrib1 % 3) != 2)"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6 eq complete) and (/suite/family/task/node7/node8/node6 eq complete)))",
+      "expected": "((/suite/family/task/node4/node5/node6 == complete) and (/suite/family/task/node7/node8/node6 == complete))"
+    },
+    {
+      "expression": "(../suite/family == complete and /task:attrib1 == 5 and /task:attrib2 ge 1200 and /task:attrib3 ge /task/node4/node5:attrib4)",
+      "expected": "((((../suite/family == complete) and (/task:attrib1 == 5)) and (/task:attrib2 >= 1200)) and (/task:attrib3 >= /task/node4/node5:attrib4))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and (/node4:attrib1 ge 15))",
+      "expected": "((((suite == complete) and (family == complete)) and (task == complete)) and (/node4:attrib1 >= 15))"
+    },
+    {
+      "expression": "(/suite/family/task/node4/node5 eq complete AND /suite/family/task/node6/node7/node8 == complete)",
+      "expected": "((/suite/family/task/node4/node5 == complete) and (/suite/family/task/node6/node7/node8 == complete))"
+    },
+    {
+      "expression": "(((suite == complete and family == complete and task == complete and node4 == complete) and (node5 == complete)) and (((/node6:attrib1 gt 1000) and /node6:attrib2 ge 27)))",
+      "expected": "((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and ((/node6:attrib1 > 1000) and (/node6:attrib2 >= 27)))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt ../../task:attrib1 or /suite/family/node4:attrib2 gt ../00:attrib2)",
+      "expected": "((/suite/family:attrib1 > ../../task:attrib1) or (/suite/family/node4:attrib2 > ../00:attrib2))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 ge ../../task:attrib1 and /suite/family/node4:attrib2 ge ../00:attrib2) or /suite/family:attrib1 gt ../../task:attrib1)",
+      "expected": "(((/suite/family:attrib1 >= ../../task:attrib1) and (/suite/family/node4:attrib2 >= ../00:attrib2)) or (/suite/family:attrib1 > ../../task:attrib1))"
+    },
+    {
+      "expression": "(:attrib1 lt :attrib2 or (:attrib1 eq :attrib2 and :attrib3 ge 0700))",
+      "expected": "((:attrib1 < :attrib2) or ((:attrib1 == :attrib2) and (:attrib3 >= 700)))"
+    },
+    {
+      "expression": "(suite eq complete and :attrib1 le family:attrib1)",
+      "expected": "((suite == complete) and (:attrib1 <= family:attrib1))"
+    },
+    {
+      "expression": "(:attrib1 lt ../suite:attrib1 or ../suite/00 eq complete)",
+      "expected": "((:attrib1 < ../suite:attrib1) or (../suite/00 == complete))"
+    },
+    {
+      "expression": "(((((((((((((((((((((((((00 eq complete) and (01 eq complete)) and (02 eq complete)) and (03 eq complete)) and (04 eq complete)) and (05 eq complete)) and (06 eq complete)) and (07 eq complete)) and (08 eq complete)) and (09 eq complete)) and (10 eq complete)) and (11 eq complete)) and (12 eq complete)) and (13 eq complete)) and (14 eq complete)) and (15 eq complete)) and (16 eq complete)) and (17 eq complete)) and (18 eq complete)) and (19 eq complete)) and (20 eq complete)) and (21 eq complete)) and (22 eq complete)) and (23 eq complete)) and (suite eq complete))",
+      "expected": "(((((((((((((((((((((((((00 == complete) and (01 == complete)) and (02 == complete)) and (03 == complete)) and (04 == complete)) and (05 == complete)) and (06 == complete)) and (07 == complete)) and (08 == complete)) and (09 == complete)) and (10 == complete)) and (11 == complete)) and (12 == complete)) and (13 == complete)) and (14 == complete)) and (15 == complete)) and (16 == complete)) and (17 == complete)) and (18 == complete)) and (19 == complete)) and (20 == complete)) and (21 == complete)) and (22 == complete)) and (23 == complete)) and (suite == complete))"
+    },
+    {
+      "expression": "((((((((((((((((((((((((00 eq complete) and (01 eq complete)) and (02 eq complete)) and (03 eq complete)) and (04 eq complete)) and (05 eq complete)) and (06 eq complete)) and (07 eq complete)) and (08 eq complete)) and (09 eq complete)) and (10 eq complete)) and (11 eq complete)) and (12 eq complete)) and (13 eq complete)) and (14 eq complete)) and (15 eq complete)) and (16 eq complete)) and (17 eq complete)) and (18 eq complete)) and (19 eq complete)) and (20 eq complete)) and (21 eq complete)) and (22 eq complete)) and (23 eq complete))",
+      "expected": "((((((((((((((((((((((((00 == complete) and (01 == complete)) and (02 == complete)) and (03 == complete)) and (04 == complete)) and (05 == complete)) and (06 == complete)) and (07 == complete)) and (08 == complete)) and (09 == complete)) and (10 == complete)) and (11 == complete)) and (12 == complete)) and (13 == complete)) and (14 == complete)) and (15 == complete)) and (16 == complete)) and (17 == complete)) and (18 == complete)) and (19 == complete)) and (20 == complete)) and (21 == complete)) and (22 == complete)) and (23 == complete))"
+    },
+    {
+      "expression": "(:attrib1/100 lt :attrib2 or (:attrib1/100 eq :attrib2 and :attrib3 ge 400))",
+      "expected": "(((:attrib1 / 100) < :attrib2) or (((:attrib1 / 100) == :attrib2) and (:attrib3 >= 400)))"
+    },
+    {
+      "expression": "(suite eq complete and (family eq complete or family eq aborted))",
+      "expected": "((suite == complete) and ((family == complete) or (family == aborted)))"
+    },
+    {
+      "expression": "(./suite:attrib1>2)",
+      "expected": "(./suite:attrib1 > 2)"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 - 1 or (/suite/family/task:attrib1 eq :attrib2 - 1 and /suite/family/task/00 == complete))",
+      "expected": "((/suite/family/task:attrib1 > (:attrib2 - 1)) or ((/suite/family/task:attrib1 == (:attrib2 - 1)) and (/suite/family/task/00 == complete)))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt ( :attrib2 * 100 ))",
+      "expected": "(/suite/family:attrib1 > (:attrib2 * 100))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt :attrib1 or (/suite/family:attrib1 eq :attrib1 and /suite/family/12/task/node4 eq complete))",
+      "expected": "((/suite/family:attrib1 > :attrib1) or ((/suite/family:attrib1 == :attrib1) and (/suite/family/12/task/node4 == complete)))"
+    },
+    {
+      "expression": "(:attrib1 lt ../suite:attrib1 or (:attrib1 eq ../suite:attrib1 and ../suite/12 eq complete))",
+      "expected": "((:attrib1 < ../suite:attrib1) or ((:attrib1 == ../suite:attrib1) and (../suite/12 == complete)))"
+    },
+    {
+      "expression": "(/suite/family/task/node4/node5 == complete and /node6:attrib1 ge ../node5:attrib2)",
+      "expected": "((/suite/family/task/node4/node5 == complete) and (/node6:attrib1 >= ../node5:attrib2))"
+    },
+    {
+      "expression": "((/suite:attrib1 ge 25) and (family == complete and task == complete and node4 == complete))",
+      "expected": "((/suite:attrib1 >= 25) and (((family == complete) and (task == complete)) and (node4 == complete)))"
+    },
+    {
+      "expression": "((/suite:attrib1 ge 28 and /suite:attrib2 gt 1000) and (family == complete and task == complete and node4 == complete))",
+      "expected": "(((/suite:attrib1 >= 28) and (/suite:attrib2 > 1000)) and (((family == complete) and (task == complete)) and (node4 == complete)))"
+    },
+    {
+      "expression": "((../../suite/family == complete) and ((/task/node4/node5:attrib1 gt /task/node4/node6:attrib1)))",
+      "expected": "((../../suite/family == complete) and (/task/node4/node5:attrib1 > /task/node4/node6:attrib1))"
+    },
+    {
+      "expression": "((/suite:attrib1 ge 26 and /suite:attrib2 gt 1000) and (family == complete and task == complete))",
+      "expected": "(((/suite:attrib1 >= 26) and (/suite:attrib2 > 1000)) and ((family == complete) and (task == complete)))"
+    },
+    {
+      "expression": "(../suite == complete AND ../family/task/node4/node5 == complete and ../node6/task/node4/node5 == complete and ../node7/task/node4/node5 == complete and ../node8/task/node4/node5 == complete and ../node9/task/node4/node5 == complete and ../node10/task/node4/node5 == complete and ../node11/task/node4/node5 == complete and ../node12/node13/task/node4/node5 == complete and ../node12/node14/task/node4/node5 == complete)",
+      "expected": "((((((((((../suite == complete) and (../family/task/node4/node5 == complete)) and (../node6/task/node4/node5 == complete)) and (../node7/task/node4/node5 == complete)) and (../node8/task/node4/node5 == complete)) and (../node9/task/node4/node5 == complete)) and (../node10/task/node4/node5 == complete)) and (../node11/task/node4/node5 == complete)) and (../node12/node13/task/node4/node5 == complete)) and (../node12/node14/task/node4/node5 == complete))"
+    },
+    {
+      "expression": "(/suite:attrib1 ge 28 and /suite:attrib2 gt 1000 and family == complete)",
+      "expected": "(((/suite:attrib1 >= 28) and (/suite:attrib2 > 1000)) and (family == complete))"
+    },
+    {
+      "expression": "(suite eq complete and family eq complete and /task/0005/node4/node5:attrib1 gt :attrib1)",
+      "expected": "(((suite == complete) and (family == complete)) and (/task/0005/node4/node5:attrib1 > :attrib1))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 > /suite/node4/node5:attrib1 and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete and node15 == complete)",
+      "expected": "(((((((((((/suite/family/task:attrib1 > /suite/node4/node5:attrib1) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 > /suite/node4/node5:attrib1 and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete and node15 == complete and node16 == complete and node17 == complete and node18 == complete and node19 == complete and node20 == complete and node21 == complete and node22 == complete and node23 == complete and node24 == complete and node25 == complete and node26 == complete and node27 == complete and node28 == complete and node29 == complete and node30 == complete and node31 == complete and node32 == complete and node33 == complete and node34 == complete and node35 == complete and node36 == complete and node37 == complete and node38 == complete and node39 == complete and node40 == complete and node41 == complete and node42 == complete and node43 == complete and node44 == complete and node45 == complete and node46 == complete and node47 == complete and node48 == complete and node49 == complete)",
+      "expected": "(((((((((((((((((((((((((((((((((((((((((((((/suite/family/task:attrib1 > /suite/node4/node5:attrib1) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)) and (node17 == complete)) and (node18 == complete)) and (node19 == complete)) and (node20 == complete)) and (node21 == complete)) and (node22 == complete)) and (node23 == complete)) and (node24 == complete)) and (node25 == complete)) and (node26 == complete)) and (node27 == complete)) and (node28 == complete)) and (node29 == complete)) and (node30 == complete)) and (node31 == complete)) and (node32 == complete)) and (node33 == complete)) and (node34 == complete)) and (node35 == complete)) and (node36 == complete)) and (node37 == complete)) and (node38 == complete)) and (node39 == complete)) and (node40 == complete)) and (node41 == complete)) and (node42 == complete)) and (node43 == complete)) and (node44 == complete)) and (node45 == complete)) and (node46 == complete)) and (node47 == complete)) and (node48 == complete)) and (node49 == complete))"
+    },
+    {
+      "expression": "(../suite:attrib1 < /family/task/suite/node4:attrib1 and ../node5:attrib1 >= node6/node7:attrib2 and node8 == complete and node6 == complete and node9 == complete and node10 == complete)",
+      "expected": "((((((../suite:attrib1 < /family/task/suite/node4:attrib1) and (../node5:attrib1 >= node6/node7:attrib2)) and (node8 == complete)) and (node6 == complete)) and (node9 == complete)) and (node10 == complete))"
+    },
+    {
+      "expression": "(../suite:attrib1 <= /family/task/node4/node5:attrib1 and ../suite:attrib1 < ../node6/node7/node8:attrib2 and ../node6/node9/node6/node10/node11/node12 == complete)",
+      "expected": "(((../suite:attrib1 <= /family/task/node4/node5:attrib1) and (../suite:attrib1 < ../node6/node7/node8:attrib2)) and (../node6/node9/node6/node10/node11/node12 == complete))"
+    },
+    {
+      "expression": "(../suite == complete and not ../suite:attrib1 or /family/task/node4:attrib2)",
+      "expected": "(((../suite == complete) and not (../suite:attrib1)) or /family/task/node4:attrib2)"
+    },
+    {
+      "expression": "(../suite == complete and ../suite:attrib1 and not /family/task/node4:attrib2)",
+      "expected": "(((../suite == complete) and ../suite:attrib1) and not (/family/task/node4:attrib2))"
+    },
+    {
+      "expression": "(/suite/family/task/node4:attrib1 >= /suite/family/node5/node4:attrib1 and (../node6:attrib1 < /suite/node7/node5:attrib1 or ../node6:attrib1 == /suite/node7/node5:attrib1 and /suite/node7/node5/node8 == complete) and not /suite/node9/node10:attrib2)",
+      "expected": "((/suite/family/task/node4:attrib1 >= /suite/family/node5/node4:attrib1) and (((../node6:attrib1 < /suite/node7/node5:attrib1) or ((../node6:attrib1 == /suite/node7/node5:attrib1) and (/suite/node7/node5/node8 == complete))) and not (/suite/node9/node10:attrib2)))"
+    },
+    {
+      "expression": "(suite == complete and suite:attrib1 and (../family:attrib2 < /task/node4/node5:attrib2 or ../family:attrib2 == /task/node4/node5:attrib2 and /task/node4/node5/node6/node5/node7 == complete))",
+      "expected": "(((suite == complete) and suite:attrib1) and ((../family:attrib2 < /task/node4/node5:attrib2) or ((../family:attrib2 == /task/node4/node5:attrib2) and (/task/node4/node5/node6/node5/node7 == complete))))"
+    },
+    {
+      "expression": "(../suite:attrib1 > ../family:attrib1 and ../family:attrib1 < /task/node4/node5/node6/node7:attrib2 and node8 == complete)",
+      "expected": "(((../suite:attrib1 > ../family:attrib1) and (../family:attrib1 < /task/node4/node5/node6/node7:attrib2)) and (node8 == complete))"
+    },
+    {
+      "expression": "(suite:attrib1 <= (family:attrib1 + 360) and suite:attrib2 < task/node4:attrib2 and node5/node6 == complete)",
+      "expected": "(((suite:attrib1 <= (family:attrib1 + 360)) and (suite:attrib2 < task/node4:attrib2)) and (node5/node6 == complete))"
+    },
+    {
+      "expression": "(((((/suite/family:attrib1*10000)+(/suite/family/task:attrib2*100)+1) == /node4/node5/node6:attrib3 and /suite/family/task/node7/node8 == complete) or (((/suite/family:attrib1*10000)+(/suite/family/task:attrib2*100)+1) > /node4/node5/node6:attrib3)))",
+      "expected": "((((((/suite/family:attrib1 * 10000) + (/suite/family/task:attrib2 * 100)) + 1) == /node4/node5/node6:attrib3) and (/suite/family/task/node7/node8 == complete)) or ((((/suite/family:attrib1 * 10000) + (/suite/family/task:attrib2 * 100)) + 1) > /node4/node5/node6:attrib3))"
+    },
+    {
+      "expression": "((((/suite/family:attrib1*10000)+(/suite/family/task:attrib2*100)+1) > (/node4/node5/node6:attrib3)) and node7 == complete and node8 == complete)",
+      "expected": "(((((/suite/family:attrib1 * 10000) + (/suite/family/task:attrib2 * 100)) + 1) > /node4/node5/node6:attrib3) and ((node7 == complete) and (node8 == complete)))"
+    },
+    {
+      "expression": "(../suite == complete and (../family:attrib1 < ../task:attrib1 or ../family:attrib1 == ../task:attrib1 and ../task/node4 == complete) and (../family:attrib1 < ../task:attrib1 or ../family:attrib1 == ../task:attrib1 and ../task/node5 == complete))",
+      "expected": "((../suite == complete) and (((../family:attrib1 < ../task:attrib1) or ((../family:attrib1 == ../task:attrib1) and (../task/node4 == complete))) and ((../family:attrib1 < ../task:attrib1) or ((../family:attrib1 == ../task:attrib1) and (../task/node5 == complete)))))"
+    },
+    {
+      "expression": "(suite/family == complete and task:attrib1 < node4/node5:attrib1 and task:attrib1 <= node6:attrib1 + 360)",
+      "expected": "(((suite/family == complete) and (task:attrib1 < node4/node5:attrib1)) and (task:attrib1 <= (node6:attrib1 + 360)))"
+    },
+    {
+      "expression": "(((((/suite/family:attrib1*10000)+(/suite/family/task:attrib2*100)+1) == /node4/node5/node6:attrib3 and /suite/family/task/node7/node8 == complete) or (((/suite/family:attrib1*10000)+(/suite/family/task:attrib2*100)+1) > /node4/node5/node6:attrib3)) and /node4/node5/node9/node10/node11:attrib3 >= /node4/node5/node6:attrib3)",
+      "expected": "(((((((/suite/family:attrib1 * 10000) + (/suite/family/task:attrib2 * 100)) + 1) == /node4/node5/node6:attrib3) and (/suite/family/task/node7/node8 == complete)) or ((((/suite/family:attrib1 * 10000) + (/suite/family/task:attrib2 * 100)) + 1) > /node4/node5/node6:attrib3)) and (/node4/node5/node9/node10/node11:attrib3 >= /node4/node5/node6:attrib3))"
+    },
+    {
+      "expression": "((((/suite/family:attrib1*10000)+(/suite/family/task:attrib2*100)+1) > (/node4/node5/node6:attrib3)))",
+      "expected": "((((/suite/family:attrib1 * 10000) + (/suite/family/task:attrib2 * 100)) + 1) > /node4/node5/node6:attrib3)"
+    },
+    {
+      "expression": "(suite == complete and family == complete and (task:attrib1 < node4:attrib1 or task:attrib1 == node4:attrib1 and node4/node5 == complete))",
+      "expected": "(((suite == complete) and (family == complete)) and ((task:attrib1 < node4:attrib1) or ((task:attrib1 == node4:attrib1) and (node4/node5 == complete))))"
+    },
+    {
+      "expression": "(((((/suite/family:attrib1*10000)+(/suite/family/task:attrib2*100)+1) == /node4/node5/node6:attrib3 and /suite/family/task/node7/node8 == complete) or (((/suite/family:attrib1*10000)+(/suite/family/task:attrib2*100)+1) > /node4/node5/node6:attrib3)) and /node4/node5/node9/node10/node11:attrib3 > /node4/node5/node6:attrib3)",
+      "expected": "(((((((/suite/family:attrib1 * 10000) + (/suite/family/task:attrib2 * 100)) + 1) == /node4/node5/node6:attrib3) and (/suite/family/task/node7/node8 == complete)) or ((((/suite/family:attrib1 * 10000) + (/suite/family/task:attrib2 * 100)) + 1) > /node4/node5/node6:attrib3)) and (/node4/node5/node9/node10/node11:attrib3 > /node4/node5/node6:attrib3))"
+    },
+    {
+      "expression": "(/suite/family == complete and /suite/task == complete and node4:attrib1 < /suite/node5/node4/node6:attrib1)",
+      "expected": "(((/suite/family == complete) and (/suite/task == complete)) and (node4:attrib1 < /suite/node5/node4/node6:attrib1))"
+    },
+    {
+      "expression": "(/suite/family/task/node4:attrib1 >= ../task:attrib1 and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete)",
+      "expected": "((((((/suite/family/task/node4:attrib1 >= ../task:attrib1) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete))"
+    },
+    {
+      "expression": "(../suite/family/task:attrib1 >= ../node4:attrib1 and node5 == complete)",
+      "expected": "((../suite/family/task:attrib1 >= ../node4:attrib1) and (node5 == complete))"
+    },
+    {
+      "expression": "(12 == complete and 06 == complete and 00 == complete and suite == complete)",
+      "expected": "((((12 == complete) and (06 == complete)) and (00 == complete)) and (suite == complete))"
+    },
+    {
+      "expression": "(12 == complete and (../suite:attrib1 < /family/task:attrib1 or ../suite:attrib1 == /family/task:attrib1 and /family/task/06 == complete) and node4/node5 == complete and node4/node6 == complete)",
+      "expected": "((12 == complete) and (((../suite:attrib1 < /family/task:attrib1) or ((../suite:attrib1 == /family/task:attrib1) and (/family/task/06 == complete))) and ((node4/node5 == complete) and (node4/node6 == complete))))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 < /suite/task:attrib1 or /suite/family:attrib1 == /suite/task:attrib1 and (/suite/task/06/node4/node5:attrib2 or /suite/task/06/node4 == complete)) and node6 == complete)",
+      "expected": "(((/suite/family:attrib1 < /suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/task/06/node4/node5:attrib2 or (/suite/task/06/node4 == complete)))) and (node6 == complete))"
+    },
+    {
+      "expression": "(../5/suite/family:attrib1 or ../5/task/family:attrib1 or ../5/node4/family:attrib1 or ../4/node5/family:attrib1 or ../4/suite/family:attrib1 or ../4/task/family:attrib1 or ../4/node4/family:attrib1 or ../3/node5/family:attrib1 or ../3/suite/family:attrib1 or ../3/task/family:attrib1 or ../3/node4/family:attrib1 or node5/family:attrib1 or suite/family:attrib1)",
+      "expected": "(../5/suite/family:attrib1 or (../5/task/family:attrib1 or (../5/node4/family:attrib1 or (../4/node5/family:attrib1 or (../4/suite/family:attrib1 or (../4/task/family:attrib1 or (../4/node4/family:attrib1 or (../3/node5/family:attrib1 or (../3/suite/family:attrib1 or (../3/task/family:attrib1 or (../3/node4/family:attrib1 or (node5/family:attrib1 or suite/family:attrib1))))))))))))"
+    },
+    {
+      "expression": "(../5/suite/family:attrib1 or ../5/task/family:attrib1 or ../5/node4/family:attrib1 or ../4/node5/family:attrib1 or ../4/suite/family:attrib1 or ../4/task/family:attrib1 or ../4/node4/family:attrib1 or ../3/node5/family:attrib1 or ../3/suite/family:attrib1 or ../3/task/family:attrib1 or ../3/node4/family:attrib1 or node5/family:attrib1 or suite/family:attrib1 or task/family:attrib1)",
+      "expected": "(../5/suite/family:attrib1 or (../5/task/family:attrib1 or (../5/node4/family:attrib1 or (../4/node5/family:attrib1 or (../4/suite/family:attrib1 or (../4/task/family:attrib1 or (../4/node4/family:attrib1 or (../3/node5/family:attrib1 or (../3/suite/family:attrib1 or (../3/task/family:attrib1 or (../3/node4/family:attrib1 or (node5/family:attrib1 or (suite/family:attrib1 or task/family:attrib1)))))))))))))"
+    },
+    {
+      "expression": "(../5/suite/family:attrib1 or ../5/task/family:attrib1 or ../5/node4/family:attrib1 or ../4/node5/family:attrib1 or ../4/suite/family:attrib1 or ../4/task/family:attrib1 or ../4/node4/family:attrib1 or ../3/node5/family:attrib1 or ../3/suite/family:attrib1 or ../3/task/family:attrib1 or ../3/node4/family:attrib1 or node5/family:attrib1 or suite/family:attrib1 or task/family:attrib1 or node4/family:attrib1)",
+      "expected": "(../5/suite/family:attrib1 or (../5/task/family:attrib1 or (../5/node4/family:attrib1 or (../4/node5/family:attrib1 or (../4/suite/family:attrib1 or (../4/task/family:attrib1 or (../4/node4/family:attrib1 or (../3/node5/family:attrib1 or (../3/suite/family:attrib1 or (../3/task/family:attrib1 or (../3/node4/family:attrib1 or (node5/family:attrib1 or (suite/family:attrib1 or (task/family:attrib1 or node4/family:attrib1))))))))))))))"
+    },
+    {
+      "expression": "(../5/suite/family:attrib1 or ../5/task/family:attrib1 or ../5/node4/family:attrib1 or ../4/node5/family:attrib1 or ../4/suite/family:attrib1 or ../4/task/family:attrib1 or ../4/node4/family:attrib1 or ../3/node5/family:attrib1 or ../3/suite/family:attrib1 or ../3/task/family:attrib1 or ../3/node4/family:attrib1 or ../2/node5/family:attrib1 or ../2/suite/family:attrib1 or ../2/task/family:attrib1 or ../2/node4/family:attrib1 or node5/family:attrib1)",
+      "expected": "(../5/suite/family:attrib1 or (../5/task/family:attrib1 or (../5/node4/family:attrib1 or (../4/node5/family:attrib1 or (../4/suite/family:attrib1 or (../4/task/family:attrib1 or (../4/node4/family:attrib1 or (../3/node5/family:attrib1 or (../3/suite/family:attrib1 or (../3/task/family:attrib1 or (../3/node4/family:attrib1 or (../2/node5/family:attrib1 or (../2/suite/family:attrib1 or (../2/task/family:attrib1 or (../2/node4/family:attrib1 or node5/family:attrib1)))))))))))))))"
+    },
+    {
+      "expression": "(../5/suite/family:attrib1 or ../5/task/family:attrib1 or ../5/node4/family:attrib1 or ../4/node5/family:attrib1 or ../4/suite/family:attrib1 or ../4/task/family:attrib1 or ../4/node4/family:attrib1 or ../3/node5/family:attrib1 or ../3/suite/family:attrib1 or ../3/task/family:attrib1 or ../3/node4/family:attrib1 or ../2/node5/family:attrib1 or ../2/suite/family:attrib1 or ../2/task/family:attrib1 or ../2/node4/family:attrib1 or node5/family:attrib1 or suite/family:attrib1)",
+      "expected": "(../5/suite/family:attrib1 or (../5/task/family:attrib1 or (../5/node4/family:attrib1 or (../4/node5/family:attrib1 or (../4/suite/family:attrib1 or (../4/task/family:attrib1 or (../4/node4/family:attrib1 or (../3/node5/family:attrib1 or (../3/suite/family:attrib1 or (../3/task/family:attrib1 or (../3/node4/family:attrib1 or (../2/node5/family:attrib1 or (../2/suite/family:attrib1 or (../2/task/family:attrib1 or (../2/node4/family:attrib1 or (node5/family:attrib1 or suite/family:attrib1))))))))))))))))"
+    },
+    {
+      "expression": "(../5/suite/family:attrib1 or ../5/task/family:attrib1 or ../5/node4/family:attrib1 or ../4/node5/family:attrib1 or ../4/suite/family:attrib1 or ../4/task/family:attrib1 or ../4/node4/family:attrib1 or ../3/node5/family:attrib1 or ../3/suite/family:attrib1 or ../3/task/family:attrib1 or ../3/node4/family:attrib1 or ../2/node5/family:attrib1 or ../2/suite/family:attrib1 or ../2/task/family:attrib1 or ../2/node4/family:attrib1 or node5/family:attrib1 or suite/family:attrib1 or task/family:attrib1)",
+      "expected": "(../5/suite/family:attrib1 or (../5/task/family:attrib1 or (../5/node4/family:attrib1 or (../4/node5/family:attrib1 or (../4/suite/family:attrib1 or (../4/task/family:attrib1 or (../4/node4/family:attrib1 or (../3/node5/family:attrib1 or (../3/suite/family:attrib1 or (../3/task/family:attrib1 or (../3/node4/family:attrib1 or (../2/node5/family:attrib1 or (../2/suite/family:attrib1 or (../2/task/family:attrib1 or (../2/node4/family:attrib1 or (node5/family:attrib1 or (suite/family:attrib1 or task/family:attrib1)))))))))))))))))"
+    },
+    {
+      "expression": "(../5/suite/family:attrib1 or ../5/task/family:attrib1 or ../5/node4/family:attrib1 or ../4/node5/family:attrib1 or ../4/suite/family:attrib1 or ../4/task/family:attrib1 or ../4/node4/family:attrib1 or ../3/node5/family:attrib1 or ../3/suite/family:attrib1 or ../3/task/family:attrib1 or ../3/node4/family:attrib1 or ../2/node5/family:attrib1 or ../2/suite/family:attrib1 or ../2/task/family:attrib1 or ../2/node4/family:attrib1 or node5/family:attrib1 or suite/family:attrib1 or task/family:attrib1 or node4/family:attrib1)",
+      "expected": "(../5/suite/family:attrib1 or (../5/task/family:attrib1 or (../5/node4/family:attrib1 or (../4/node5/family:attrib1 or (../4/suite/family:attrib1 or (../4/task/family:attrib1 or (../4/node4/family:attrib1 or (../3/node5/family:attrib1 or (../3/suite/family:attrib1 or (../3/task/family:attrib1 or (../3/node4/family:attrib1 or (../2/node5/family:attrib1 or (../2/suite/family:attrib1 or (../2/task/family:attrib1 or (../2/node4/family:attrib1 or (node5/family:attrib1 or (suite/family:attrib1 or (task/family:attrib1 or node4/family:attrib1))))))))))))))))))"
+    },
+    {
+      "expression": "(../5/suite/family:attrib1 or ../5/task/family:attrib1 or ../5/node4/family:attrib1 or ../4/node5/family:attrib1 or ../4/suite/family:attrib1 or ../4/task/family:attrib1 or ../4/node4/family:attrib1 or ../3/node5/family:attrib1 or ../3/suite/family:attrib1 or ../3/task/family:attrib1 or ../3/node4/family:attrib1 or ../2/node5/family:attrib1 or ../2/suite/family:attrib1 or ../2/task/family:attrib1 or ../2/node4/family:attrib1 or ../1/node5/family:attrib1 or ../1/suite/family:attrib1 or ../1/task/family:attrib1 or ../1/node4/family:attrib1 or node5/family:attrib1)",
+      "expected": "(../5/suite/family:attrib1 or (../5/task/family:attrib1 or (../5/node4/family:attrib1 or (../4/node5/family:attrib1 or (../4/suite/family:attrib1 or (../4/task/family:attrib1 or (../4/node4/family:attrib1 or (../3/node5/family:attrib1 or (../3/suite/family:attrib1 or (../3/task/family:attrib1 or (../3/node4/family:attrib1 or (../2/node5/family:attrib1 or (../2/suite/family:attrib1 or (../2/task/family:attrib1 or (../2/node4/family:attrib1 or (../1/node5/family:attrib1 or (../1/suite/family:attrib1 or (../1/task/family:attrib1 or (../1/node4/family:attrib1 or node5/family:attrib1)))))))))))))))))))"
+    },
+    {
+      "expression": "(06 == complete and suite/family == complete and suite/task == complete)",
+      "expected": "(((06 == complete) and (suite/family == complete)) and (suite/task == complete))"
+    },
+    {
+      "expression": "(suite:attrib1 <= /family/task/suite/node4:attrib1 and suite:attrib1 < node5/node6/node7:attrib2)",
+      "expected": "((suite:attrib1 <= /family/task/suite/node4:attrib1) and (suite:attrib1 < node5/node6/node7:attrib2))"
+    },
+    {
+      "expression": "(((suite:attrib1+4) le :attrib2 and family eq complete and :attrib3 ge 645) or :attrib4)",
+      "expected": "(((((suite:attrib1 + 4) <= :attrib2) and (family == complete)) and (:attrib3 >= 645)) or :attrib4)"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt ../../../task:attrib1 or (node4 eq complete and node5 eq complete and node6 eq complete and node7 eq complete and node8 eq complete))",
+      "expected": "((/suite/family:attrib1 > ../../../task:attrib1) or (((((node4 == complete) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4/node5 eq complete or ../node6 eq complete) and (/node7/family:attrib1 ge /node8/node5:attrib1))",
+      "expected": "(((/suite/family/12/task/node4/node5 == complete) or (../node6 == complete)) and (/node7/family:attrib1 >= /node8/node5:attrib1))"
+    },
+    {
+      "expression": "(suite == complete and (/family/0001/task/node4/node5:attrib1 lt /node6/0001/task/node4/node7:attrib1 + 2))",
+      "expected": "((suite == complete) and (/family/0001/task/node4/node5:attrib1 < (/node6/0001/task/node4/node7:attrib1 + 2)))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 ge ../task:attrib1 or (/suite/family:attrib1 + 1 eq ../task:attrib1 and /suite/family/00/node4/node5 eq complete))",
+      "expected": "((/suite/family:attrib1 >= ../task:attrib1) or (((/suite/family:attrib1 + 1) == ../task:attrib1) and (/suite/family/00/node4/node5 == complete)))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt (:attrib1 - 1) or (/suite/family:attrib1 eq (:attrib1 - 1) and /suite/family/00 eq complete))",
+      "expected": "((/suite/family:attrib1 > (:attrib1 - 1)) or ((/suite/family:attrib1 == (:attrib1 - 1)) and (/suite/family/00 == complete)))"
+    },
+    {
+      "expression": "(../suite/family/task:attrib1 + 1 < ../node4/node5:attrib2)",
+      "expected": "((../suite/family/task:attrib1 + 1) < ../node4/node5:attrib2)"
+    },
+    {
+      "expression": "(../suite/family/task:attrib1 + 1 < ../suite/family:attrib2 or ../suite/family/node4:attrib1 + 1 < ../suite/family:attrib2)",
+      "expected": "(((../suite/family/task:attrib1 + 1) < ../suite/family:attrib2) or ((../suite/family/node4:attrib1 + 1) < ../suite/family:attrib2))"
+    },
+    {
+      "expression": "(:attrib1 < :attrib2 or (:attrib1 == :attrib2 and :attrib3 >= 0630))",
+      "expected": "((:attrib1 < :attrib2) or ((:attrib1 == :attrib2) and (:attrib3 >= 630)))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 > :attrib2 - 1 or (/suite/family/task:attrib1 == :attrib2 - 1 and /suite/family/task/00 == complete))",
+      "expected": "((/suite/family/task:attrib1 > (:attrib2 - 1)) or ((/suite/family/task:attrib1 == (:attrib2 - 1)) and (/suite/family/task/00 == complete)))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 > ( :attrib2 * 100 ))",
+      "expected": "(/suite/family:attrib1 > (:attrib2 * 100))"
+    },
+    {
+      "expression": "(/suite/family/task/node4/00:attrib1 > :attrib2 or (/suite/family/task/node4/00:attrib1 == :attrib2 and /suite/family/task/node4/00/node5 == complete))",
+      "expected": "((/suite/family/task/node4/00:attrib1 > :attrib2) or ((/suite/family/task/node4/00:attrib1 == :attrib2) and (/suite/family/task/node4/00/node5 == complete)))"
+    },
+    {
+      "expression": "(( (/suite/family:attrib1 / 100) gt ../task:attrib1) or ( (/suite/family:attrib1 / 100) eq ../task:attrib1 and /suite/family eq complete ))",
+      "expected": "(((/suite/family:attrib1 / 100) > ../task:attrib1) or (((/suite/family:attrib1 / 100) == ../task:attrib1) and (/suite/family == complete)))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 / 100 gt ../task:attrib1 or ( /suite/family:attrib1 / 100 eq ../task:attrib1 and /suite/family eq complete ))",
+      "expected": "(((/suite/family:attrib1 / 100) > ../task:attrib1) or (((/suite/family:attrib1 / 100) == ../task:attrib1) and (/suite/family == complete)))"
+    },
+    {
+      "expression": "((/suite/family/00/task/node4/node5 eq complete and (/suite/family:attrib1 eq /node6/node7/node8/00:attrib1)) or (/suite/family:attrib1 gt /node6/node7/node8/00:attrib1))",
+      "expected": "(((/suite/family/00/task/node4/node5 == complete) and (/suite/family:attrib1 == /node6/node7/node8/00:attrib1)) or (/suite/family:attrib1 > /node6/node7/node8/00:attrib1))"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4==complete and /suite/family:attrib1 eq :attrib1) or /suite/family:attrib1 gt :attrib1)",
+      "expected": "(((/suite/family/12/task/node4 == complete) and (/suite/family:attrib1 == :attrib1)) or (/suite/family:attrib1 > :attrib1))"
+    },
+    {
+      "expression": "(1)",
+      "expected": "1"
+    },
+    {
+      "expression": "(../suite/family/task/node4==complete or ../suite/family/task/node5:attrib1 gt ../node6:attrib1)",
+      "expected": "((../suite/family/task/node4 == complete) or (../suite/family/task/node5:attrib1 > ../node6:attrib1))"
+    },
+    {
+      "expression": "(/suite:attrib1 ge 01 and /suite:attrib2 gt 0500 AND family == complete and task == complete)",
+      "expected": "((((/suite:attrib1 >= 1) and (/suite:attrib2 > 500)) and (family == complete)) and (task == complete))"
+    },
+    {
+      "expression": "((suite == complete and ../family == complete) and (../task/node4/node5/node6 == complete and ../node7/node4/node5/node6 == complete and ../node8/node4/node5/node6 == complete and ../node9/node4/node5/node6 == complete and ../node10/node4/node5/node6 == complete and ../node11/node4/node5/node6 == complete and ../node12/node4/node5/node6 == complete and ../node13/node14/node4/node5/node6 == complete and ../node13/node15/node4/node5/node6 == complete))",
+      "expected": "(((suite == complete) and (../family == complete)) and (((((((((../task/node4/node5/node6 == complete) and (../node7/node4/node5/node6 == complete)) and (../node8/node4/node5/node6 == complete)) and (../node9/node4/node5/node6 == complete)) and (../node10/node4/node5/node6 == complete)) and (../node11/node4/node5/node6 == complete)) and (../node12/node4/node5/node6 == complete)) and (../node13/node14/node4/node5/node6 == complete)) and (../node13/node15/node4/node5/node6 == complete)))"
+    },
+    {
+      "expression": "(12 == complete and 06 == complete and 00 == complete)",
+      "expected": "(((12 == complete) and (06 == complete)) and (00 == complete))"
+    },
+    {
+      "expression": "(../../suite:attrib1 ne family:attrib1)",
+      "expected": "(../../suite:attrib1 != family:attrib1)"
+    },
+    {
+      "expression": "(not (../../../suite:attrib1))",
+      "expected": "not (../../../suite:attrib1)"
+    },
+    {
+      "expression": "(../suite/family:attrib1 gt task:attrib1 or ../node4/node5/node6:attrib2)",
+      "expected": "((../suite/family:attrib1 > task:attrib1) or ../node4/node5/node6:attrib2)"
+    },
+    {
+      "expression": "((../suite/family:attrib1 gt family:attrib1 or (../suite/family:attrib1 eq family:attrib1 and ../suite/family eq complete)) or ../task/node4/node5:attrib2)",
+      "expected": "(((../suite/family:attrib1 > family:attrib1) or ((../suite/family:attrib1 == family:attrib1) and (../suite/family == complete))) or ../task/node4/node5:attrib2)"
+    },
+    {
+      "expression": "(/suite/family/task/node4/00 eq complete and /suite/family/task/node4/00:attrib1 eq 0 and /node5/node4/00/node6/node7 eq complete and /node5/node4/12/node6/node7 eq complete)",
+      "expected": "((((/suite/family/task/node4/00 == complete) and (/suite/family/task/node4/00:attrib1 == 0)) and (/node5/node4/00/node6/node7 == complete)) and (/node5/node4/12/node6/node7 == complete))"
+    },
+    {
+      "expression": "((suite/family:attrib1 >= task:attrib1) and node4 == complete)",
+      "expected": "((suite/family:attrib1 >= task:attrib1) and (node4 == complete))"
+    },
+    {
+      "expression": "(../suite:attrib1 > ../family:attrib1 or ../suite:attrib1 == ../family:attrib1 and ../suite/task == complete)",
+      "expected": "((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and (../suite/task == complete)))"
+    },
+    {
+      "expression": "(((((/suite/family:attrib1*10000)+(/suite/family/task:attrib2*100)+1) == /node4/node5/node6:attrib3 and /suite/family/task/node7/node8 == complete))or (((/suite/family:attrib1*10000)+(/suite/family/task:attrib2*100)+1) > /node4/node5/node6:attrib3))",
+      "expected": "((((((/suite/family:attrib1 * 10000) + (/suite/family/task:attrib2 * 100)) + 1) == /node4/node5/node6:attrib3) and (/suite/family/task/node7/node8 == complete)) or ((((/suite/family:attrib1 * 10000) + (/suite/family/task:attrib2 * 100)) + 1) > /node4/node5/node6:attrib3))"
+    },
+    {
+      "expression": "((((/suite/family:attrib1*10000)+(/suite/family/task:attrib2*100)+1) > /node4/node5/node6:attrib3))",
+      "expected": "((((/suite/family:attrib1 * 10000) + (/suite/family/task:attrib2 * 100)) + 1) > /node4/node5/node6:attrib3)"
+    },
+    {
+      "expression": "(suite == complete and family:attrib1 <= task/node4:attrib1)",
+      "expected": "((suite == complete) and (family:attrib1 <= task/node4:attrib1))"
+    },
+    {
+      "expression": "(../suite:attrib1 > ../family:attrib1 and task == complete and 06 == complete and 18 == complete and node4 == complete)",
+      "expected": "(((((../suite:attrib1 > ../family:attrib1) and (task == complete)) and (06 == complete)) and (18 == complete)) and (node4 == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 == /task/node4:attrib1 and /suite/family/12/node5/node6 == complete) or (/suite/family:attrib1 > /task/node4:attrib1) and /task/node7/12/node4/node8:attrib1 > /task/node4:attrib1)",
+      "expected": "(((/suite/family:attrib1 == /task/node4:attrib1) and (/suite/family/12/node5/node6 == complete)) or ((/suite/family:attrib1 > /task/node4:attrib1) and (/task/node7/12/node4/node8:attrib1 > /task/node4:attrib1)))"
+    },
+    {
+      "expression": "((cal::date_to_julian(/suite/family/task/node4:attrib1) == cal::date_to_julian(/node5/node6:attrib1)and /suite/family/task/node4/node7/node8 == complete) or (cal::date_to_julian(/suite/family/task/node4:attrib1) > cal::date_to_julian(/node5/node6:attrib1)))",
+      "expected": "(((date_to_julian(arg:0) = 0 == date_to_julian(arg:0) = 0) and (/suite/family/task/node4/node7/node8 == complete)) or (date_to_julian(arg:0) = 0 > date_to_julian(arg:0) = 0))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 == /task/node4:attrib1 and /suite/family/00/node5/node6 == complete) or (/suite/family:attrib1 > /task/node4:attrib1) and /task/node7/00/node4 == complete)",
+      "expected": "(((/suite/family:attrib1 == /task/node4:attrib1) and (/suite/family/00/node5/node6 == complete)) or ((/suite/family:attrib1 > /task/node4:attrib1) and (/task/node7/00/node4 == complete)))"
+    },
+    {
+      "expression": "(23 eq complete)",
+      "expected": "(23 == complete)"
+    },
+    {
+      "expression": "((((((((((((((((((((((((((00 eq complete) and (01 eq complete)) and (02 eq complete)) and (03 eq complete)) and (04 eq complete)) and (05 eq complete)) and (06 eq complete)) and (07 eq complete)) and (08 eq complete)) and (09 eq complete)) and (10 eq complete)) and (11 eq complete)) and (12 eq complete)) and (13 eq complete)) and (14 eq complete)) and (15 eq complete)) and (16 eq complete)) and (17 eq complete)) and (18 eq complete)) and (19 eq complete)) and (20 eq complete)) and (21 eq complete)) and (22 eq complete)) and (23 eq complete)) and (suite eq complete)) and (family eq complete))",
+      "expected": "((((((((((((((((((((((((((00 == complete) and (01 == complete)) and (02 == complete)) and (03 == complete)) and (04 == complete)) and (05 == complete)) and (06 == complete)) and (07 == complete)) and (08 == complete)) and (09 == complete)) and (10 == complete)) and (11 == complete)) and (12 == complete)) and (13 == complete)) and (14 == complete)) and (15 == complete)) and (16 == complete)) and (17 == complete)) and (18 == complete)) and (19 == complete)) and (20 == complete)) and (21 == complete)) and (22 == complete)) and (23 == complete)) and (suite == complete)) and (family == complete))"
+    },
+    {
+      "expression": "(:attrib1/100 < :attrib2 or (:attrib1/100 == :attrib2 and :attrib3 >= 400))",
+      "expected": "(((:attrib1 / 100) < :attrib2) or (((:attrib1 / 100) == :attrib2) and (:attrib3 >= 400)))"
+    },
+    {
+      "expression": "(suite == complete and (family == complete or family == aborted))",
+      "expected": "((suite == complete) and ((family == complete) or (family == aborted)))"
+    },
+    {
+      "expression": "(suite:attrib1 < family:attrib1 or (suite:attrib1 == family:attrib1 and family/task == complete))",
+      "expected": "((suite:attrib1 < family:attrib1) or ((suite:attrib1 == family:attrib1) and (family/task == complete)))"
+    },
+    {
+      "expression": "(suite==complete and ((:attrib1==1 and (:attrib2>:attrib3 or (:attrib2==:attrib3 and :attrib4>1910))) or (:attrib1==0 and (:attrib2>:attrib3 + 1 or (:attrib2==:attrib3 + 1 and :attrib4>600)))) and :attrib3 < /family/task:attrib3 and :attrib3 < /node4/node5:attrib3)",
+      "expected": "((suite == complete) and ((((:attrib1 == 1) and ((:attrib2 > :attrib3) or ((:attrib2 == :attrib3) and (:attrib4 > 1910)))) or ((:attrib1 == 0) and ((:attrib2 > (:attrib3 + 1)) or ((:attrib2 == (:attrib3 + 1)) and (:attrib4 > 600))))) and ((:attrib3 < /family/task:attrib3) and (:attrib3 < /node4/node5:attrib3))))"
+    },
+    {
+      "expression": "(suite==complete and ((:attrib1==1 and (:attrib2>:attrib3 + 1 or (:attrib2==:attrib3 + 1 and :attrib4>710))) or (:attrib1==0 and (:attrib2>:attrib3 + 1 or (:attrib2==:attrib3 + 1 and :attrib4>1800)))) and :attrib3 < /family/task:attrib3 and :attrib3 < /node4/node5:attrib3)",
+      "expected": "((suite == complete) and ((((:attrib1 == 1) and ((:attrib2 > (:attrib3 + 1)) or ((:attrib2 == (:attrib3 + 1)) and (:attrib4 > 710)))) or ((:attrib1 == 0) and ((:attrib2 > (:attrib3 + 1)) or ((:attrib2 == (:attrib3 + 1)) and (:attrib4 > 1800))))) and ((:attrib3 < /family/task:attrib3) and (:attrib3 < /node4/node5:attrib3))))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt ../../../task:attrib1 and /node4/family:attrib1 gt ../../../task:attrib1) or (node5 eq complete and node6 eq complete and node7 eq complete and node8 eq complete and node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete and node13 eq complete))",
+      "expected": "(((/suite/family:attrib1 > ../../../task:attrib1) and (/node4/family:attrib1 > ../../../task:attrib1)) or (((((((((node5 == complete) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)))"
+    },
+    {
+      "expression": "((((((((((((((((((((((((./12 eq complete and ./13 eq complete) and ./14 eq complete) and ./15 eq complete) and ./16 eq complete) and ./17 eq complete) and ./18 eq complete) and ./19 eq complete) and ./20 eq complete) and ./21 eq complete) and ./22 eq complete) and ./23 eq complete) and ./00 eq complete) and ./01 eq complete) and ./02 eq complete) and ./03 eq complete) and ./04 eq complete) and ./05 eq complete) and ./06 eq complete) and ./07 eq complete) and ./08 eq complete) and ./09 eq complete) and ./10 eq complete) and ./11 eq complete) and suite eq complete)",
+      "expected": "(((((((((((((((((((((((((./12 == complete) and (./13 == complete)) and (./14 == complete)) and (./15 == complete)) and (./16 == complete)) and (./17 == complete)) and (./18 == complete)) and (./19 == complete)) and (./20 == complete)) and (./21 == complete)) and (./22 == complete)) and (./23 == complete)) and (./00 == complete)) and (./01 == complete)) and (./02 == complete)) and (./03 == complete)) and (./04 == complete)) and (./05 == complete)) and (./06 == complete)) and (./07 == complete)) and (./08 == complete)) and (./09 == complete)) and (./10 == complete)) and (./11 == complete)) and (suite == complete))"
+    },
+    {
+      "expression": "((suite == complete) and (suite:attrib1))",
+      "expected": "((suite == complete) and suite:attrib1)"
+    },
+    {
+      "expression": "((((suite == complete) and (family == complete)) and (task == complete)) and (node4/node5 == complete))",
+      "expected": "((((suite == complete) and (family == complete)) and (task == complete)) and (node4/node5 == complete))"
+    },
+    {
+      "expression": "(((((suite == complete) and (family == complete)) and (task == complete)) and (node4/node5 == complete)) and (node6 == complete))",
+      "expected": "(((((suite == complete) and (family == complete)) and (task == complete)) and (node4/node5 == complete)) and (node6 == complete))"
+    },
+    {
+      "expression": "(:attrib1 ge (245 + :attrib2 + :attrib3) AND :attrib4 gt :attrib5)",
+      "expected": "((:attrib1 >= ((245 + :attrib2) + :attrib3)) and (:attrib4 > :attrib5))"
+    },
+    {
+      "expression": "((:attrib1 eq 0 or (suite/family/task/node4/task/node5 eq complete)) AND node6 == complete and ../../node7/node8 eq complete)",
+      "expected": "(((:attrib1 == 0) or (suite/family/task/node4/task/node5 == complete)) and ((node6 == complete) and (../../node7/node8 == complete)))"
+    },
+    {
+      "expression": "((:attrib1 eq 0 or (suite/family/task/node4/task/node5 ne queued)) AND node6 == complete and (/node7/node8/12 eq complete or /node7/node8/12 eq complete) and ../../node9/node10 eq complete)",
+      "expected": "(((:attrib1 == 0) or (suite/family/task/node4/task/node5 != queued)) and ((node6 == complete) and (((/node7/node8/12 == complete) or (/node7/node8/12 == complete)) and (../../node9/node10 == complete))))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete AND node6 == complete and ../../node7 eq complete)",
+      "expected": "(((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (../../node7 == complete))"
+    },
+    {
+      "expression": "(suite == complete and :attrib1 gt 1400 or :attrib2 gt :attrib3)",
+      "expected": "(((suite == complete) and (:attrib1 > 1400)) or (:attrib2 > :attrib3))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /task/family:attrib1) or (/suite/family:attrib1 eq /task/family:attrib1 and /suite/family/00/node4==complete) or /suite/family/00 eq complete)",
+      "expected": "((/suite/family:attrib1 > /task/family:attrib1) or (((/suite/family:attrib1 == /task/family:attrib1) and (/suite/family/00/node4 == complete)) or (/suite/family/00 == complete)))"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4 == complete and :attrib1 ge :attrib2)",
+      "expected": "((/suite/family/12/task/node4 == complete) and (:attrib1 >= :attrib2))"
+    },
+    {
+      "expression": "(/suite/family/12/task:attrib1 gt 0 or /suite/family/12/node4:attrib2 gt 0)",
+      "expected": "((/suite/family/12/task:attrib1 > 0) or (/suite/family/12/node4:attrib2 > 0))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /task/family:attrib1) or (/suite/family:attrib1 eq /task/family:attrib1 and /suite/family/12/node4==complete) or (/suite/family/12 eq complete and 1==0))",
+      "expected": "((/suite/family:attrib1 > /task/family:attrib1) or (((/suite/family:attrib1 == /task/family:attrib1) and (/suite/family/12/node4 == complete)) or ((/suite/family/12 == complete) and (1 == 0))))"
+    },
+    {
+      "expression": "(/suite/family/00/task/node4 == complete and :attrib1 ge :attrib2 and :attrib3 gt 500)",
+      "expected": "(((/suite/family/00/task/node4 == complete) and (:attrib1 >= :attrib2)) and (:attrib3 > 500))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt /task/family:attrib1 or :attrib2 ge 1645)",
+      "expected": "((/suite/family:attrib1 > /task/family:attrib1) or (:attrib2 >= 1645))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete) AND (/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node6==complete))",
+      "expected": "((/suite/family:attrib1 > /suite/task:attrib1) or (((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/12/node4/node5 == complete)) and ((/suite/family:attrib1 > /suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/12/node6 == complete)))))"
+    },
+    {
+      "expression": "(/suite/family/task/node4/node5:attrib1 ge 0 or /suite/family/task/node4/node6:attrib1 ge 0 or /suite/family/task/node4 eq complete or :attrib2)",
+      "expected": "((/suite/family/task/node4/node5:attrib1 >= 0) or ((/suite/family/task/node4/node6:attrib1 >= 0) or ((/suite/family/task/node4 == complete) or :attrib2)))"
+    },
+    {
+      "expression": "((./000/suite == complete) and (/family/task/node4/node5/node6:attrib1 ge 1 or /family/task/node4/node5/node7:attrib1 ge 1 or /family/task/node4/node5 eq complete or :attrib2))",
+      "expected": "((./000/suite == complete) and ((/family/task/node4/node5/node6:attrib1 >= 1) or ((/family/task/node4/node5/node7:attrib1 >= 1) or ((/family/task/node4/node5 == complete) or :attrib2))))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5:attrib1 ge 72 or /suite/family/task/node4/node6:attrib1 ge 72 or /suite/family/task/node4 eq complete or :attrib2) and /node7/family:attrib3 eq /suite/family:attrib3) or /node7/family:attrib3 lt /suite/family:attrib3)",
+      "expected": "((((/suite/family/task/node4/node5:attrib1 >= 72) or ((/suite/family/task/node4/node6:attrib1 >= 72) or ((/suite/family/task/node4 == complete) or :attrib2))) and (/node7/family:attrib3 == /suite/family:attrib3)) or (/node7/family:attrib3 < /suite/family:attrib3))"
+    },
+    {
+      "expression": "(suite == complete AND ../108/suite eq complete AND ../120/suite eq complete)",
+      "expected": "(((suite == complete) and (../108/suite == complete)) and (../120/suite == complete))"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4:attrib1 gt 180 or /suite/family/12/task/node4 eq complete) and /suite/family:attrib2 ge :attrib2)",
+      "expected": "(((/suite/family/12/task/node4:attrib1 > 180) or (/suite/family/12/task/node4 == complete)) and (/suite/family:attrib2 >= :attrib2))"
+    },
+    {
+      "expression": "(:attrib1 ge 20231120 and 0==1)",
+      "expected": "((:attrib1 >= 20231120) and (0 == 1))"
+    },
+    {
+      "expression": "(/suite/family/12/task:attrib1 gt 144 or /suite/family/12/task eq complete and /suite/family:attrib2 ge :attrib2)",
+      "expected": "((/suite/family/12/task:attrib1 > 144) or ((/suite/family/12/task == complete) and (/suite/family:attrib2 >= :attrib2)))"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4:attrib1 ge 180 or /suite/family/12/task/node4 eq complete and /suite/family:attrib2 ge :attrib2)",
+      "expected": "((/suite/family/12/task/node4:attrib1 >= 180) or ((/suite/family/12/task/node4 == complete) and (/suite/family:attrib2 >= :attrib2)))"
+    },
+    {
+      "expression": "(:attrib1 gt :attrib2 and (:attrib3 gt 1000 or /suite/family/00/task/node4 eq complete))",
+      "expected": "((:attrib1 > :attrib2) and ((:attrib3 > 1000) or (/suite/family/00/task/node4 == complete)))"
+    },
+    {
+      "expression": "(./12 == complete and ./18 == complete and ./00 == complete and ./06 == complete AND :attrib1 gt 1402 or ( /suite/family:attrib2 gt :attrib2 AND /task/family:attrib2 gt :attrib2))",
+      "expected": "((((((./12 == complete) and (./18 == complete)) and (./00 == complete)) and (./06 == complete)) and (:attrib1 > 1402)) or ((/suite/family:attrib2 > :attrib2) and (/task/family:attrib2 > :attrib2)))"
+    },
+    {
+      "expression": "(./12 == complete and ./18 == complete and ./00 == complete and ./06 == complete AND /suite/family:attrib1 gt /task/node4:attrib1)",
+      "expected": "(((((./12 == complete) and (./18 == complete)) and (./00 == complete)) and (./06 == complete)) and (/suite/family:attrib1 > /task/node4:attrib1))"
+    },
+    {
+      "expression": "((suite == complete) and (suite == complete and family == complete and /task/node4/node5/node6 == complete))",
+      "expected": "((suite == complete) and (((suite == complete) and (family == complete)) and (/task/node4/node5/node6 == complete)))"
+    },
+    {
+      "expression": "((../suite/family == complete) or (:attrib1 == 0))",
+      "expected": "((../suite/family == complete) or (:attrib1 == 0))"
+    },
+    {
+      "expression": "((../suite == complete and ../family == complete) or (:attrib1 == 0))",
+      "expected": "(((../suite == complete) and (../family == complete)) or (:attrib1 == 0))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and ./task/node4 == complete and (./task/node4 == complete or ./task/node4/node5:attrib1))",
+      "expected": "((((suite == complete) and (family == complete)) and (./task/node4 == complete)) and ((./task/node4 == complete) or ./task/node4/node5:attrib1))"
+    },
+    {
+      "expression": "(:attrib1 gt (:attrib2+1) or (:attrib3 eq 12 and :attrib4 gt 1715))",
+      "expected": "((:attrib1 > (:attrib2 + 1)) or ((:attrib3 == 12) and (:attrib4 > 1715)))"
+    },
+    {
+      "expression": "(:attrib1 gt (:attrib2+1) or (:attrib3 eq 0 and :attrib4 gt 530 and :attrib4 le 1100))",
+      "expected": "((:attrib1 > (:attrib2 + 1)) or (((:attrib3 == 0) and (:attrib4 > 530)) and (:attrib4 <= 1100)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7 eq active or /suite/family/task/node4/node5/node6/node7 eq complete) or ../node8 eq complete) and (/suite/family:attrib1 ge /node9/node10/node11:attrib1))",
+      "expected": "((((/suite/family/task/node4/node5/node6/node7 == active) or (/suite/family/task/node4/node5/node6/node7 == complete)) or (../node8 == complete)) and (/suite/family:attrib1 >= /node9/node10/node11:attrib1))"
+    },
+    {
+      "expression": "((((/suite/family/12/task/node4:attrib1 ge node5:attrib2 or /suite/family/12/task/node6:attrib1 ge node5:attrib2) or /suite/family/12/task/node6 eq aborted) or /suite/family/12/task/node6 eq complete) or /suite/family:attrib3 gt :attrib3)",
+      "expected": "(((((/suite/family/12/task/node4:attrib1 >= node5:attrib2) or (/suite/family/12/task/node6:attrib1 >= node5:attrib2)) or (/suite/family/12/task/node6 == aborted)) or (/suite/family/12/task/node6 == complete)) or (/suite/family:attrib3 > :attrib3))"
+    },
+    {
+      "expression": "(((((/suite/family/12/task:attrib1 ge 0 or /suite/family/12/node4:attrib2 ge 0) or /suite/family/12/node5/node6 eq complete) and ../../node7/node8 eq complete) or ../../node9 eq complete) and node10 eq complete)",
+      "expected": "((((((/suite/family/12/task:attrib1 >= 0) or (/suite/family/12/node4:attrib2 >= 0)) or (/suite/family/12/node5/node6 == complete)) and (../../node7/node8 == complete)) or (../../node9 == complete)) and (node10 == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt ../../../task:attrib1 and /node4/family:attrib1 gt ../../../task:attrib1) or (node5 eq complete and node6 eq complete and node7 eq complete and node8 eq complete and node9 eq complete))",
+      "expected": "(((/suite/family:attrib1 > ../../../task:attrib1) and (/node4/family:attrib1 > ../../../task:attrib1)) or (((((node5 == complete) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)))"
+    },
+    {
+      "expression": "(((((/suite/family/task/node4/node5/node6/node7 eq complete and (/node8/node9/00:attrib1 eq /node10/node11/node12:attrib1)) or (/node8/node9/00:attrib1 gt /node10/node11/node12:attrib1)) and ((/node8/node9/00:attrib1 gt /node10/node11/node12:attrib1) or ((/node8/node9/00:attrib1 eq /node10/node11/node12:attrib1) and /node10/node11/node13 eq complete))) or ../node14 eq complete) and (/node8/node9/00:attrib1 ge /node10/node11/node12:attrib1))",
+      "expected": "((((((/suite/family/task/node4/node5/node6/node7 == complete) and (/node8/node9/00:attrib1 == /node10/node11/node12:attrib1)) or (/node8/node9/00:attrib1 > /node10/node11/node12:attrib1)) and ((/node8/node9/00:attrib1 > /node10/node11/node12:attrib1) or ((/node8/node9/00:attrib1 == /node10/node11/node12:attrib1) and (/node10/node11/node13 == complete)))) or (../node14 == complete)) and (/node8/node9/00:attrib1 >= /node10/node11/node12:attrib1))"
+    },
+    {
+      "expression": "(/suite/family/task/node4/node5:attrib1 gt /node6/family/node7/00/node8:attrib1 or (node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete))",
+      "expected": "((/suite/family/task/node4/node5:attrib1 > /node6/family/node7/00/node8:attrib1) or ((((node9 == complete) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)))"
+    },
+    {
+      "expression": "((((/suite/family/task/node4/node5/node6 eq complete and /suite/family/task/node4/node5/node7/node8 eq complete) and /suite/family/task/node4/node5/node7/node9 eq complete) or ../node10 eq complete) and /suite/family/task/node4/node5:attrib1 >= /node11/family/node12/00/node13:attrib1)",
+      "expected": "(((((/suite/family/task/node4/node5/node6 == complete) and (/suite/family/task/node4/node5/node7/node8 == complete)) and (/suite/family/task/node4/node5/node7/node9 == complete)) or (../node10 == complete)) and (/suite/family/task/node4/node5:attrib1 >= /node11/family/node12/00/node13:attrib1))"
+    },
+    {
+      "expression": "((((/suite/family/task/node4/node5/node6 eq complete and /suite/family/task/node4/node5/node7/node8 eq complete) and /suite/family/task/node4/node5/node7/node9 eq complete) or ../../node10 eq complete) and node11 eq complete)",
+      "expected": "(((((/suite/family/task/node4/node5/node6 == complete) and (/suite/family/task/node4/node5/node7/node8 == complete)) and (/suite/family/task/node4/node5/node7/node9 == complete)) or (../../node10 == complete)) and (node11 == complete))"
+    },
+    {
+      "expression": "((suite == complete and :attrib1 eq 0) or :attrib2 ge 1300)",
+      "expected": "(((suite == complete) and (:attrib1 == 0)) or (:attrib2 >= 1300))"
+    },
+    {
+      "expression": "((:attrib1 == 1 and (( :attrib2 ge (1300 + :attrib3) and :attrib4 eq :attrib5 ) or ( :attrib4 gt :attrib5 ))))",
+      "expected": "((:attrib1 == 1) and (((:attrib2 >= (1300 + :attrib3)) and (:attrib4 == :attrib5)) or (:attrib4 > :attrib5)))"
+    },
+    {
+      "expression": "(suite == complete and family == complete AND ../../../../task/node4/node5 == complete)",
+      "expected": "(((suite == complete) and (family == complete)) and (../../../../task/node4/node5 == complete))"
+    },
+    {
+      "expression": "(./suite==complete or family:attrib1 gt 48 or family:attrib2 ge 28)",
+      "expected": "((./suite == complete) or ((family:attrib1 > 48) or (family:attrib2 >= 28)))"
+    },
+    {
+      "expression": "((suite == complete and :attrib1 eq 0) or (:attrib2 gt :attrib3 and :attrib4 ge 100))",
+      "expected": "(((suite == complete) and (:attrib1 == 0)) or ((:attrib2 > :attrib3) and (:attrib4 >= 100)))"
+    },
+    {
+      "expression": "(:attrib1 gt 2000 and /suite/family/12/task eq complete)",
+      "expected": "((:attrib1 > 2000) and (/suite/family/12/task == complete))"
+    },
+    {
+      "expression": "((/suite/family/00:attrib1 gt :attrib1 or /suite/family/00/task eq complete) and :attrib2 ge 2100 or 1==1)",
+      "expected": "(((/suite/family/00:attrib1 > :attrib1) or (/suite/family/00/task == complete)) and ((:attrib2 >= 2100) or (1 == 1)))"
+    },
+    {
+      "expression": "((/suite/family/00:attrib1 gt :attrib1 or /suite/family/00/task eq complete) and :attrib2 ge 2100)",
+      "expected": "(((/suite/family/00:attrib1 > :attrib1) or (/suite/family/00/task == complete)) and (:attrib2 >= 2100))"
+    },
+    {
+      "expression": "(suite eq complete and (:attrib1 ge 2300 or (:attrib1 gt 1930 and :attrib2 -1 gt :attrib3)))",
+      "expected": "((suite == complete) and ((:attrib1 >= 2300) or ((:attrib1 > 1930) and ((:attrib2 - 1) > :attrib3))))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /task/node4:attrib1) or (/suite/family:attrib1 eq /task/node4:attrib1 and /suite/node5:attrib1 ge /task/node4:attrib1 and /suite/family/12/node6==complete))",
+      "expected": "((/suite/family:attrib1 > /task/node4:attrib1) or (((/suite/family:attrib1 == /task/node4:attrib1) and (/suite/node5:attrib1 >= /task/node4:attrib1)) and (/suite/family/12/node6 == complete)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /task/node4:attrib1) or (/suite/family:attrib1 eq /task/node4:attrib1 and /suite/family/12/node5/node6==complete) and (/node7/node8/family/12 eq complete or /node7/node8/family:attrib1 gt :attrib1) and (/node9/node10/family/12/node11/node12 eq complete or /node9/node10/family:attrib1 gt :attrib1))",
+      "expected": "((/suite/family:attrib1 > /task/node4:attrib1) or (((/suite/family:attrib1 == /task/node4:attrib1) and (/suite/family/12/node5/node6 == complete)) and (((/node7/node8/family/12 == complete) or (/node7/node8/family:attrib1 > :attrib1)) and ((/node9/node10/family/12/node11/node12 == complete) or (/node9/node10/family:attrib1 > :attrib1)))))"
+    },
+    {
+      "expression": "(suite eq complete and (/family/task/node4/node5/node6/node7 eq complete))",
+      "expected": "((suite == complete) and (/family/task/node4/node5/node6/node7 == complete))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 ge /suite/task:attrib1 and /suite/node4:attrib1 ge /suite/task:attrib1 AND family:attrib1 ge task:attrib1 or 1==1)",
+      "expected": "((((/suite/family:attrib1 >= /suite/task:attrib1) and (/suite/node4:attrib1 >= /suite/task:attrib1)) and (family:attrib1 >= task:attrib1)) or (1 == 1))"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt ../../../task:attrib1 and /node4/family:attrib1 gt ../../../task:attrib1) and /node5/node6/node7/node8/family:attrib1 gt ../../../task:attrib1) or (node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete and node13 eq complete and node14 eq complete))",
+      "expected": "((((/suite/family:attrib1 > ../../../task:attrib1) and (/node4/family:attrib1 > ../../../task:attrib1)) and (/node5/node6/node7/node8/family:attrib1 > ../../../task:attrib1)) or ((((((node9 == complete) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5/00:attrib1 == :attrib2 and /suite/family/task/node4/node5/00/node6 != complete and :attrib3 > 1000) or /suite/family/task/node4/node5/00:attrib1 < :attrib2)",
+      "expected": "((((/suite/family/task/node4/node5/00:attrib1 == :attrib2) and (/suite/family/task/node4/node5/00/node6 != complete)) and (:attrib3 > 1000)) or (/suite/family/task/node4/node5/00:attrib1 < :attrib2))"
+    },
+    {
+      "expression": "(((((((((((((((((((((((((((00 eq complete) and (01 eq complete)) and (02 eq complete)) and (03 eq complete)) and (04 eq complete)) and (05 eq complete)) and (06 eq complete)) and (07 eq complete)) and (08 eq complete)) and (09 eq complete)) and (10 eq complete)) and (11 eq complete)) and (12 eq complete)) and (13 eq complete)) and (14 eq complete)) and (15 eq complete)) and (16 eq complete)) and (17 eq complete)) and (18 eq complete)) and (19 eq complete)) and (20 eq complete)) and (21 eq complete)) and (22 eq complete)) and (23 eq complete)) and (suite eq complete)) and (family eq complete)) and (task eq complete))",
+      "expected": "(((((((((((((((((((((((((((00 == complete) and (01 == complete)) and (02 == complete)) and (03 == complete)) and (04 == complete)) and (05 == complete)) and (06 == complete)) and (07 == complete)) and (08 == complete)) and (09 == complete)) and (10 == complete)) and (11 == complete)) and (12 == complete)) and (13 == complete)) and (14 == complete)) and (15 == complete)) and (16 == complete)) and (17 == complete)) and (18 == complete)) and (19 == complete)) and (20 == complete)) and (21 == complete)) and (22 == complete)) and (23 == complete)) and (suite == complete)) and (family == complete)) and (task == complete))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and /task:attrib1 == 5 and /task:attrib2 ge 1200 and /task:attrib3 ge /task/node4/node5:attrib4)",
+      "expected": "(((((suite == complete) and (family == complete)) and (/task:attrib1 == 5)) and (/task:attrib2 >= 1200)) and (/task:attrib3 >= /task/node4/node5:attrib4))"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 > /suite/node4/node5:attrib1 and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete)",
+      "expected": "((((((((/suite/family/task:attrib1 > /suite/node4/node5:attrib1) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete))"
+    },
+    {
+      "expression": "(1 == complete and 3 == complete and 6 == complete and 12 == complete and 24 == complete and 36 == complete and 48 == complete)",
+      "expected": "(((((((1 == complete) and (3 == complete)) and (6 == complete)) and (12 == complete)) and (24 == complete)) and (36 == complete)) and (48 == complete))"
+    },
+    {
+      "expression": "(00 == complete and 01 == complete and 02 == complete and 03 == complete and 04 == complete and 05 == complete and 06 == complete and 07 == complete and 08 == complete and 09 == complete)",
+      "expected": "((((((((((00 == complete) and (01 == complete)) and (02 == complete)) and (03 == complete)) and (04 == complete)) and (05 == complete)) and (06 == complete)) and (07 == complete)) and (08 == complete)) and (09 == complete))"
+    },
+    {
+      "expression": "((./suite == complete))",
+      "expected": "(./suite == complete)"
+    },
+    {
+      "expression": "((/suite/family/task/node4:attrib1 > /suite/family/node5/node4:attrib1 and ../node5:attrib1 < /suite/node6/node5:attrib1) or (../node5:attrib1 == /suite/node6/node5:attrib1 and /suite/node6/node5/node7 == complete))",
+      "expected": "(((/suite/family/task/node4:attrib1 > /suite/family/node5/node4:attrib1) and (../node5:attrib1 < /suite/node6/node5:attrib1)) or ((../node5:attrib1 == /suite/node6/node5:attrib1) and (/suite/node6/node5/node7 == complete)))"
+    },
+    {
+      "expression": "((suite eq complete and family:attrib1 le task/family:attrib1) and family:attrib1 lt node4:attrib1)",
+      "expected": "(((suite == complete) and (family:attrib1 <= task/family:attrib1)) and (family:attrib1 < node4:attrib1))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt ../../../task:attrib1 and /node4/family:attrib1 gt ../../../task:attrib1) or (node5 eq complete and node6 eq complete and node7 eq complete and node8 eq complete and node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete and node13 eq complete and node14 eq complete))",
+      "expected": "(((/suite/family:attrib1 > ../../../task:attrib1) and (/node4/family:attrib1 > ../../../task:attrib1)) or ((((((((((node5 == complete) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/12/task/node4 eq complete and node5 eq complete) or ../node6 eq complete) or (../node7/node8 eq complete and node5 eq complete))",
+      "expected": "((((/suite/family/12/task/node4 == complete) and (node5 == complete)) or (../node6 == complete)) or ((../node7/node8 == complete) and (node5 == complete)))"
+    },
+    {
+      "expression": "(((((/suite/family/12/task/node4:attrib1 ge 1 or /suite/family/12/task/node5:attrib1 ge 1) or /suite/family/12/task/node4 eq complete) and node6 eq complete) or ../../node7 eq complete) or (../../node8/node9 eq complete and node6 eq complete))",
+      "expected": "((((((/suite/family/12/task/node4:attrib1 >= 1) or (/suite/family/12/task/node5:attrib1 >= 1)) or (/suite/family/12/task/node4 == complete)) and (node6 == complete)) or (../../node7 == complete)) or ((../../node8/node9 == complete) and (node6 == complete)))"
+    },
+    {
+      "expression": "((((/suite/family/task/node4/node5/12/node6 eq complete and node7 eq complete) or (/node8/family/task/node4/node5:attrib1 gt /node9/node10/node11:attrib1)) or ../../node12 eq complete) or (../../node13/node14 eq complete and node7 eq complete))",
+      "expected": "(((((/suite/family/task/node4/node5/12/node6 == complete) and (node7 == complete)) or (/node8/family/task/node4/node5:attrib1 > /node9/node10/node11:attrib1)) or (../../node12 == complete)) or ((../../node13/node14 == complete) and (node7 == complete)))"
+    },
+    {
+      "expression": "((/suite:attrib1 le /family/task:attrib2 ) and /family/task/node4/node5/node6 eq complete)",
+      "expected": "((/suite:attrib1 <= /family/task:attrib2) and (/family/task/node4/node5/node6 == complete))"
+    },
+    {
+      "expression": "(/suite/family/12/task/240/node4==complete and (/suite/family/12/task/360/node4==complete) AND node5 == complete and /node6/node7/node8/node9/family/12/360/node10 eq complete)",
+      "expected": "((/suite/family/12/task/240/node4 == complete) and ((/suite/family/12/task/360/node4 == complete) and ((node5 == complete) and (/node6/node7/node8/node9/family/12/360/node10 == complete))))"
+    },
+    {
+      "expression": "((((/suite/family/task/node4/node5:attrib1 ge 1 and /suite/family/task/node4/node5:attrib2 ge 1) or /suite/family/task/node4/node5 eq complete) or ../../node6 eq complete) and node7 eq complete)",
+      "expected": "(((((/suite/family/task/node4/node5:attrib1 >= 1) and (/suite/family/task/node4/node5:attrib2 >= 1)) or (/suite/family/task/node4/node5 == complete)) or (../../node6 == complete)) and (node7 == complete))"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt ../../../task:attrib1 and /node4/family:attrib1 gt ../../../task:attrib1) and /node5/node6/node7/node8/family:attrib1 gt ../../../task:attrib1) or (node9 eq complete and node10 eq complete and node11 eq complete and node12 eq complete and node13 eq complete and node14 eq complete and node15 eq complete and node16 eq complete and node17 eq complete))",
+      "expected": "((((/suite/family:attrib1 > ../../../task:attrib1) and (/node4/family:attrib1 > ../../../task:attrib1)) and (/node5/node6/node7/node8/family:attrib1 > ../../../task:attrib1)) or (((((((((node9 == complete) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)) and (node17 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/task/node4 == complete) and ((/node5/node6:attrib1 gt :attrib1) or (/node5/node6:attrib1 eq :attrib1 and /node5/node6/node7/node8/node9 eq complete)))",
+      "expected": "((/suite/family/task/node4 == complete) and ((/node5/node6:attrib1 > :attrib1) or ((/node5/node6:attrib1 == :attrib1) and (/node5/node6/node7/node8/node9 == complete))))"
+    },
+    {
+      "expression": "((../suite/12 == complete AND ../suite:attrib1 == ../family:attrib1) OR ../family:attrib1 < ../suite:attrib1)",
+      "expected": "(((../suite/12 == complete) and (../suite:attrib1 == ../family:attrib1)) or (../family:attrib1 < ../suite:attrib1))"
+    },
+    {
+      "expression": "(suite == complete AND ((../family/00 == complete AND ../family:attrib1 == ../task:attrib1) OR ../task:attrib1 < ../family:attrib1))",
+      "expected": "((suite == complete) and (((../family/00 == complete) and (../family:attrib1 == ../task:attrib1)) or (../task:attrib1 < ../family:attrib1)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt ../../../task:attrib1 and /node4/family:attrib1 gt ../../../task:attrib1) or (node5 eq complete and node6 eq complete and node7 eq complete and node8 eq complete and node9 eq complete and node10 eq complete))",
+      "expected": "(((/suite/family:attrib1 > ../../../task:attrib1) and (/node4/family:attrib1 > ../../../task:attrib1)) or ((((((node5 == complete) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)))"
+    },
+    {
+      "expression": "(:attrib1 >= 0200 and :attrib1 <= 2300 or 1==1)",
+      "expected": "(((:attrib1 >= 200) and (:attrib1 <= 2300)) or (1 == 1))"
+    },
+    {
+      "expression": "(suite==complete AND family==complete AND task==complete and node4 eq complete and node5 eq complete)",
+      "expected": "(((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and /task/node4/12/node5/node6 eq complete and /task/node4/12/node7/node8/node9 eq complete or :attrib1 gt 1900)",
+      "expected": "(((((suite == complete) and (family == complete)) and (/task/node4/12/node5/node6 == complete)) and (/task/node4/12/node7/node8/node9 == complete)) or (:attrib1 > 1900))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and /task/node4/00/node5/node6 eq complete and /task/node4/00/node7/node8/node9 eq complete or (:attrib1 gt 900 and :attrib1 lt 1130))",
+      "expected": "(((((suite == complete) and (family == complete)) and (/task/node4/00/node5/node6 == complete)) and (/task/node4/00/node7/node8/node9 == complete)) or ((:attrib1 > 900) and (:attrib1 < 1130)))"
+    },
+    {
+      "expression": "(../suite == complete and ../family eq complete and ../task eq complete and ../../../node4/node5/node6 eq complete and ../../../node7/node8 eq complete)",
+      "expected": "(((((../suite == complete) and (../family == complete)) and (../task == complete)) and (../../../node4/node5/node6 == complete)) and (../../../node7/node8 == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and (/suite/family/12/node4/node5==complete or /suite/family/12/node6:attrib2 ge 6)))",
+      "expected": "((/suite/family:attrib1 > /suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and ((/suite/family/12/node4/node5 == complete) or (/suite/family/12/node6:attrib2 >= 6))))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5/node6==complete and (/suite/task/node7/12/node8==complete or /suite/family/12/node9:attrib2 ge 6)))",
+      "expected": "((/suite/family:attrib1 > /suite/task:attrib1) or (((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/12/node4/node5/node6 == complete)) and ((/suite/task/node7/12/node8 == complete) or (/suite/family/12/node9:attrib2 >= 6))))"
+    },
+    {
+      "expression": "((/suite/family/12/task:attrib1 ge 006 or /suite/family/12/task eq complete) or (/suite/family:attrib2 gt /suite/node4:attrib2))",
+      "expected": "(((/suite/family/12/task:attrib1 >= 6) or (/suite/family/12/task == complete)) or (/suite/family:attrib2 > /suite/node4:attrib2))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/task/node4/node5/node6==complete) AND (/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and (/suite/family/node5/node7/node8==complete or /suite/family/node5/node9:attrib2 ge 6)))",
+      "expected": "((/suite/family:attrib1 > /suite/task:attrib1) or (((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/task/node4/node5/node6 == complete)) and ((/suite/family:attrib1 > /suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and ((/suite/family/node5/node7/node8 == complete) or (/suite/family/node5/node9:attrib2 >= 6))))))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/00/node4/node5/node6==complete and /suite/task/node7/00/node8==complete or /suite/family/00/node9:attrib2 ge 6))",
+      "expected": "((/suite/family:attrib1 > /suite/task:attrib1) or ((((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/00/node4/node5/node6 == complete)) and (/suite/task/node7/00/node8 == complete)) or (/suite/family/00/node9:attrib2 >= 6)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/task/node4/node5/node6==complete) AND (/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/node5/node7/node8==complete or /suite/family/node5/node9:attrib2 ge 6))",
+      "expected": "((/suite/family:attrib1 > /suite/task:attrib1) or (((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/task/node4/node5/node6 == complete)) and ((/suite/family:attrib1 > /suite/task:attrib1) or (((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/node5/node7/node8 == complete)) or (/suite/family/node5/node9:attrib2 >= 6)))))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and (/suite/family/node4/node5/node6/node7==complete or /suite/family/node4/node8:attrib2 ge 6) and (/suite/task/node9/node4/node10==complete or 1==1)))",
+      "expected": "((/suite/family:attrib1 > /suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and (((/suite/family/node4/node5/node6/node7 == complete) or (/suite/family/node4/node8:attrib2 >= 6)) and ((/suite/task/node9/node4/node10 == complete) or (1 == 1)))))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family/node4/node5:attrib2 ge 6 or /suite/family/node4/node5 eq complete))",
+      "expected": "((/suite/family:attrib1 > /suite/task:attrib1) or ((/suite/family/node4/node5:attrib2 >= 6) or (/suite/family/node4/node5 == complete)))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task eq complete and ((:attrib1 gt :attrib2 -1) or :attrib3 gt 1530))",
+      "expected": "((((suite == complete) and (family == complete)) and (task == complete)) and ((:attrib1 > (:attrib2 - 1)) or (:attrib3 > 1530)))"
+    },
+    {
+      "expression": "(suite eq complete and :attrib1 gt :attrib2 and (:attrib3 gt 2000))",
+      "expected": "(((suite == complete) and (:attrib1 > :attrib2)) and (:attrib3 > 2000))"
+    },
+    {
+      "expression": "(suite == complete and :attrib1 ge 2000)",
+      "expected": "((suite == complete) and (:attrib1 >= 2000))"
+    },
+    {
+      "expression": "(suite == complete and family eq complete and (1==1 or ../../task/node4 eq complete))",
+      "expected": "(((suite == complete) and (family == complete)) and ((1 == 1) or (../../task/node4 == complete)))"
+    },
+    {
+      "expression": "(suite == complete and family eq complete and (../../task/node4 eq complete))",
+      "expected": "(((suite == complete) and (family == complete)) and (../../task/node4 == complete))"
+    },
+    {
+      "expression": "(./suite == complete and ./family == complete and (/task/node4:attrib1-2 gt :attrib1 or (/task/node4:attrib1-2 eq :attrib1 and /task/node4/00 eq complete)))",
+      "expected": "(((./suite == complete) and (./family == complete)) and (((/task/node4:attrib1 - 2) > :attrib1) or (((/task/node4:attrib1 - 2) == :attrib1) and (/task/node4/00 == complete))))"
+    },
+    {
+      "expression": "((((/suite/family/task/node4/node5/12/240 eq complete and /suite/family/task/node4/node5/12/360 eq complete) and node6 eq complete) or ../../node7 eq complete) or (../../node8/node9 eq complete and node6 eq complete))",
+      "expected": "(((((/suite/family/task/node4/node5/12/240 == complete) and (/suite/family/task/node4/node5/12/360 == complete)) and (node6 == complete)) or (../../node7 == complete)) or ((../../node8/node9 == complete) and (node6 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/task/node4 == active and /node5:attrib1 eq 2) or /node5:attrib1 ne 2)",
+      "expected": "(((/suite/family/task/node4 == active) and (/node5:attrib1 == 2)) or (/node5:attrib1 != 2))"
+    },
+    {
+      "expression": "((1==1 and /suite/family/12/task/360/node4==complete and /suite/family/12/task/360/node5==complete and /suite/family/12/task/240/node5==complete))",
+      "expected": "((((1 == 1) and (/suite/family/12/task/360/node4 == complete)) and (/suite/family/12/task/360/node5 == complete)) and (/suite/family/12/task/240/node5 == complete))"
+    },
+    {
+      "expression": "(((../suite:attrib1 ge 24 or ../suite eq complete)) and (./012 eq complete))",
+      "expected": "(((../suite:attrib1 >= 24) or (../suite == complete)) and (./012 == complete))"
+    },
+    {
+      "expression": "((((((((((../suite/000001/family/task:attrib1 gt node4:attrib1 or ../suite/000001/family/task eq complete) and (../suite/000002/family/task:attrib1 gt node4:attrib1 or ../suite/000002/family/task eq complete)) and (../suite/000003/family/task:attrib1 gt node4:attrib1 or ../suite/000003/family/task eq complete)) and (../suite/000004/family/task:attrib1 gt node4:attrib1 or ../suite/000004/family/task eq complete)) and (../suite/000005/family/task:attrib1 gt node4:attrib1 or ../suite/000005/family/task eq complete)) and (../suite/000006/family/task:attrib1 gt node4:attrib1 or ../suite/000006/family/task eq complete)) and (../suite/000007/family/task:attrib1 gt node4:attrib1 or ../suite/000007/family/task eq complete)) and (../suite/000008/family/task:attrib1 gt node4:attrib1 or ../suite/000008/family/task eq complete)) and (../suite/000009/family/task:attrib1 gt node4:attrib1 or ../suite/000009/family/task eq complete)) and (../suite/000010/family/task:attrib1 gt node4:attrib1 or ../suite/000010/family/task eq complete))",
+      "expected": "(((((((((((../suite/000001/family/task:attrib1 > node4:attrib1) or (../suite/000001/family/task == complete)) and ((../suite/000002/family/task:attrib1 > node4:attrib1) or (../suite/000002/family/task == complete))) and ((../suite/000003/family/task:attrib1 > node4:attrib1) or (../suite/000003/family/task == complete))) and ((../suite/000004/family/task:attrib1 > node4:attrib1) or (../suite/000004/family/task == complete))) and ((../suite/000005/family/task:attrib1 > node4:attrib1) or (../suite/000005/family/task == complete))) and ((../suite/000006/family/task:attrib1 > node4:attrib1) or (../suite/000006/family/task == complete))) and ((../suite/000007/family/task:attrib1 > node4:attrib1) or (../suite/000007/family/task == complete))) and ((../suite/000008/family/task:attrib1 > node4:attrib1) or (../suite/000008/family/task == complete))) and ((../suite/000009/family/task:attrib1 > node4:attrib1) or (../suite/000009/family/task == complete))) and ((../suite/000010/family/task:attrib1 > node4:attrib1) or (../suite/000010/family/task == complete)))"
+    },
+    {
+      "expression": "(suite:attrib1 + 604800 gt family:attrib1)",
+      "expected": "((suite:attrib1 + 604800) > family:attrib1)"
+    },
+    {
+      "expression": "((((((((((((((((((((((((((((((((((((((((((((((((((../suite/000001/family/task:attrib1 gt node4:attrib1 or ../suite/000001/family/task eq complete) and (../suite/000002/family/task:attrib1 gt node4:attrib1 or ../suite/000002/family/task eq complete)) and (../suite/000003/family/task:attrib1 gt node4:attrib1 or ../suite/000003/family/task eq complete)) and (../suite/000004/family/task:attrib1 gt node4:attrib1 or ../suite/000004/family/task eq complete)) and (../suite/000005/family/task:attrib1 gt node4:attrib1 or ../suite/000005/family/task eq complete)) and (../suite/000006/family/task:attrib1 gt node4:attrib1 or ../suite/000006/family/task eq complete)) and (../suite/000007/family/task:attrib1 gt node4:attrib1 or ../suite/000007/family/task eq complete)) and (../suite/000008/family/task:attrib1 gt node4:attrib1 or ../suite/000008/family/task eq complete)) and (../suite/000009/family/task:attrib1 gt node4:attrib1 or ../suite/000009/family/task eq complete)) and (../suite/000010/family/task:attrib1 gt node4:attrib1 or ../suite/000010/family/task eq complete)) and (../suite/000011/family/task:attrib1 gt node4:attrib1 or ../suite/000011/family/task eq complete)) and (../suite/000012/family/task:attrib1 gt node4:attrib1 or ../suite/000012/family/task eq complete)) and (../suite/000013/family/task:attrib1 gt node4:attrib1 or ../suite/000013/family/task eq complete)) and (../suite/000014/family/task:attrib1 gt node4:attrib1 or ../suite/000014/family/task eq complete)) and (../suite/000015/family/task:attrib1 gt node4:attrib1 or ../suite/000015/family/task eq complete)) and (../suite/000016/family/task:attrib1 gt node4:attrib1 or ../suite/000016/family/task eq complete)) and (../suite/000017/family/task:attrib1 gt node4:attrib1 or ../suite/000017/family/task eq complete)) and (../suite/000018/family/task:attrib1 gt node4:attrib1 or ../suite/000018/family/task eq complete)) and (../suite/000019/family/task:attrib1 gt node4:attrib1 or ../suite/000019/family/task eq complete)) and (../suite/000020/family/task:attrib1 gt node4:attrib1 or ../suite/000020/family/task eq complete)) and (../suite/000021/family/task:attrib1 gt node4:attrib1 or ../suite/000021/family/task eq complete)) and (../suite/000022/family/task:attrib1 gt node4:attrib1 or ../suite/000022/family/task eq complete)) and (../suite/000023/family/task:attrib1 gt node4:attrib1 or ../suite/000023/family/task eq complete)) and (../suite/000024/family/task:attrib1 gt node4:attrib1 or ../suite/000024/family/task eq complete)) and (../suite/000025/family/task:attrib1 gt node4:attrib1 or ../suite/000025/family/task eq complete)) and (../suite/000026/family/task:attrib1 gt node4:attrib1 or ../suite/000026/family/task eq complete)) and (../suite/000027/family/task:attrib1 gt node4:attrib1 or ../suite/000027/family/task eq complete)) and (../suite/000028/family/task:attrib1 gt node4:attrib1 or ../suite/000028/family/task eq complete)) and (../suite/000029/family/task:attrib1 gt node4:attrib1 or ../suite/000029/family/task eq complete)) and (../suite/000030/family/task:attrib1 gt node4:attrib1 or ../suite/000030/family/task eq complete)) and (../suite/000031/family/task:attrib1 gt node4:attrib1 or ../suite/000031/family/task eq complete)) and (../suite/000032/family/task:attrib1 gt node4:attrib1 or ../suite/000032/family/task eq complete)) and (../suite/000033/family/task:attrib1 gt node4:attrib1 or ../suite/000033/family/task eq complete)) and (../suite/000034/family/task:attrib1 gt node4:attrib1 or ../suite/000034/family/task eq complete)) and (../suite/000035/family/task:attrib1 gt node4:attrib1 or ../suite/000035/family/task eq complete)) and (../suite/000036/family/task:attrib1 gt node4:attrib1 or ../suite/000036/family/task eq complete)) and (../suite/000037/family/task:attrib1 gt node4:attrib1 or ../suite/000037/family/task eq complete)) and (../suite/000038/family/task:attrib1 gt node4:attrib1 or ../suite/000038/family/task eq complete)) and (../suite/000039/family/task:attrib1 gt node4:attrib1 or ../suite/000039/family/task eq complete)) and (../suite/000040/family/task:attrib1 gt node4:attrib1 or ../suite/000040/family/task eq complete)) and (../suite/000041/family/task:attrib1 gt node4:attrib1 or ../suite/000041/family/task eq complete)) and (../suite/000042/family/task:attrib1 gt node4:attrib1 or ../suite/000042/family/task eq complete)) and (../suite/000043/family/task:attrib1 gt node4:attrib1 or ../suite/000043/family/task eq complete)) and (../suite/000044/family/task:attrib1 gt node4:attrib1 or ../suite/000044/family/task eq complete)) and (../suite/000045/family/task:attrib1 gt node4:attrib1 or ../suite/000045/family/task eq complete)) and (../suite/000046/family/task:attrib1 gt node4:attrib1 or ../suite/000046/family/task eq complete)) and (../suite/000047/family/task:attrib1 gt node4:attrib1 or ../suite/000047/family/task eq complete)) and (../suite/000048/family/task:attrib1 gt node4:attrib1 or ../suite/000048/family/task eq complete)) and (../suite/000049/family/task:attrib1 gt node4:attrib1 or ../suite/000049/family/task eq complete)) and (../suite/000050/family/task:attrib1 gt node4:attrib1 or ../suite/000050/family/task eq complete))",
+      "expected": "(((((((((((((((((((((((((((((((((((((((((((((((((((../suite/000001/family/task:attrib1 > node4:attrib1) or (../suite/000001/family/task == complete)) and ((../suite/000002/family/task:attrib1 > node4:attrib1) or (../suite/000002/family/task == complete))) and ((../suite/000003/family/task:attrib1 > node4:attrib1) or (../suite/000003/family/task == complete))) and ((../suite/000004/family/task:attrib1 > node4:attrib1) or (../suite/000004/family/task == complete))) and ((../suite/000005/family/task:attrib1 > node4:attrib1) or (../suite/000005/family/task == complete))) and ((../suite/000006/family/task:attrib1 > node4:attrib1) or (../suite/000006/family/task == complete))) and ((../suite/000007/family/task:attrib1 > node4:attrib1) or (../suite/000007/family/task == complete))) and ((../suite/000008/family/task:attrib1 > node4:attrib1) or (../suite/000008/family/task == complete))) and ((../suite/000009/family/task:attrib1 > node4:attrib1) or (../suite/000009/family/task == complete))) and ((../suite/000010/family/task:attrib1 > node4:attrib1) or (../suite/000010/family/task == complete))) and ((../suite/000011/family/task:attrib1 > node4:attrib1) or (../suite/000011/family/task == complete))) and ((../suite/000012/family/task:attrib1 > node4:attrib1) or (../suite/000012/family/task == complete))) and ((../suite/000013/family/task:attrib1 > node4:attrib1) or (../suite/000013/family/task == complete))) and ((../suite/000014/family/task:attrib1 > node4:attrib1) or (../suite/000014/family/task == complete))) and ((../suite/000015/family/task:attrib1 > node4:attrib1) or (../suite/000015/family/task == complete))) and ((../suite/000016/family/task:attrib1 > node4:attrib1) or (../suite/000016/family/task == complete))) and ((../suite/000017/family/task:attrib1 > node4:attrib1) or (../suite/000017/family/task == complete))) and ((../suite/000018/family/task:attrib1 > node4:attrib1) or (../suite/000018/family/task == complete))) and ((../suite/000019/family/task:attrib1 > node4:attrib1) or (../suite/000019/family/task == complete))) and ((../suite/000020/family/task:attrib1 > node4:attrib1) or (../suite/000020/family/task == complete))) and ((../suite/000021/family/task:attrib1 > node4:attrib1) or (../suite/000021/family/task == complete))) and ((../suite/000022/family/task:attrib1 > node4:attrib1) or (../suite/000022/family/task == complete))) and ((../suite/000023/family/task:attrib1 > node4:attrib1) or (../suite/000023/family/task == complete))) and ((../suite/000024/family/task:attrib1 > node4:attrib1) or (../suite/000024/family/task == complete))) and ((../suite/000025/family/task:attrib1 > node4:attrib1) or (../suite/000025/family/task == complete))) and ((../suite/000026/family/task:attrib1 > node4:attrib1) or (../suite/000026/family/task == complete))) and ((../suite/000027/family/task:attrib1 > node4:attrib1) or (../suite/000027/family/task == complete))) and ((../suite/000028/family/task:attrib1 > node4:attrib1) or (../suite/000028/family/task == complete))) and ((../suite/000029/family/task:attrib1 > node4:attrib1) or (../suite/000029/family/task == complete))) and ((../suite/000030/family/task:attrib1 > node4:attrib1) or (../suite/000030/family/task == complete))) and ((../suite/000031/family/task:attrib1 > node4:attrib1) or (../suite/000031/family/task == complete))) and ((../suite/000032/family/task:attrib1 > node4:attrib1) or (../suite/000032/family/task == complete))) and ((../suite/000033/family/task:attrib1 > node4:attrib1) or (../suite/000033/family/task == complete))) and ((../suite/000034/family/task:attrib1 > node4:attrib1) or (../suite/000034/family/task == complete))) and ((../suite/000035/family/task:attrib1 > node4:attrib1) or (../suite/000035/family/task == complete))) and ((../suite/000036/family/task:attrib1 > node4:attrib1) or (../suite/000036/family/task == complete))) and ((../suite/000037/family/task:attrib1 > node4:attrib1) or (../suite/000037/family/task == complete))) and ((../suite/000038/family/task:attrib1 > node4:attrib1) or (../suite/000038/family/task == complete))) and ((../suite/000039/family/task:attrib1 > node4:attrib1) or (../suite/000039/family/task == complete))) and ((../suite/000040/family/task:attrib1 > node4:attrib1) or (../suite/000040/family/task == complete))) and ((../suite/000041/family/task:attrib1 > node4:attrib1) or (../suite/000041/family/task == complete))) and ((../suite/000042/family/task:attrib1 > node4:attrib1) or (../suite/000042/family/task == complete))) and ((../suite/000043/family/task:attrib1 > node4:attrib1) or (../suite/000043/family/task == complete))) and ((../suite/000044/family/task:attrib1 > node4:attrib1) or (../suite/000044/family/task == complete))) and ((../suite/000045/family/task:attrib1 > node4:attrib1) or (../suite/000045/family/task == complete))) and ((../suite/000046/family/task:attrib1 > node4:attrib1) or (../suite/000046/family/task == complete))) and ((../suite/000047/family/task:attrib1 > node4:attrib1) or (../suite/000047/family/task == complete))) and ((../suite/000048/family/task:attrib1 > node4:attrib1) or (../suite/000048/family/task == complete))) and ((../suite/000049/family/task:attrib1 > node4:attrib1) or (../suite/000049/family/task == complete))) and ((../suite/000050/family/task:attrib1 > node4:attrib1) or (../suite/000050/family/task == complete)))"
+    },
+    {
+      "expression": "((((((((../suite/000001/family/task:attrib1 gt node4:attrib1 or ../suite/000001/family/task eq complete) and (../suite/000002/family/task:attrib1 gt node4:attrib1 or ../suite/000002/family/task eq complete)) and (../suite/000003/family/task:attrib1 gt node4:attrib1 or ../suite/000003/family/task eq complete)) and (../suite/000004/family/task:attrib1 gt node4:attrib1 or ../suite/000004/family/task eq complete)) and (../suite/000005/family/task:attrib1 gt node4:attrib1 or ../suite/000005/family/task eq complete)) and (../suite/000006/family/task:attrib1 gt node4:attrib1 or ../suite/000006/family/task eq complete)) and (../suite/000007/family/task:attrib1 gt node4:attrib1 or ../suite/000007/family/task eq complete)) and (../suite/000008/family/task:attrib1 gt node4:attrib1 or ../suite/000008/family/task eq complete))",
+      "expected": "(((((((((../suite/000001/family/task:attrib1 > node4:attrib1) or (../suite/000001/family/task == complete)) and ((../suite/000002/family/task:attrib1 > node4:attrib1) or (../suite/000002/family/task == complete))) and ((../suite/000003/family/task:attrib1 > node4:attrib1) or (../suite/000003/family/task == complete))) and ((../suite/000004/family/task:attrib1 > node4:attrib1) or (../suite/000004/family/task == complete))) and ((../suite/000005/family/task:attrib1 > node4:attrib1) or (../suite/000005/family/task == complete))) and ((../suite/000006/family/task:attrib1 > node4:attrib1) or (../suite/000006/family/task == complete))) and ((../suite/000007/family/task:attrib1 > node4:attrib1) or (../suite/000007/family/task == complete))) and ((../suite/000008/family/task:attrib1 > node4:attrib1) or (../suite/000008/family/task == complete)))"
+    },
+    {
+      "expression": "((./000001/suite/family:attrib1 gt task:attrib1 or ./000001/suite/family eq complete) and (./000002/suite/family:attrib1 gt task:attrib1 or ./000002/suite/family eq complete))",
+      "expected": "(((./000001/suite/family:attrib1 > task:attrib1) or (./000001/suite/family == complete)) and ((./000002/suite/family:attrib1 > task:attrib1) or (./000002/suite/family == complete)))"
+    },
+    {
+      "expression": "(((../../suite:attrib1 gt family:attrib1 or ../../suite eq complete) and task:attrib1 + 604800 gt family:attrib1) and (../../suite:attrib1 gt family:attrib1 or ../../suite eq complete))",
+      "expected": "((((../../suite:attrib1 > family:attrib1) or (../../suite == complete)) and ((task:attrib1 + 604800) > family:attrib1)) and ((../../suite:attrib1 > family:attrib1) or (../../suite == complete)))"
+    },
+    {
+      "expression": "((((./000001/suite/family:attrib1 gt task:attrib1 or ./000001/suite/family eq complete) and (./000002/suite/family:attrib1 gt task:attrib1 or ./000002/suite/family eq complete)) and (./000003/suite/family:attrib1 gt task:attrib1 or ./000003/suite/family eq complete)) and (./000004/suite/family:attrib1 gt task:attrib1 or ./000004/suite/family eq complete))",
+      "expected": "(((((./000001/suite/family:attrib1 > task:attrib1) or (./000001/suite/family == complete)) and ((./000002/suite/family:attrib1 > task:attrib1) or (./000002/suite/family == complete))) and ((./000003/suite/family:attrib1 > task:attrib1) or (./000003/suite/family == complete))) and ((./000004/suite/family:attrib1 > task:attrib1) or (./000004/suite/family == complete)))"
+    },
+    {
+      "expression": "((suite:attrib1 gt family:attrib1 or suite eq complete) and task:attrib1 + 604800 gt family:attrib1)",
+      "expected": "(((suite:attrib1 > family:attrib1) or (suite == complete)) and ((task:attrib1 + 604800) > family:attrib1))"
+    },
+    {
+      "expression": "(../suite eq complete and ../family/task:attrib1 + 6 gt task:attrib1)",
+      "expected": "((../suite == complete) and ((../family/task:attrib1 + 6) > task:attrib1))"
+    },
+    {
+      "expression": "(suite eq complete or 1)",
+      "expected": "((suite == complete) or 1)"
+    },
+    {
+      "expression": "((../../suite:attrib1 gt family:attrib1 + 86400 or ../../suite eq complete) and task:attrib1 + 604800 gt family:attrib1)",
+      "expected": "(((../../suite:attrib1 > (family:attrib1 + 86400)) or (../../suite == complete)) and ((task:attrib1 + 604800) > family:attrib1))"
+    },
+    {
+      "expression": "(suite:attrib1 gt family:attrib1 + 0 or suite eq complete)",
+      "expected": "((suite:attrib1 > (family:attrib1 + 0)) or (suite == complete))"
+    },
+    {
+      "expression": "((((((((((((((((((((((((((((((((((((((((((((((((((../suite/000001/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000001/family/task eq complete) and (../suite/000002/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000002/family/task eq complete)) and (../suite/000003/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000003/family/task eq complete)) and (../suite/000004/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000004/family/task eq complete)) and (../suite/000005/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000005/family/task eq complete)) and (../suite/000006/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000006/family/task eq complete)) and (../suite/000007/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000007/family/task eq complete)) and (../suite/000008/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000008/family/task eq complete)) and (../suite/000009/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000009/family/task eq complete)) and (../suite/000010/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000010/family/task eq complete)) and (../suite/000011/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000011/family/task eq complete)) and (../suite/000012/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000012/family/task eq complete)) and (../suite/000013/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000013/family/task eq complete)) and (../suite/000014/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000014/family/task eq complete)) and (../suite/000015/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000015/family/task eq complete)) and (../suite/000016/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000016/family/task eq complete)) and (../suite/000017/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000017/family/task eq complete)) and (../suite/000018/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000018/family/task eq complete)) and (../suite/000019/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000019/family/task eq complete)) and (../suite/000020/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000020/family/task eq complete)) and (../suite/000021/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000021/family/task eq complete)) and (../suite/000022/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000022/family/task eq complete)) and (../suite/000023/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000023/family/task eq complete)) and (../suite/000024/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000024/family/task eq complete)) and (../suite/000025/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000025/family/task eq complete)) and (../suite/000026/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000026/family/task eq complete)) and (../suite/000027/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000027/family/task eq complete)) and (../suite/000028/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000028/family/task eq complete)) and (../suite/000029/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000029/family/task eq complete)) and (../suite/000030/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000030/family/task eq complete)) and (../suite/000031/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000031/family/task eq complete)) and (../suite/000032/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000032/family/task eq complete)) and (../suite/000033/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000033/family/task eq complete)) and (../suite/000034/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000034/family/task eq complete)) and (../suite/000035/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000035/family/task eq complete)) and (../suite/000036/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000036/family/task eq complete)) and (../suite/000037/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000037/family/task eq complete)) and (../suite/000038/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000038/family/task eq complete)) and (../suite/000039/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000039/family/task eq complete)) and (../suite/000040/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000040/family/task eq complete)) and (../suite/000041/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000041/family/task eq complete)) and (../suite/000042/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000042/family/task eq complete)) and (../suite/000043/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000043/family/task eq complete)) and (../suite/000044/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000044/family/task eq complete)) and (../suite/000045/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000045/family/task eq complete)) and (../suite/000046/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000046/family/task eq complete)) and (../suite/000047/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000047/family/task eq complete)) and (../suite/000048/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000048/family/task eq complete)) and (../suite/000049/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000049/family/task eq complete)) and (../suite/000050/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000050/family/task eq complete))",
+      "expected": "(((((((((((((((((((((((((((((((((((((((((((((((((((../suite/000001/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000001/family/task == complete)) and ((../suite/000002/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000002/family/task == complete))) and ((../suite/000003/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000003/family/task == complete))) and ((../suite/000004/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000004/family/task == complete))) and ((../suite/000005/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000005/family/task == complete))) and ((../suite/000006/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000006/family/task == complete))) and ((../suite/000007/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000007/family/task == complete))) and ((../suite/000008/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000008/family/task == complete))) and ((../suite/000009/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000009/family/task == complete))) and ((../suite/000010/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000010/family/task == complete))) and ((../suite/000011/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000011/family/task == complete))) and ((../suite/000012/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000012/family/task == complete))) and ((../suite/000013/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000013/family/task == complete))) and ((../suite/000014/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000014/family/task == complete))) and ((../suite/000015/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000015/family/task == complete))) and ((../suite/000016/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000016/family/task == complete))) and ((../suite/000017/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000017/family/task == complete))) and ((../suite/000018/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000018/family/task == complete))) and ((../suite/000019/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000019/family/task == complete))) and ((../suite/000020/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000020/family/task == complete))) and ((../suite/000021/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000021/family/task == complete))) and ((../suite/000022/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000022/family/task == complete))) and ((../suite/000023/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000023/family/task == complete))) and ((../suite/000024/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000024/family/task == complete))) and ((../suite/000025/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000025/family/task == complete))) and ((../suite/000026/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000026/family/task == complete))) and ((../suite/000027/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000027/family/task == complete))) and ((../suite/000028/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000028/family/task == complete))) and ((../suite/000029/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000029/family/task == complete))) and ((../suite/000030/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000030/family/task == complete))) and ((../suite/000031/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000031/family/task == complete))) and ((../suite/000032/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000032/family/task == complete))) and ((../suite/000033/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000033/family/task == complete))) and ((../suite/000034/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000034/family/task == complete))) and ((../suite/000035/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000035/family/task == complete))) and ((../suite/000036/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000036/family/task == complete))) and ((../suite/000037/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000037/family/task == complete))) and ((../suite/000038/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000038/family/task == complete))) and ((../suite/000039/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000039/family/task == complete))) and ((../suite/000040/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000040/family/task == complete))) and ((../suite/000041/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000041/family/task == complete))) and ((../suite/000042/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000042/family/task == complete))) and ((../suite/000043/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000043/family/task == complete))) and ((../suite/000044/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000044/family/task == complete))) and ((../suite/000045/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000045/family/task == complete))) and ((../suite/000046/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000046/family/task == complete))) and ((../suite/000047/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000047/family/task == complete))) and ((../suite/000048/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000048/family/task == complete))) and ((../suite/000049/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000049/family/task == complete))) and ((../suite/000050/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000050/family/task == complete)))"
+    },
+    {
+      "expression": "((../../suite:attrib1 gt family:attrib1 or ../../suite eq complete) and (task:attrib1 + 604800 gt family:attrib1) and (../../suite:attrib1 gt family:attrib1 or ../../suite eq complete))",
+      "expected": "(((../../suite:attrib1 > family:attrib1) or (../../suite == complete)) and (((task:attrib1 + 604800) > family:attrib1) and ((../../suite:attrib1 > family:attrib1) or (../../suite == complete))))"
+    },
+    {
+      "expression": "(((((((((((((((((((((((((((((((((((((((((((((((((((./000001/suite/family:attrib1 gt task:attrib1 or ./000001/suite/family eq complete) and (./000002/suite/family:attrib1 gt task:attrib1 or ./000002/suite/family eq complete)) and (./000003/suite/family:attrib1 gt task:attrib1 or ./000003/suite/family eq complete)) and (./000004/suite/family:attrib1 gt task:attrib1 or ./000004/suite/family eq complete)) and (./000005/suite/family:attrib1 gt task:attrib1 or ./000005/suite/family eq complete)) and (./000006/suite/family:attrib1 gt task:attrib1 or ./000006/suite/family eq complete)) and (./000007/suite/family:attrib1 gt task:attrib1 or ./000007/suite/family eq complete)) and (./000008/suite/family:attrib1 gt task:attrib1 or ./000008/suite/family eq complete)) and (./000009/suite/family:attrib1 gt task:attrib1 or ./000009/suite/family eq complete)) and (./000010/suite/family:attrib1 gt task:attrib1 or ./000010/suite/family eq complete)) and (./000011/suite/family:attrib1 gt task:attrib1 or ./000011/suite/family eq complete)) and (./000012/suite/family:attrib1 gt task:attrib1 or ./000012/suite/family eq complete)) and (./000013/suite/family:attrib1 gt task:attrib1 or ./000013/suite/family eq complete)) and (./000014/suite/family:attrib1 gt task:attrib1 or ./000014/suite/family eq complete)) and (./000015/suite/family:attrib1 gt task:attrib1 or ./000015/suite/family eq complete)) and (./000016/suite/family:attrib1 gt task:attrib1 or ./000016/suite/family eq complete)) and (./000017/suite/family:attrib1 gt task:attrib1 or ./000017/suite/family eq complete)) and (./000018/suite/family:attrib1 gt task:attrib1 or ./000018/suite/family eq complete)) and (./000019/suite/family:attrib1 gt task:attrib1 or ./000019/suite/family eq complete)) and (./000020/suite/family:attrib1 gt task:attrib1 or ./000020/suite/family eq complete)) and (./000021/suite/family:attrib1 gt task:attrib1 or ./000021/suite/family eq complete)) and (./000022/suite/family:attrib1 gt task:attrib1 or ./000022/suite/family eq complete)) and (./000023/suite/family:attrib1 gt task:attrib1 or ./000023/suite/family eq complete)) and (./000024/suite/family:attrib1 gt task:attrib1 or ./000024/suite/family eq complete)) and (./000025/suite/family:attrib1 gt task:attrib1 or ./000025/suite/family eq complete)) and (./000026/suite/family:attrib1 gt task:attrib1 or ./000026/suite/family eq complete)) and (./000027/suite/family:attrib1 gt task:attrib1 or ./000027/suite/family eq complete)) and (./000028/suite/family:attrib1 gt task:attrib1 or ./000028/suite/family eq complete)) and (./000029/suite/family:attrib1 gt task:attrib1 or ./000029/suite/family eq complete)) and (./000030/suite/family:attrib1 gt task:attrib1 or ./000030/suite/family eq complete)) and (./000031/suite/family:attrib1 gt task:attrib1 or ./000031/suite/family eq complete)) and (./000032/suite/family:attrib1 gt task:attrib1 or ./000032/suite/family eq complete)) and (./000033/suite/family:attrib1 gt task:attrib1 or ./000033/suite/family eq complete)) and (./000034/suite/family:attrib1 gt task:attrib1 or ./000034/suite/family eq complete)) and (./000035/suite/family:attrib1 gt task:attrib1 or ./000035/suite/family eq complete)) and (./000036/suite/family:attrib1 gt task:attrib1 or ./000036/suite/family eq complete)) and (./000037/suite/family:attrib1 gt task:attrib1 or ./000037/suite/family eq complete)) and (./000038/suite/family:attrib1 gt task:attrib1 or ./000038/suite/family eq complete)) and (./000039/suite/family:attrib1 gt task:attrib1 or ./000039/suite/family eq complete)) and (./000040/suite/family:attrib1 gt task:attrib1 or ./000040/suite/family eq complete)) and (./000041/suite/family:attrib1 gt task:attrib1 or ./000041/suite/family eq complete)) and (./000042/suite/family:attrib1 gt task:attrib1 or ./000042/suite/family eq complete)) and (./000043/suite/family:attrib1 gt task:attrib1 or ./000043/suite/family eq complete)) and (./000044/suite/family:attrib1 gt task:attrib1 or ./000044/suite/family eq complete)) and (./000045/suite/family:attrib1 gt task:attrib1 or ./000045/suite/family eq complete)) and (./000046/suite/family:attrib1 gt task:attrib1 or ./000046/suite/family eq complete)) and (./000047/suite/family:attrib1 gt task:attrib1 or ./000047/suite/family eq complete)) and (./000048/suite/family:attrib1 gt task:attrib1 or ./000048/suite/family eq complete)) and (./000049/suite/family:attrib1 gt task:attrib1 or ./000049/suite/family eq complete)) and (./000050/suite/family:attrib1 gt task:attrib1 or ./000050/suite/family eq complete)) and (./000051/suite/family:attrib1 gt task:attrib1 or ./000051/suite/family eq complete))",
+      "expected": "((((((((((((((((((((((((((((((((((((((((((((((((((((./000001/suite/family:attrib1 > task:attrib1) or (./000001/suite/family == complete)) and ((./000002/suite/family:attrib1 > task:attrib1) or (./000002/suite/family == complete))) and ((./000003/suite/family:attrib1 > task:attrib1) or (./000003/suite/family == complete))) and ((./000004/suite/family:attrib1 > task:attrib1) or (./000004/suite/family == complete))) and ((./000005/suite/family:attrib1 > task:attrib1) or (./000005/suite/family == complete))) and ((./000006/suite/family:attrib1 > task:attrib1) or (./000006/suite/family == complete))) and ((./000007/suite/family:attrib1 > task:attrib1) or (./000007/suite/family == complete))) and ((./000008/suite/family:attrib1 > task:attrib1) or (./000008/suite/family == complete))) and ((./000009/suite/family:attrib1 > task:attrib1) or (./000009/suite/family == complete))) and ((./000010/suite/family:attrib1 > task:attrib1) or (./000010/suite/family == complete))) and ((./000011/suite/family:attrib1 > task:attrib1) or (./000011/suite/family == complete))) and ((./000012/suite/family:attrib1 > task:attrib1) or (./000012/suite/family == complete))) and ((./000013/suite/family:attrib1 > task:attrib1) or (./000013/suite/family == complete))) and ((./000014/suite/family:attrib1 > task:attrib1) or (./000014/suite/family == complete))) and ((./000015/suite/family:attrib1 > task:attrib1) or (./000015/suite/family == complete))) and ((./000016/suite/family:attrib1 > task:attrib1) or (./000016/suite/family == complete))) and ((./000017/suite/family:attrib1 > task:attrib1) or (./000017/suite/family == complete))) and ((./000018/suite/family:attrib1 > task:attrib1) or (./000018/suite/family == complete))) and ((./000019/suite/family:attrib1 > task:attrib1) or (./000019/suite/family == complete))) and ((./000020/suite/family:attrib1 > task:attrib1) or (./000020/suite/family == complete))) and ((./000021/suite/family:attrib1 > task:attrib1) or (./000021/suite/family == complete))) and ((./000022/suite/family:attrib1 > task:attrib1) or (./000022/suite/family == complete))) and ((./000023/suite/family:attrib1 > task:attrib1) or (./000023/suite/family == complete))) and ((./000024/suite/family:attrib1 > task:attrib1) or (./000024/suite/family == complete))) and ((./000025/suite/family:attrib1 > task:attrib1) or (./000025/suite/family == complete))) and ((./000026/suite/family:attrib1 > task:attrib1) or (./000026/suite/family == complete))) and ((./000027/suite/family:attrib1 > task:attrib1) or (./000027/suite/family == complete))) and ((./000028/suite/family:attrib1 > task:attrib1) or (./000028/suite/family == complete))) and ((./000029/suite/family:attrib1 > task:attrib1) or (./000029/suite/family == complete))) and ((./000030/suite/family:attrib1 > task:attrib1) or (./000030/suite/family == complete))) and ((./000031/suite/family:attrib1 > task:attrib1) or (./000031/suite/family == complete))) and ((./000032/suite/family:attrib1 > task:attrib1) or (./000032/suite/family == complete))) and ((./000033/suite/family:attrib1 > task:attrib1) or (./000033/suite/family == complete))) and ((./000034/suite/family:attrib1 > task:attrib1) or (./000034/suite/family == complete))) and ((./000035/suite/family:attrib1 > task:attrib1) or (./000035/suite/family == complete))) and ((./000036/suite/family:attrib1 > task:attrib1) or (./000036/suite/family == complete))) and ((./000037/suite/family:attrib1 > task:attrib1) or (./000037/suite/family == complete))) and ((./000038/suite/family:attrib1 > task:attrib1) or (./000038/suite/family == complete))) and ((./000039/suite/family:attrib1 > task:attrib1) or (./000039/suite/family == complete))) and ((./000040/suite/family:attrib1 > task:attrib1) or (./000040/suite/family == complete))) and ((./000041/suite/family:attrib1 > task:attrib1) or (./000041/suite/family == complete))) and ((./000042/suite/family:attrib1 > task:attrib1) or (./000042/suite/family == complete))) and ((./000043/suite/family:attrib1 > task:attrib1) or (./000043/suite/family == complete))) and ((./000044/suite/family:attrib1 > task:attrib1) or (./000044/suite/family == complete))) and ((./000045/suite/family:attrib1 > task:attrib1) or (./000045/suite/family == complete))) and ((./000046/suite/family:attrib1 > task:attrib1) or (./000046/suite/family == complete))) and ((./000047/suite/family:attrib1 > task:attrib1) or (./000047/suite/family == complete))) and ((./000048/suite/family:attrib1 > task:attrib1) or (./000048/suite/family == complete))) and ((./000049/suite/family:attrib1 > task:attrib1) or (./000049/suite/family == complete))) and ((./000050/suite/family:attrib1 > task:attrib1) or (./000050/suite/family == complete))) and ((./000051/suite/family:attrib1 > task:attrib1) or (./000051/suite/family == complete)))"
+    },
+    {
+      "expression": "((((../../../suite:attrib1 gt family:attrib1 or ../../../suite eq complete) and (../../task:attrib1 gt family:attrib1 or ../../task eq complete)) and node4:attrib1 + 604800 gt family:attrib1) and (../../task:attrib1 gt family:attrib1 or ../../task eq complete))",
+      "expected": "(((((../../../suite:attrib1 > family:attrib1) or (../../../suite == complete)) and ((../../task:attrib1 > family:attrib1) or (../../task == complete))) and ((node4:attrib1 + 604800) > family:attrib1)) and ((../../task:attrib1 > family:attrib1) or (../../task == complete)))"
+    },
+    {
+      "expression": "((((((((../suite/000001/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000001/family/task eq complete) and (../suite/000002/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000002/family/task eq complete)) and (../suite/000003/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000003/family/task eq complete)) and (../suite/000004/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000004/family/task eq complete)) and (../suite/000005/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000005/family/task eq complete)) and (../suite/000006/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000006/family/task eq complete)) and (../suite/000007/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000007/family/task eq complete)) and (../suite/000008/family/task:attrib1 gt node4:attrib1 + 864000 or ../suite/000008/family/task eq complete))",
+      "expected": "(((((((((../suite/000001/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000001/family/task == complete)) and ((../suite/000002/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000002/family/task == complete))) and ((../suite/000003/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000003/family/task == complete))) and ((../suite/000004/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000004/family/task == complete))) and ((../suite/000005/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000005/family/task == complete))) and ((../suite/000006/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000006/family/task == complete))) and ((../suite/000007/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000007/family/task == complete))) and ((../suite/000008/family/task:attrib1 > (node4:attrib1 + 864000)) or (../suite/000008/family/task == complete)))"
+    },
+    {
+      "expression": "(suite:attrib1 and family:attrib2 + 604800 gt task:attrib2)",
+      "expected": "(suite:attrib1 and ((family:attrib2 + 604800) > task:attrib2))"
+    },
+    {
+      "expression": "(((((../suite/000001/family/task:attrib1 gt node4:attrib1 or ../suite/000001/family/task eq complete) and (../suite/000002/family/task:attrib1 gt node4:attrib1 or ../suite/000002/family/task eq complete)) and (../suite/000003/family/task:attrib1 gt node4:attrib1 or ../suite/000003/family/task eq complete)) and (../suite/000004/family/task:attrib1 gt node4:attrib1 or ../suite/000004/family/task eq complete)) and (../suite/000005/family/task:attrib1 gt node4:attrib1 or ../suite/000005/family/task eq complete))",
+      "expected": "((((((../suite/000001/family/task:attrib1 > node4:attrib1) or (../suite/000001/family/task == complete)) and ((../suite/000002/family/task:attrib1 > node4:attrib1) or (../suite/000002/family/task == complete))) and ((../suite/000003/family/task:attrib1 > node4:attrib1) or (../suite/000003/family/task == complete))) and ((../suite/000004/family/task:attrib1 > node4:attrib1) or (../suite/000004/family/task == complete))) and ((../suite/000005/family/task:attrib1 > node4:attrib1) or (../suite/000005/family/task == complete)))"
+    },
+    {
+      "expression": "(((../suite/000001/family/task:attrib1 gt node4:attrib1 or ../suite/000001/family/task eq complete) and (../suite/000002/family/task:attrib1 gt node4:attrib1 or ../suite/000002/family/task eq complete)) and (../suite/000003/family/task:attrib1 gt node4:attrib1 or ../suite/000003/family/task eq complete))",
+      "expected": "((((../suite/000001/family/task:attrib1 > node4:attrib1) or (../suite/000001/family/task == complete)) and ((../suite/000002/family/task:attrib1 > node4:attrib1) or (../suite/000002/family/task == complete))) and ((../suite/000003/family/task:attrib1 > node4:attrib1) or (../suite/000003/family/task == complete)))"
+    },
+    {
+      "expression": "(((suite/000001/family/task:attrib1 gt node4:attrib1 or suite/000001/family/task eq complete) and (suite/000002/family/task:attrib1 gt node4:attrib1 or suite/000002/family/task eq complete)) and node5 eq complete)",
+      "expected": "((((suite/000001/family/task:attrib1 > node4:attrib1) or (suite/000001/family/task == complete)) and ((suite/000002/family/task:attrib1 > node4:attrib1) or (suite/000002/family/task == complete))) and (node5 == complete))"
+    },
+    {
+      "expression": "(((((((((./000001/suite/family:attrib1 gt task:attrib1 or ./000001/suite/family eq complete) and (./000002/suite/family:attrib1 gt task:attrib1 or ./000002/suite/family eq complete)) and (./000003/suite/family:attrib1 gt task:attrib1 or ./000003/suite/family eq complete)) and (./000004/suite/family:attrib1 gt task:attrib1 or ./000004/suite/family eq complete)) and (./000005/suite/family:attrib1 gt task:attrib1 or ./000005/suite/family eq complete)) and (./000006/suite/family:attrib1 gt task:attrib1 or ./000006/suite/family eq complete)) and (./000007/suite/family:attrib1 gt task:attrib1 or ./000007/suite/family eq complete)) and (./000008/suite/family:attrib1 gt task:attrib1 or ./000008/suite/family eq complete)) and (./000009/suite/family:attrib1 gt task:attrib1 or ./000009/suite/family eq complete))",
+      "expected": "((((((((((./000001/suite/family:attrib1 > task:attrib1) or (./000001/suite/family == complete)) and ((./000002/suite/family:attrib1 > task:attrib1) or (./000002/suite/family == complete))) and ((./000003/suite/family:attrib1 > task:attrib1) or (./000003/suite/family == complete))) and ((./000004/suite/family:attrib1 > task:attrib1) or (./000004/suite/family == complete))) and ((./000005/suite/family:attrib1 > task:attrib1) or (./000005/suite/family == complete))) and ((./000006/suite/family:attrib1 > task:attrib1) or (./000006/suite/family == complete))) and ((./000007/suite/family:attrib1 > task:attrib1) or (./000007/suite/family == complete))) and ((./000008/suite/family:attrib1 > task:attrib1) or (./000008/suite/family == complete))) and ((./000009/suite/family:attrib1 > task:attrib1) or (./000009/suite/family == complete)))"
+    },
+    {
+      "expression": "((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((./000001/suite/family:attrib1 gt task:attrib1 or ./000001/suite/family eq complete) and (./000002/suite/family:attrib1 gt task:attrib1 or ./000002/suite/family eq complete)) and (./000003/suite/family:attrib1 gt task:attrib1 or ./000003/suite/family eq complete)) and (./000004/suite/family:attrib1 gt task:attrib1 or ./000004/suite/family eq complete)) and (./000005/suite/family:attrib1 gt task:attrib1 or ./000005/suite/family eq complete)) and (./000006/suite/family:attrib1 gt task:attrib1 or ./000006/suite/family eq complete)) and (./000007/suite/family:attrib1 gt task:attrib1 or ./000007/suite/family eq complete)) and (./000008/suite/family:attrib1 gt task:attrib1 or ./000008/suite/family eq complete)) and (./000009/suite/family:attrib1 gt task:attrib1 or ./000009/suite/family eq complete)) and (./000010/suite/family:attrib1 gt task:attrib1 or ./000010/suite/family eq complete)) and (./000011/suite/family:attrib1 gt task:attrib1 or ./000011/suite/family eq complete)) and (./000012/suite/family:attrib1 gt task:attrib1 or ./000012/suite/family eq complete)) and (./000013/suite/family:attrib1 gt task:attrib1 or ./000013/suite/family eq complete)) and (./000014/suite/family:attrib1 gt task:attrib1 or ./000014/suite/family eq complete)) and (./000015/suite/family:attrib1 gt task:attrib1 or ./000015/suite/family eq complete)) and (./000016/suite/family:attrib1 gt task:attrib1 or ./000016/suite/family eq complete)) and (./000017/suite/family:attrib1 gt task:attrib1 or ./000017/suite/family eq complete)) and (./000018/suite/family:attrib1 gt task:attrib1 or ./000018/suite/family eq complete)) and (./000019/suite/family:attrib1 gt task:attrib1 or ./000019/suite/family eq complete)) and (./000020/suite/family:attrib1 gt task:attrib1 or ./000020/suite/family eq complete)) and (./000021/suite/family:attrib1 gt task:attrib1 or ./000021/suite/family eq complete)) and (./000022/suite/family:attrib1 gt task:attrib1 or ./000022/suite/family eq complete)) and (./000023/suite/family:attrib1 gt task:attrib1 or ./000023/suite/family eq complete)) and (./000024/suite/family:attrib1 gt task:attrib1 or ./000024/suite/family eq complete)) and (./000025/suite/family:attrib1 gt task:attrib1 or ./000025/suite/family eq complete)) and (./000026/suite/family:attrib1 gt task:attrib1 or ./000026/suite/family eq complete)) and (./000027/suite/family:attrib1 gt task:attrib1 or ./000027/suite/family eq complete)) and (./000028/suite/family:attrib1 gt task:attrib1 or ./000028/suite/family eq complete)) and (./000029/suite/family:attrib1 gt task:attrib1 or ./000029/suite/family eq complete)) and (./000030/suite/family:attrib1 gt task:attrib1 or ./000030/suite/family eq complete)) and (./000031/suite/family:attrib1 gt task:attrib1 or ./000031/suite/family eq complete)) and (./000032/suite/family:attrib1 gt task:attrib1 or ./000032/suite/family eq complete)) and (./000033/suite/family:attrib1 gt task:attrib1 or ./000033/suite/family eq complete)) and (./000034/suite/family:attrib1 gt task:attrib1 or ./000034/suite/family eq complete)) and (./000035/suite/family:attrib1 gt task:attrib1 or ./000035/suite/family eq complete)) and (./000036/suite/family:attrib1 gt task:attrib1 or ./000036/suite/family eq complete)) and (./000037/suite/family:attrib1 gt task:attrib1 or ./000037/suite/family eq complete)) and (./000038/suite/family:attrib1 gt task:attrib1 or ./000038/suite/family eq complete)) and (./000039/suite/family:attrib1 gt task:attrib1 or ./000039/suite/family eq complete)) and (./000040/suite/family:attrib1 gt task:attrib1 or ./000040/suite/family eq complete)) and (./000041/suite/family:attrib1 gt task:attrib1 or ./000041/suite/family eq complete)) and (./000042/suite/family:attrib1 gt task:attrib1 or ./000042/suite/family eq complete)) and (./000043/suite/family:attrib1 gt task:attrib1 or ./000043/suite/family eq complete)) and (./000044/suite/family:attrib1 gt task:attrib1 or ./000044/suite/family eq complete)) and (./000045/suite/family:attrib1 gt task:attrib1 or ./000045/suite/family eq complete)) and (./000046/suite/family:attrib1 gt task:attrib1 or ./000046/suite/family eq complete)) and (./000047/suite/family:attrib1 gt task:attrib1 or ./000047/suite/family eq complete)) and (./000048/suite/family:attrib1 gt task:attrib1 or ./000048/suite/family eq complete)) and (./000049/suite/family:attrib1 gt task:attrib1 or ./000049/suite/family eq complete)) and (./000050/suite/family:attrib1 gt task:attrib1 or ./000050/suite/family eq complete)) and (./000051/suite/family:attrib1 gt task:attrib1 or ./000051/suite/family eq complete)) and (./000052/suite/family:attrib1 gt task:attrib1 or ./000052/suite/family eq complete)) and (./000053/suite/family:attrib1 gt task:attrib1 or ./000053/suite/family eq complete)) and (./000054/suite/family:attrib1 gt task:attrib1 or ./000054/suite/family eq complete)) and (./000055/suite/family:attrib1 gt task:attrib1 or ./000055/suite/family eq complete)) and (./000056/suite/family:attrib1 gt task:attrib1 or ./000056/suite/family eq complete)) and (./000057/suite/family:attrib1 gt task:attrib1 or ./000057/suite/family eq complete)) and (./000058/suite/family:attrib1 gt task:attrib1 or ./000058/suite/family eq complete)) and (./000059/suite/family:attrib1 gt task:attrib1 or ./000059/suite/family eq complete)) and (./000060/suite/family:attrib1 gt task:attrib1 or ./000060/suite/family eq complete)) and (./000061/suite/family:attrib1 gt task:attrib1 or ./000061/suite/family eq complete)) and (./000062/suite/family:attrib1 gt task:attrib1 or ./000062/suite/family eq complete)) and (./000063/suite/family:attrib1 gt task:attrib1 or ./000063/suite/family eq complete)) and (./000064/suite/family:attrib1 gt task:attrib1 or ./000064/suite/family eq complete)) and (./000065/suite/family:attrib1 gt task:attrib1 or ./000065/suite/family eq complete)) and (./000066/suite/family:attrib1 gt task:attrib1 or ./000066/suite/family eq complete)) and (./000067/suite/family:attrib1 gt task:attrib1 or ./000067/suite/family eq complete)) and (./000068/suite/family:attrib1 gt task:attrib1 or ./000068/suite/family eq complete)) and (./000069/suite/family:attrib1 gt task:attrib1 or ./000069/suite/family eq complete)) and (./000070/suite/family:attrib1 gt task:attrib1 or ./000070/suite/family eq complete)) and (./000071/suite/family:attrib1 gt task:attrib1 or ./000071/suite/family eq complete)) and (./000072/suite/family:attrib1 gt task:attrib1 or ./000072/suite/family eq complete)) and (./000073/suite/family:attrib1 gt task:attrib1 or ./000073/suite/family eq complete)) and (./000074/suite/family:attrib1 gt task:attrib1 or ./000074/suite/family eq complete)) and (./000075/suite/family:attrib1 gt task:attrib1 or ./000075/suite/family eq complete)) and (./000076/suite/family:attrib1 gt task:attrib1 or ./000076/suite/family eq complete)) and (./000077/suite/family:attrib1 gt task:attrib1 or ./000077/suite/family eq complete)) and (./000078/suite/family:attrib1 gt task:attrib1 or ./000078/suite/family eq complete)) and (./000079/suite/family:attrib1 gt task:attrib1 or ./000079/suite/family eq complete)) and (./000080/suite/family:attrib1 gt task:attrib1 or ./000080/suite/family eq complete)) and (./000081/suite/family:attrib1 gt task:attrib1 or ./000081/suite/family eq complete)) and (./000082/suite/family:attrib1 gt task:attrib1 or ./000082/suite/family eq complete)) and (./000083/suite/family:attrib1 gt task:attrib1 or ./000083/suite/family eq complete)) and (./000084/suite/family:attrib1 gt task:attrib1 or ./000084/suite/family eq complete)) and (./000085/suite/family:attrib1 gt task:attrib1 or ./000085/suite/family eq complete)) and (./000086/suite/family:attrib1 gt task:attrib1 or ./000086/suite/family eq complete)) and (./000087/suite/family:attrib1 gt task:attrib1 or ./000087/suite/family eq complete)) and (./000088/suite/family:attrib1 gt task:attrib1 or ./000088/suite/family eq complete)) and (./000089/suite/family:attrib1 gt task:attrib1 or ./000089/suite/family eq complete)) and (./000090/suite/family:attrib1 gt task:attrib1 or ./000090/suite/family eq complete)) and (./000091/suite/family:attrib1 gt task:attrib1 or ./000091/suite/family eq complete)) and (./000092/suite/family:attrib1 gt task:attrib1 or ./000092/suite/family eq complete)) and (./000093/suite/family:attrib1 gt task:attrib1 or ./000093/suite/family eq complete)) and (./000094/suite/family:attrib1 gt task:attrib1 or ./000094/suite/family eq complete)) and (./000095/suite/family:attrib1 gt task:attrib1 or ./000095/suite/family eq complete)) and (./000096/suite/family:attrib1 gt task:attrib1 or ./000096/suite/family eq complete)) and (./000097/suite/family:attrib1 gt task:attrib1 or ./000097/suite/family eq complete)) and (./000098/suite/family:attrib1 gt task:attrib1 or ./000098/suite/family eq complete)) and (./000099/suite/family:attrib1 gt task:attrib1 or ./000099/suite/family eq complete)) and (./000100/suite/family:attrib1 gt task:attrib1 or ./000100/suite/family eq complete))",
+      "expected": "(((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((./000001/suite/family:attrib1 > task:attrib1) or (./000001/suite/family == complete)) and ((./000002/suite/family:attrib1 > task:attrib1) or (./000002/suite/family == complete))) and ((./000003/suite/family:attrib1 > task:attrib1) or (./000003/suite/family == complete))) and ((./000004/suite/family:attrib1 > task:attrib1) or (./000004/suite/family == complete))) and ((./000005/suite/family:attrib1 > task:attrib1) or (./000005/suite/family == complete))) and ((./000006/suite/family:attrib1 > task:attrib1) or (./000006/suite/family == complete))) and ((./000007/suite/family:attrib1 > task:attrib1) or (./000007/suite/family == complete))) and ((./000008/suite/family:attrib1 > task:attrib1) or (./000008/suite/family == complete))) and ((./000009/suite/family:attrib1 > task:attrib1) or (./000009/suite/family == complete))) and ((./000010/suite/family:attrib1 > task:attrib1) or (./000010/suite/family == complete))) and ((./000011/suite/family:attrib1 > task:attrib1) or (./000011/suite/family == complete))) and ((./000012/suite/family:attrib1 > task:attrib1) or (./000012/suite/family == complete))) and ((./000013/suite/family:attrib1 > task:attrib1) or (./000013/suite/family == complete))) and ((./000014/suite/family:attrib1 > task:attrib1) or (./000014/suite/family == complete))) and ((./000015/suite/family:attrib1 > task:attrib1) or (./000015/suite/family == complete))) and ((./000016/suite/family:attrib1 > task:attrib1) or (./000016/suite/family == complete))) and ((./000017/suite/family:attrib1 > task:attrib1) or (./000017/suite/family == complete))) and ((./000018/suite/family:attrib1 > task:attrib1) or (./000018/suite/family == complete))) and ((./000019/suite/family:attrib1 > task:attrib1) or (./000019/suite/family == complete))) and ((./000020/suite/family:attrib1 > task:attrib1) or (./000020/suite/family == complete))) and ((./000021/suite/family:attrib1 > task:attrib1) or (./000021/suite/family == complete))) and ((./000022/suite/family:attrib1 > task:attrib1) or (./000022/suite/family == complete))) and ((./000023/suite/family:attrib1 > task:attrib1) or (./000023/suite/family == complete))) and ((./000024/suite/family:attrib1 > task:attrib1) or (./000024/suite/family == complete))) and ((./000025/suite/family:attrib1 > task:attrib1) or (./000025/suite/family == complete))) and ((./000026/suite/family:attrib1 > task:attrib1) or (./000026/suite/family == complete))) and ((./000027/suite/family:attrib1 > task:attrib1) or (./000027/suite/family == complete))) and ((./000028/suite/family:attrib1 > task:attrib1) or (./000028/suite/family == complete))) and ((./000029/suite/family:attrib1 > task:attrib1) or (./000029/suite/family == complete))) and ((./000030/suite/family:attrib1 > task:attrib1) or (./000030/suite/family == complete))) and ((./000031/suite/family:attrib1 > task:attrib1) or (./000031/suite/family == complete))) and ((./000032/suite/family:attrib1 > task:attrib1) or (./000032/suite/family == complete))) and ((./000033/suite/family:attrib1 > task:attrib1) or (./000033/suite/family == complete))) and ((./000034/suite/family:attrib1 > task:attrib1) or (./000034/suite/family == complete))) and ((./000035/suite/family:attrib1 > task:attrib1) or (./000035/suite/family == complete))) and ((./000036/suite/family:attrib1 > task:attrib1) or (./000036/suite/family == complete))) and ((./000037/suite/family:attrib1 > task:attrib1) or (./000037/suite/family == complete))) and ((./000038/suite/family:attrib1 > task:attrib1) or (./000038/suite/family == complete))) and ((./000039/suite/family:attrib1 > task:attrib1) or (./000039/suite/family == complete))) and ((./000040/suite/family:attrib1 > task:attrib1) or (./000040/suite/family == complete))) and ((./000041/suite/family:attrib1 > task:attrib1) or (./000041/suite/family == complete))) and ((./000042/suite/family:attrib1 > task:attrib1) or (./000042/suite/family == complete))) and ((./000043/suite/family:attrib1 > task:attrib1) or (./000043/suite/family == complete))) and ((./000044/suite/family:attrib1 > task:attrib1) or (./000044/suite/family == complete))) and ((./000045/suite/family:attrib1 > task:attrib1) or (./000045/suite/family == complete))) and ((./000046/suite/family:attrib1 > task:attrib1) or (./000046/suite/family == complete))) and ((./000047/suite/family:attrib1 > task:attrib1) or (./000047/suite/family == complete))) and ((./000048/suite/family:attrib1 > task:attrib1) or (./000048/suite/family == complete))) and ((./000049/suite/family:attrib1 > task:attrib1) or (./000049/suite/family == complete))) and ((./000050/suite/family:attrib1 > task:attrib1) or (./000050/suite/family == complete))) and ((./000051/suite/family:attrib1 > task:attrib1) or (./000051/suite/family == complete))) and ((./000052/suite/family:attrib1 > task:attrib1) or (./000052/suite/family == complete))) and ((./000053/suite/family:attrib1 > task:attrib1) or (./000053/suite/family == complete))) and ((./000054/suite/family:attrib1 > task:attrib1) or (./000054/suite/family == complete))) and ((./000055/suite/family:attrib1 > task:attrib1) or (./000055/suite/family == complete))) and ((./000056/suite/family:attrib1 > task:attrib1) or (./000056/suite/family == complete))) and ((./000057/suite/family:attrib1 > task:attrib1) or (./000057/suite/family == complete))) and ((./000058/suite/family:attrib1 > task:attrib1) or (./000058/suite/family == complete))) and ((./000059/suite/family:attrib1 > task:attrib1) or (./000059/suite/family == complete))) and ((./000060/suite/family:attrib1 > task:attrib1) or (./000060/suite/family == complete))) and ((./000061/suite/family:attrib1 > task:attrib1) or (./000061/suite/family == complete))) and ((./000062/suite/family:attrib1 > task:attrib1) or (./000062/suite/family == complete))) and ((./000063/suite/family:attrib1 > task:attrib1) or (./000063/suite/family == complete))) and ((./000064/suite/family:attrib1 > task:attrib1) or (./000064/suite/family == complete))) and ((./000065/suite/family:attrib1 > task:attrib1) or (./000065/suite/family == complete))) and ((./000066/suite/family:attrib1 > task:attrib1) or (./000066/suite/family == complete))) and ((./000067/suite/family:attrib1 > task:attrib1) or (./000067/suite/family == complete))) and ((./000068/suite/family:attrib1 > task:attrib1) or (./000068/suite/family == complete))) and ((./000069/suite/family:attrib1 > task:attrib1) or (./000069/suite/family == complete))) and ((./000070/suite/family:attrib1 > task:attrib1) or (./000070/suite/family == complete))) and ((./000071/suite/family:attrib1 > task:attrib1) or (./000071/suite/family == complete))) and ((./000072/suite/family:attrib1 > task:attrib1) or (./000072/suite/family == complete))) and ((./000073/suite/family:attrib1 > task:attrib1) or (./000073/suite/family == complete))) and ((./000074/suite/family:attrib1 > task:attrib1) or (./000074/suite/family == complete))) and ((./000075/suite/family:attrib1 > task:attrib1) or (./000075/suite/family == complete))) and ((./000076/suite/family:attrib1 > task:attrib1) or (./000076/suite/family == complete))) and ((./000077/suite/family:attrib1 > task:attrib1) or (./000077/suite/family == complete))) and ((./000078/suite/family:attrib1 > task:attrib1) or (./000078/suite/family == complete))) and ((./000079/suite/family:attrib1 > task:attrib1) or (./000079/suite/family == complete))) and ((./000080/suite/family:attrib1 > task:attrib1) or (./000080/suite/family == complete))) and ((./000081/suite/family:attrib1 > task:attrib1) or (./000081/suite/family == complete))) and ((./000082/suite/family:attrib1 > task:attrib1) or (./000082/suite/family == complete))) and ((./000083/suite/family:attrib1 > task:attrib1) or (./000083/suite/family == complete))) and ((./000084/suite/family:attrib1 > task:attrib1) or (./000084/suite/family == complete))) and ((./000085/suite/family:attrib1 > task:attrib1) or (./000085/suite/family == complete))) and ((./000086/suite/family:attrib1 > task:attrib1) or (./000086/suite/family == complete))) and ((./000087/suite/family:attrib1 > task:attrib1) or (./000087/suite/family == complete))) and ((./000088/suite/family:attrib1 > task:attrib1) or (./000088/suite/family == complete))) and ((./000089/suite/family:attrib1 > task:attrib1) or (./000089/suite/family == complete))) and ((./000090/suite/family:attrib1 > task:attrib1) or (./000090/suite/family == complete))) and ((./000091/suite/family:attrib1 > task:attrib1) or (./000091/suite/family == complete))) and ((./000092/suite/family:attrib1 > task:attrib1) or (./000092/suite/family == complete))) and ((./000093/suite/family:attrib1 > task:attrib1) or (./000093/suite/family == complete))) and ((./000094/suite/family:attrib1 > task:attrib1) or (./000094/suite/family == complete))) and ((./000095/suite/family:attrib1 > task:attrib1) or (./000095/suite/family == complete))) and ((./000096/suite/family:attrib1 > task:attrib1) or (./000096/suite/family == complete))) and ((./000097/suite/family:attrib1 > task:attrib1) or (./000097/suite/family == complete))) and ((./000098/suite/family:attrib1 > task:attrib1) or (./000098/suite/family == complete))) and ((./000099/suite/family:attrib1 > task:attrib1) or (./000099/suite/family == complete))) and ((./000100/suite/family:attrib1 > task:attrib1) or (./000100/suite/family == complete)))"
+    },
+    {
+      "expression": "(:attrib1>:attrib2 or (:attrib1==:attrib2 and :attrib3>1915))",
+      "expected": "((:attrib1 > :attrib2) or ((:attrib1 == :attrib2) and (:attrib3 > 1915)))"
+    },
+    {
+      "expression": "(:attrib1>:attrib2+1 or (:attrib1==:attrib2+1 and :attrib3>715))",
+      "expected": "((:attrib1 > (:attrib2 + 1)) or ((:attrib1 == (:attrib2 + 1)) and (:attrib3 > 715)))"
+    },
+    {
+      "expression": "(suite==complete and ((:attrib1==1 and (:attrib2>:attrib3 or (:attrib2==:attrib3 and :attrib4>1910))) or (:attrib1==0 and (:attrib2>:attrib3 + 1 or (:attrib2==:attrib3 + 1 and :attrib4>600)))))",
+      "expected": "((suite == complete) and (((:attrib1 == 1) and ((:attrib2 > :attrib3) or ((:attrib2 == :attrib3) and (:attrib4 > 1910)))) or ((:attrib1 == 0) and ((:attrib2 > (:attrib3 + 1)) or ((:attrib2 == (:attrib3 + 1)) and (:attrib4 > 600))))))"
+    },
+    {
+      "expression": "(suite==complete and ((:attrib1==1 and (:attrib2>:attrib3 + 1 or (:attrib2==:attrib3 + 1 and :attrib4>710))) or (:attrib1==0 and (:attrib2>:attrib3 + 1 or (:attrib2==:attrib3 + 1 and :attrib4>1800)))))",
+      "expected": "((suite == complete) and (((:attrib1 == 1) and ((:attrib2 > (:attrib3 + 1)) or ((:attrib2 == (:attrib3 + 1)) and (:attrib4 > 710)))) or ((:attrib1 == 0) and ((:attrib2 > (:attrib3 + 1)) or ((:attrib2 == (:attrib3 + 1)) and (:attrib4 > 1800))))))"
+    },
+    {
+      "expression": "(suite==complete and ( ../../12/family/task==complete or ../../12/family/task:attrib1>9))",
+      "expected": "((suite == complete) and ((../../12/family/task == complete) or (../../12/family/task:attrib1 > 9)))"
+    },
+    {
+      "expression": "(../suite eq complete and ((../family/task:attrib1 eq node4:attrib1 and not (../node5/node6/node7:attrib2)) or (../family/node8:attrib1 eq node4:attrib1 and ../node5/node6/node7:attrib2)))",
+      "expected": "((../suite == complete) and (((../family/task:attrib1 == node4:attrib1) and not (../node5/node6/node7:attrib2)) or ((../family/node8:attrib1 == node4:attrib1) and ../node5/node6/node7:attrib2)))"
+    },
+    {
+      "expression": "((cal::date_to_julian(/suite/family/task/node4:attrib1)-1 == cal::date_to_julian(/node5/node6:attrib1)and /suite/family/task/node4/node7/node8 == complete) or (cal::date_to_julian(/suite/family/task/node4:attrib1)-1 >= cal::date_to_julian(/node5/node6:attrib1)))",
+      "expected": "((((date_to_julian(arg:0) = 0 - 1) == date_to_julian(arg:0) = 0) and (/suite/family/task/node4/node7/node8 == complete)) or ((date_to_julian(arg:0) = 0 - 1) >= date_to_julian(arg:0) = 0))"
+    },
+    {
+      "expression": "((cal::date_to_julian(/suite/family/task/node4:attrib1)-1 == cal::date_to_julian(/node5/node6:attrib1)and /suite/family/task/node4/node7/node8 == complete) or (cal::date_to_julian(/suite/family/task/node4:attrib1)-1 > cal::date_to_julian(/node5/node6:attrib1)))",
+      "expected": "((((date_to_julian(arg:0) = 0 - 1) == date_to_julian(arg:0) = 0) and (/suite/family/task/node4/node7/node8 == complete)) or ((date_to_julian(arg:0) = 0 - 1) > date_to_julian(arg:0) = 0))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 > /task/node4:attrib1 or /suite/family:attrib1 == /task/node4:attrib1 and /suite/family/00/node5/node6 == complete))",
+      "expected": "((/suite/family:attrib1 > /task/node4:attrib1) or ((/suite/family:attrib1 == /task/node4:attrib1) and (/suite/family/00/node5/node6 == complete)))"
+    },
+    {
+      "expression": "(( suite:attrib1 < ( family:attrib1 + 3 ) and task == complete ))",
+      "expected": "((suite:attrib1 < (family:attrib1 + 3)) and (task == complete))"
+    },
+    {
+      "expression": "(( ( ( ../suite:attrib1 <= 20250918 ) and ( family:attrib2 < 12 ) ) or ( ( ../suite:attrib1 >= 20250922 ) and ( family:attrib2 > 00 ) ) ))",
+      "expected": "(((../suite:attrib1 <= 20250918) and (family:attrib2 < 12)) or ((../suite:attrib1 >= 20250922) and (family:attrib2 > 0)))"
+    },
+    {
+      "expression": "(( suite == complete and 1 ))",
+      "expected": "((suite == complete) and 1)"
+    },
+    {
+      "expression": "(( suite == aborted or suite == complete ))",
+      "expected": "((suite == aborted) or (suite == complete))"
+    },
+    {
+      "expression": "(( ( ../../suite == complete ) or ( ../../suite:attrib1 > ../../family:attrib1 or ( ../../suite:attrib1 == ../../family:attrib1 and ( ../../suite/task:attrib2 > ../task:attrib2 or ( ../../suite/task:attrib2 == ../task:attrib2 and ../../suite/task/node4/node5 == complete and ../../suite/task/node4/node6/node7 == complete ))))))",
+      "expected": "((../../suite == complete) or ((../../suite:attrib1 > ../../family:attrib1) or ((../../suite:attrib1 == ../../family:attrib1) and ((../../suite/task:attrib2 > ../task:attrib2) or (((../../suite/task:attrib2 == ../task:attrib2) and (../../suite/task/node4/node5 == complete)) and (../../suite/task/node4/node6/node7 == complete))))))"
+    },
+    {
+      "expression": "(( suite == complete and family == complete ))",
+      "expected": "((suite == complete) and (family == complete))"
+    },
+    {
+      "expression": "(( suite == complete and family == complete and task == complete ))",
+      "expected": "(((suite == complete) and (family == complete)) and (task == complete))"
+    },
+    {
+      "expression": "(( suite == complete and family == complete and ( ( ../../../task == complete ) or ( ../../../task:attrib1 > ../../../node4:attrib1 or ( ../../../task:attrib1 == ../../../node4:attrib1 and ( ../../../task/node5:attrib2 > ../../node5:attrib2 or ../../../task/node5:attrib2 == ../../node5:attrib2 and ../../../task/node5/node6/node7 == complete ))))))",
+      "expected": "(((suite == complete) and (family == complete)) and ((../../../task == complete) or ((../../../task:attrib1 > ../../../node4:attrib1) or ((../../../task:attrib1 == ../../../node4:attrib1) and ((../../../task/node5:attrib2 > ../../node5:attrib2) or ((../../../task/node5:attrib2 == ../../node5:attrib2) and (../../../task/node5/node6/node7 == complete)))))))"
+    },
+    {
+      "expression": "(( ../../suite == complete or ( ../../suite:attrib1 > ../../family:attrib1 or ( ../../suite:attrib1 == ../../family:attrib1 and ( ../../suite/task:attrib2 > ../task:attrib2 or ( ../../suite/task:attrib2 == ../task:attrib2 and ../../suite/task/node4/node5 == complete ))))))",
+      "expected": "((../../suite == complete) or ((../../suite:attrib1 > ../../family:attrib1) or ((../../suite:attrib1 == ../../family:attrib1) and ((../../suite/task:attrib2 > ../task:attrib2) or ((../../suite/task:attrib2 == ../task:attrib2) and (../../suite/task/node4/node5 == complete))))))"
+    },
+    {
+      "expression": "(( 1 and suite == complete and family == complete and 1 ))",
+      "expected": "(((1 and (suite == complete)) and (family == complete)) and 1)"
+    },
+    {
+      "expression": "(( ( suite == complete ) or ( family == aborted or task == aborted or node4 == aborted or suite == aborted ) ))",
+      "expected": "((suite == complete) or ((family == aborted) or ((task == aborted) or ((node4 == aborted) or (suite == aborted)))))"
+    },
+    {
+      "expression": "(( ( suite == aborted or suite == complete ) and family == complete ))",
+      "expected": "(((suite == aborted) or (suite == complete)) and (family == complete))"
+    },
+    {
+      "expression": "(( suite == complete && family == complete && task == complete ))",
+      "expected": "(((suite == complete) and (family == complete)) and (task == complete))"
+    },
+    {
+      "expression": "((/suite/family == complete AND /suite/task == complete))",
+      "expected": "((/suite/family == complete) and (/suite/task == complete))"
+    },
+    {
+      "expression": "((/suite/20241121/0000/family/task/node4/node5 == active OR /suite/20241121/0000/family/task/node4/node5 == complete))",
+      "expected": "((/suite/20241121/0000/family/task/node4/node5 == active) or (/suite/20241121/0000/family/task/node4/node5 == complete))"
+    },
+    {
+      "expression": "(( 1 and suite == complete and family == complete and task == complete and 1 ))",
+      "expected": "((((1 and (suite == complete)) and (family == complete)) and (task == complete)) and 1)"
+    },
+    {
+      "expression": "(suite eq complete and (family eq complete and task eq complete))",
+      "expected": "((suite == complete) and ((family == complete) and (task == complete)))"
+    },
+    {
+      "expression": "((./00:attrib1 le ../suite/00:attrib1 + 2 or ../suite/00 eq complete) and /family/task:attrib1 gt ./00:attrib1 - 1)",
+      "expected": "(((./00:attrib1 <= (../suite/00:attrib1 + 2)) or (../suite/00 == complete)) and (/family/task:attrib1 > (./00:attrib1 - 1)))"
+    },
+    {
+      "expression": "((./00:attrib1 le ../suite/00:attrib1 + 2 or ../suite/00 eq complete) and /family/0011/task/node4/node5:attrib1 > :attrib1)",
+      "expected": "(((./00:attrib1 <= (../suite/00:attrib1 + 2)) or (../suite/00 == complete)) and (/family/0011/task/node4/node5:attrib1 > :attrib1))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1-1) and /suite/family/task/node4/node5/node7/node8:attrib2 >= 12 and /suite/family/task/node4/node5/task==complete)) and node9 == complete)",
+      "expected": "(((/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node6:attrib1 - 1)) and ((/suite/family/task/node4/node5/node7/node8:attrib2 >= 12) and (/suite/family/task/node4/node5/task == complete)))) and (node9 == complete))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and /suite/family/task/node4/node5/node7/node8:attrib2 >= 12 and /suite/family/task/node4/node5/task==complete)) and node9 == complete)",
+      "expected": "(((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and ((/suite/family/task/node4/node5/node7/node8:attrib2 >= 12) and (/suite/family/task/node4/node5/task == complete)))) and (node9 == complete))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 eq 0 and /suite/family/12 eq complete and /suite/family/00 eq complete)",
+      "expected": "(((/suite/family:attrib1 == 0) and (/suite/family/12 == complete)) and (/suite/family/00 == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 >= ./00:attrib1) or (/suite/family:attrib1 == ./00:attrib1 -1 and /suite/family/00/task == complete))",
+      "expected": "((/suite/family:attrib1 >= ./00:attrib1) or ((/suite/family:attrib1 == (./00:attrib1 - 1)) and (/suite/family/00/task == complete)))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 >= ./00:attrib1 or (/suite/family:attrib1 + 1 == ./00:attrib1 and /suite/family/00/task == complete))",
+      "expected": "((/suite/family:attrib1 >= ./00:attrib1) or (((/suite/family:attrib1 + 1) == ./00:attrib1) and (/suite/family/00/task == complete)))"
+    },
+    {
+      "expression": "((../../suite/family == complete) AND (/task/5974/node4/node5/node6:attrib1 lt /task/5973/node4/node7/node8:attrib1))",
+      "expected": "((../../suite/family == complete) and (/task/5974/node4/node5/node6:attrib1 < /task/5973/node4/node7/node8:attrib1))"
+    },
+    {
+      "expression": "(./suite:attrib1 lt (../family/suite:attrib1 + 2))",
+      "expected": "(./suite:attrib1 < (../family/suite:attrib1 + 2))"
+    },
+    {
+      "expression": "((/suite/5989/family/task/node4/node5 == complete and /suite/5989/family/task/node4:attrib1 == /suite/5989/family/node6/node4:attrib1 or (/suite/5989/family/task/node4:attrib1 gt /suite/5989/family/node6/node4:attrib1)) and ((/suite/5989/family/node6/node4:attrib1 le /suite/5989/family/node7/node4:attrib1 + /suite/5989:attrib2)))",
+      "expected": "((((/suite/5989/family/task/node4/node5 == complete) and (/suite/5989/family/task/node4:attrib1 == /suite/5989/family/node6/node4:attrib1)) or (/suite/5989/family/task/node4:attrib1 > /suite/5989/family/node6/node4:attrib1)) and (/suite/5989/family/node6/node4:attrib1 <= (/suite/5989/family/node7/node4:attrib1 + /suite/5989:attrib2)))"
+    },
+    {
+      "expression": "((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (/node5/5989/node6/node7/node8/node6/node9 == complete)) and (node10 == complete))",
+      "expected": "((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (/node5/5989/node6/node7/node8/node6/node9 == complete)) and (node10 == complete))"
+    },
+    {
+      "expression": "((/suite/5989/family/task/node4/family/node5/node6/node7:attrib1 and /suite/5989/family/task/node4/family/node8==complete and /suite/5989/family/task/node4:attrib2 == /suite/5989/family/node9/node4:attrib2) or (/suite/5989/family/task/node4:attrib2 gt /suite/5989/family/node9/node4:attrib2))",
+      "expected": "(((/suite/5989/family/task/node4/family/node5/node6/node7:attrib1 and (/suite/5989/family/task/node4/family/node8 == complete)) and (/suite/5989/family/task/node4:attrib2 == /suite/5989/family/node9/node4:attrib2)) or (/suite/5989/family/task/node4:attrib2 > /suite/5989/family/node9/node4:attrib2))"
+    },
+    {
+      "expression": "((/suite/5989/family/task/node4/node5/node6 == complete) and ((../../node7:attrib1 >= ../../node4:attrib1) or ((../../node7:attrib1 == ../../node4:attrib1-1) and ../../node7/node5/node8 == complete)))",
+      "expected": "((/suite/5989/family/task/node4/node5/node6 == complete) and ((../../node7:attrib1 >= ../../node4:attrib1) or ((../../node7:attrib1 == (../../node4:attrib1 - 1)) and (../../node7/node5/node8 == complete))))"
+    },
+    {
+      "expression": "(((((../suite:attrib1 >= ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1-1) and ../suite/task == complete))) and (node4 == complete)) and (node5 == complete))",
+      "expected": "((((../suite:attrib1 >= ../family:attrib1) or ((../suite:attrib1 == (../family:attrib1 - 1)) and (../suite/task == complete))) and (node4 == complete)) and (node5 == complete))"
+    },
+    {
+      "expression": "((/suite/5989/family/task/node4/node5/node6 == complete) and ((../../node7:attrib1 > ../../node4:attrib1) or ((../../node7:attrib1 == ../../node4:attrib1) and ../../node7/node5/node8 == complete)))",
+      "expected": "((/suite/5989/family/task/node4/node5/node6 == complete) and ((../../node7:attrib1 > ../../node4:attrib1) or ((../../node7:attrib1 == ../../node4:attrib1) and (../../node7/node5/node8 == complete))))"
+    },
+    {
+      "expression": "(((((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and ../suite/task == complete))) and (node4 == complete)) and (node5 == complete))",
+      "expected": "((((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and (../suite/task == complete))) and (node4 == complete)) and (node5 == complete))"
+    },
+    {
+      "expression": "(../../../suite/family == complete or ../../../suite/task:attrib1 > (../../../node4/family:attrib1 + 1) or (../../../suite/task:attrib1 == (../../../node4/family:attrib1 + 1) and ../../../suite/task/node5 == complete))",
+      "expected": "((../../../suite/family == complete) or ((../../../suite/task:attrib1 > (../../../node4/family:attrib1 + 1)) or ((../../../suite/task:attrib1 == (../../../node4/family:attrib1 + 1)) and (../../../suite/task/node5 == complete))))"
+    },
+    {
+      "expression": "(../../../suite/family == complete or (../../../suite/family:attrib1 > ../../../task/family:attrib1))",
+      "expected": "((../../../suite/family == complete) or (../../../suite/family:attrib1 > ../../../task/family:attrib1))"
+    },
+    {
+      "expression": "(../../suite/family:attrib1 gt (../../task/node4:attrib1 + 1) or ((../../suite/family:attrib1 eq ../../task/node4:attrib1 + 1) and (../../suite/family/node5/node6/node7 == complete)))",
+      "expected": "((../../suite/family:attrib1 > (../../task/node4:attrib1 + 1)) or ((../../suite/family:attrib1 == (../../task/node4:attrib1 + 1)) and (../../suite/family/node5/node6/node7 == complete)))"
+    },
+    {
+      "expression": "(../../suite/family:attrib1 gt ../../task/family:attrib1 or (../../suite/family:attrib1 eq ../../task/family:attrib1 and (../../suite/family/node4/node5/node6 == complete)))",
+      "expected": "((../../suite/family:attrib1 > ../../task/family:attrib1) or ((../../suite/family:attrib1 == ../../task/family:attrib1) and (../../suite/family/node4/node5/node6 == complete)))"
+    },
+    {
+      "expression": "(../../../suite/family:attrib1 > ../../../task/family:attrib1 or (../../../suite/family:attrib1 == ../../../task/family:attrib1 and ../../../suite/family/node4/node5==complete))",
+      "expected": "((../../../suite/family:attrib1 > ../../../task/family:attrib1) or ((../../../suite/family:attrib1 == ../../../task/family:attrib1) and (../../../suite/family/node4/node5 == complete)))"
+    },
+    {
+      "expression": "(../../suite/family:attrib1 eq ../../suite/task:attrib1 and ../../suite/family:attrib1 lt ../../node4/family:attrib1)",
+      "expected": "((../../suite/family:attrib1 == ../../suite/task:attrib1) and (../../suite/family:attrib1 < ../../node4/family:attrib1))"
+    },
+    {
+      "expression": "(../../suite/family:attrib1 lt ../../suite/task:attrib1 and (../../suite/family:attrib1 lt ../../node4/family:attrib1))",
+      "expected": "((../../suite/family:attrib1 < ../../suite/task:attrib1) and (../../suite/family:attrib1 < ../../node4/family:attrib1))"
+    },
+    {
+      "expression": "(/suite/5989/family/task/node4:attrib1 > ../../node5/node4:attrib1+1)",
+      "expected": "(/suite/5989/family/task/node4:attrib1 > (../../node5/node4:attrib1 + 1))"
+    },
+    {
+      "expression": "(/suite/5989/family/task/node4/node5 == complete and /suite/5989/family/task/node4:attrib1 == /suite/5989/family/node6/node7/node8/node4:attrib1 + 10 or (/suite/5989/family/task/node4:attrib1 gt /suite/5989/family/node6/node7/node8/node4:attrib1 + 10))",
+      "expected": "(((/suite/5989/family/task/node4/node5 == complete) and (/suite/5989/family/task/node4:attrib1 == (/suite/5989/family/node6/node7/node8/node4:attrib1 + 10))) or (/suite/5989/family/task/node4:attrib1 > (/suite/5989/family/node6/node7/node8/node4:attrib1 + 10)))"
+    },
+    {
+      "expression": "(( /suite/5989/family/task/node4/node5/node6 == complete and /suite/5989/family/task/node4/node5/node7 == complete and /suite/5989/family/task/node4:attrib1 == /suite/5989/family/node8/node9/node10/node4:attrib1 or (/suite/5989/family/task/node4:attrib1 gt /suite/5989/family/node8/node9/node10/node4:attrib1) ) and ((../node11:attrib1 >= ../node4:attrib1) or ((../node11:attrib1 == ../node4:attrib1-1) and ../node11/node10 == complete)))",
+      "expected": "(((((/suite/5989/family/task/node4/node5/node6 == complete) and (/suite/5989/family/task/node4/node5/node7 == complete)) and (/suite/5989/family/task/node4:attrib1 == /suite/5989/family/node8/node9/node10/node4:attrib1)) or (/suite/5989/family/task/node4:attrib1 > /suite/5989/family/node8/node9/node10/node4:attrib1)) and ((../node11:attrib1 >= ../node4:attrib1) or ((../node11:attrib1 == (../node4:attrib1 - 1)) and (../node11/node10 == complete))))"
+    },
+    {
+      "expression": "(( /suite/5989/family/task/node4/node5/node6 == complete and /suite/5989/family/task/node4/node5/node7 == complete and /suite/5989/family/task/node4:attrib1 == /suite/5989/family/node8/node9/node10/node4:attrib1 or (/suite/5989/family/task/node4:attrib1 gt /suite/5989/family/node8/node9/node10/node4:attrib1) ) and ((../node11:attrib1 > ../node4:attrib1) or ((../node11:attrib1 == ../node4:attrib1) and ../node11/node10 == complete)))",
+      "expected": "(((((/suite/5989/family/task/node4/node5/node6 == complete) and (/suite/5989/family/task/node4/node5/node7 == complete)) and (/suite/5989/family/task/node4:attrib1 == /suite/5989/family/node8/node9/node10/node4:attrib1)) or (/suite/5989/family/task/node4:attrib1 > /suite/5989/family/node8/node9/node10/node4:attrib1)) and ((../node11:attrib1 > ../node4:attrib1) or ((../node11:attrib1 == ../node4:attrib1) and (../node11/node10 == complete))))"
+    },
+    {
+      "expression": "((/suite/5989/family/task/node4/node5/node6 == complete and /suite/5989/family/task/node4/node5/node6:attrib1 == /suite/5989/family/task/node4/node7/node6:attrib1 or (/suite/5989/family/task/node4/node5/node6:attrib1 gt /suite/5989/family/task/node4/node7/node6:attrib1)) and (/suite/5989/family/task/node4/node8/node6 == complete and /suite/5989/family/task/node4/node8/node6:attrib1 == /suite/5989/family/task/node4/node7/node6:attrib1 or (/suite/5989/family/task/node4/node8/node6:attrib1 gt /suite/5989/family/task/node4/node7/node6:attrib1)) and (/suite/5989/family/task/node4/node9/node6 == complete and /suite/5989/family/task/node4/node9/node6:attrib1 == /suite/5989/family/task/node4/node7/node6:attrib1 or (/suite/5989/family/task/node4/node9/node6:attrib1 gt /suite/5989/family/task/node4/node7/node6:attrib1)) and (/suite/5989/family/task/node4/node10/node6 == complete and /suite/5989/family/task/node4/node10/node6:attrib1 == /suite/5989/family/task/node4/node7/node6:attrib1 or (/suite/5989/family/task/node4/node10/node6:attrib1 gt /suite/5989/family/task/node4/node7/node6:attrib1)))",
+      "expected": "((((/suite/5989/family/task/node4/node5/node6 == complete) and (/suite/5989/family/task/node4/node5/node6:attrib1 == /suite/5989/family/task/node4/node7/node6:attrib1)) or (/suite/5989/family/task/node4/node5/node6:attrib1 > /suite/5989/family/task/node4/node7/node6:attrib1)) and ((((/suite/5989/family/task/node4/node8/node6 == complete) and (/suite/5989/family/task/node4/node8/node6:attrib1 == /suite/5989/family/task/node4/node7/node6:attrib1)) or (/suite/5989/family/task/node4/node8/node6:attrib1 > /suite/5989/family/task/node4/node7/node6:attrib1)) and ((((/suite/5989/family/task/node4/node9/node6 == complete) and (/suite/5989/family/task/node4/node9/node6:attrib1 == /suite/5989/family/task/node4/node7/node6:attrib1)) or (/suite/5989/family/task/node4/node9/node6:attrib1 > /suite/5989/family/task/node4/node7/node6:attrib1)) and (((/suite/5989/family/task/node4/node10/node6 == complete) and (/suite/5989/family/task/node4/node10/node6:attrib1 == /suite/5989/family/task/node4/node7/node6:attrib1)) or (/suite/5989/family/task/node4/node10/node6:attrib1 > /suite/5989/family/task/node4/node7/node6:attrib1)))))"
+    },
+    {
+      "expression": "((/suite/5989/family/task/node4/node5/node6 == complete and /suite/5989/family/task/node4/node5/node6:attrib1 == /suite/5989/family/task/node4/node7/node6:attrib1 or (/suite/5989/family/task/node4/node5/node6:attrib1 gt /suite/5989/family/task/node4/node7/node6:attrib1)) and (/suite/5989/family/task/node4/node8/node6 == complete and /suite/5989/family/task/node4/node8/node6:attrib1 == /suite/5989/family/task/node4/node7/node6:attrib1 or (/suite/5989/family/task/node4/node8/node6:attrib1 gt /suite/5989/family/task/node4/node7/node6:attrib1)) and /suite/5989/family/task/node4/node8/node6:attrib1 > /suite/5989/family/task/node4/node7/node6:attrib1)",
+      "expected": "((((/suite/5989/family/task/node4/node5/node6 == complete) and (/suite/5989/family/task/node4/node5/node6:attrib1 == /suite/5989/family/task/node4/node7/node6:attrib1)) or (/suite/5989/family/task/node4/node5/node6:attrib1 > /suite/5989/family/task/node4/node7/node6:attrib1)) and ((((/suite/5989/family/task/node4/node8/node6 == complete) and (/suite/5989/family/task/node4/node8/node6:attrib1 == /suite/5989/family/task/node4/node7/node6:attrib1)) or (/suite/5989/family/task/node4/node8/node6:attrib1 > /suite/5989/family/task/node4/node7/node6:attrib1)) and (/suite/5989/family/task/node4/node8/node6:attrib1 > /suite/5989/family/task/node4/node7/node6:attrib1)))"
+    },
+    {
+      "expression": "(((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete))",
+      "expected": "(((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete))"
+    },
+    {
+      "expression": "(((../suite/family == complete and (../suite:attrib1 == ../task:attrib1-1)) or (../suite:attrib1 >= ../task:attrib1)) and /node4/5973/node5/node6/node7 == complete and node8 == complete and node9 == complete)",
+      "expected": "((((../suite/family == complete) and (../suite:attrib1 == (../task:attrib1 - 1))) or (../suite:attrib1 >= ../task:attrib1)) and (((/node4/5973/node5/node6/node7 == complete) and (node8 == complete)) and (node9 == complete)))"
+    },
+    {
+      "expression": "(((../suite/family == complete and (../suite:attrib1 == ../task:attrib1)) or (../suite:attrib1 > ../task:attrib1)) and /node4/5973/node5/node6/node7 == complete and node8 == complete and node9 == complete)",
+      "expected": "((((../suite/family == complete) and (../suite:attrib1 == ../task:attrib1)) or (../suite:attrib1 > ../task:attrib1)) and (((/node4/5973/node5/node6/node7 == complete) and (node8 == complete)) and (node9 == complete)))"
+    },
+    {
+      "expression": "((/suite/5924/family/task/node4/node5/node6/node7:attrib1 >= 12 and /suite/5924/family/task/node4/family/node6 == complete and (/suite/5924/family/task/node4:attrib2 == /suite/5924/family/task/node8:attrib2-1)) or (/suite/5924/family/task/node4:attrib2 >= /suite/5924/family/task/node8:attrib2))",
+      "expected": "((((/suite/5924/family/task/node4/node5/node6/node7:attrib1 >= 12) and (/suite/5924/family/task/node4/family/node6 == complete)) and (/suite/5924/family/task/node4:attrib2 == (/suite/5924/family/task/node8:attrib2 - 1))) or (/suite/5924/family/task/node4:attrib2 >= /suite/5924/family/task/node8:attrib2))"
+    },
+    {
+      "expression": "((suite == complete) and ((/family/5924/task/node4/node5/node6 == complete and (/family/5924/task/node4/node5:attrib1 == /family/5924/task/node4/node7:attrib1-1)) or (/family/5924/task/node4/node5:attrib1 >= /family/5924/task/node4/node7:attrib1)))",
+      "expected": "((suite == complete) and (((/family/5924/task/node4/node5/node6 == complete) and (/family/5924/task/node4/node5:attrib1 == (/family/5924/task/node4/node7:attrib1 - 1))) or (/family/5924/task/node4/node5:attrib1 >= /family/5924/task/node4/node7:attrib1)))"
+    },
+    {
+      "expression": "((/suite/5924/family/task/node4/node5/node6/node7:attrib1 >= 12 and /suite/5924/family/task/node4/family/node6 == complete and (/suite/5924/family/task/node4:attrib2 == /suite/5924/family/task/node8:attrib2)) or (/suite/5924/family/task/node4:attrib2 > /suite/5924/family/task/node8:attrib2))",
+      "expected": "((((/suite/5924/family/task/node4/node5/node6/node7:attrib1 >= 12) and (/suite/5924/family/task/node4/family/node6 == complete)) and (/suite/5924/family/task/node4:attrib2 == /suite/5924/family/task/node8:attrib2)) or (/suite/5924/family/task/node4:attrib2 > /suite/5924/family/task/node8:attrib2))"
+    },
+    {
+      "expression": "((suite == complete) and ((/family/5924/task/node4/node5/node6 == complete and (/family/5924/task/node4/node5:attrib1 == /family/5924/task/node4/node7:attrib1)) or (/family/5924/task/node4/node5:attrib1 > /family/5924/task/node4/node7:attrib1)))",
+      "expected": "((suite == complete) and (((/family/5924/task/node4/node5/node6 == complete) and (/family/5924/task/node4/node5:attrib1 == /family/5924/task/node4/node7:attrib1)) or (/family/5924/task/node4/node5:attrib1 > /family/5924/task/node4/node7:attrib1)))"
+    },
+    {
+      "expression": "((/suite/5739/family/task/node4/node5/node6 == complete and /suite/5739/family/task/node4/node5/node6:attrib1 == /suite/5739/family/task/node4/node7/node6:attrib1 or (/suite/5739/family/task/node4/node5/node6:attrib1 gt /suite/5739/family/task/node4/node7/node6:attrib1)))",
+      "expected": "(((/suite/5739/family/task/node4/node5/node6 == complete) and (/suite/5739/family/task/node4/node5/node6:attrib1 == /suite/5739/family/task/node4/node7/node6:attrib1)) or (/suite/5739/family/task/node4/node5/node6:attrib1 > /suite/5739/family/task/node4/node7/node6:attrib1))"
+    },
+    {
+      "expression": "(/suite/5708/family/task/node4 == complete and /suite/5708/family/task/node4:attrib1 == /suite/5708/family/node5/node4:attrib1 or (/suite/5708/family/task/node4:attrib1 gt /suite/5708/family/node5/node4:attrib1) AND (/suite/5708/family/node5/node4:attrib1 le /suite/5708/family/node6/node4:attrib1 + /suite/5708:attrib2))",
+      "expected": "(((/suite/5708/family/task/node4 == complete) and (/suite/5708/family/task/node4:attrib1 == /suite/5708/family/node5/node4:attrib1)) or ((/suite/5708/family/task/node4:attrib1 > /suite/5708/family/node5/node4:attrib1) and (/suite/5708/family/node5/node4:attrib1 <= (/suite/5708/family/node6/node4:attrib1 + /suite/5708:attrib2))))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete and node15 == complete and node16 == complete and node17 == complete)",
+      "expected": "(((((((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)) and (node17 == complete))"
+    },
+    {
+      "expression": "(/suite/5352/family/task/node4/node5 == complete and /suite/5352/family/task/node4/node6 == complete and /suite/5352/family/task/node4:attrib1 == /suite/5352/family/node7/node4:attrib1 or (/suite/5352/family/task/node4:attrib1 gt /suite/5352/family/node7/node4:attrib1))",
+      "expected": "((((/suite/5352/family/task/node4/node5 == complete) and (/suite/5352/family/task/node4/node6 == complete)) and (/suite/5352/family/task/node4:attrib1 == /suite/5352/family/node7/node4:attrib1)) or (/suite/5352/family/task/node4:attrib1 > /suite/5352/family/node7/node4:attrib1))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and (./task/node4 == complete or ./task/node4/node5:attrib1))",
+      "expected": "(((suite == complete) and (family == complete)) and ((./task/node4 == complete) or ./task/node4/node5:attrib1))"
+    },
+    {
+      "expression": "((suite == complete) and ((../../../../family/task/node4 == complete and ../../../../family/task:attrib1 == ../../../../node5/task:attrib1) or (../../../../family/task:attrib1 gt ../../../../node5/task:attrib1)))",
+      "expected": "((suite == complete) and (((../../../../family/task/node4 == complete) and (../../../../family/task:attrib1 == ../../../../node5/task:attrib1)) or (../../../../family/task:attrib1 > ../../../../node5/task:attrib1)))"
+    },
+    {
+      "expression": "((/suite/5059/family/task/node4/node5 == complete and /suite/5059/family/task/node4/node6 == complete and /suite/5059/family/task/node4/node7 == complete and (/suite/5059/family/task/node4:attrib1 == /suite/5059/family/task/node8:attrib1-1)) or (/suite/5059/family/task/node4:attrib1 >= /suite/5059/family/task/node8:attrib1))",
+      "expected": "(((((/suite/5059/family/task/node4/node5 == complete) and (/suite/5059/family/task/node4/node6 == complete)) and (/suite/5059/family/task/node4/node7 == complete)) and (/suite/5059/family/task/node4:attrib1 == (/suite/5059/family/task/node8:attrib1 - 1))) or (/suite/5059/family/task/node4:attrib1 >= /suite/5059/family/task/node8:attrib1))"
+    },
+    {
+      "expression": "((/suite/5059/family/task/node4/node5 == complete and /suite/5059/family/task/node4/node6 == complete and /suite/5059/family/task/node4/node7 == complete and /suite/5059/family/task/node4/node8 == complete and (/suite/5059/family/task/node4:attrib1 == /suite/5059/family/task/node9:attrib1-1)) or (/suite/5059/family/task/node4:attrib1 >= /suite/5059/family/task/node9:attrib1))",
+      "expected": "((((((/suite/5059/family/task/node4/node5 == complete) and (/suite/5059/family/task/node4/node6 == complete)) and (/suite/5059/family/task/node4/node7 == complete)) and (/suite/5059/family/task/node4/node8 == complete)) and (/suite/5059/family/task/node4:attrib1 == (/suite/5059/family/task/node9:attrib1 - 1))) or (/suite/5059/family/task/node4:attrib1 >= /suite/5059/family/task/node9:attrib1))"
+    },
+    {
+      "expression": "((/suite/5059/family/task/node4/node5 == complete and /suite/5059/family/task/node4/node6 == complete and /suite/5059/family/task/node4/node7 == complete and (/suite/5059/family/task/node4:attrib1 == /suite/5059/family/task/node8:attrib1)) or (/suite/5059/family/task/node4:attrib1 > /suite/5059/family/task/node8:attrib1))",
+      "expected": "(((((/suite/5059/family/task/node4/node5 == complete) and (/suite/5059/family/task/node4/node6 == complete)) and (/suite/5059/family/task/node4/node7 == complete)) and (/suite/5059/family/task/node4:attrib1 == /suite/5059/family/task/node8:attrib1)) or (/suite/5059/family/task/node4:attrib1 > /suite/5059/family/task/node8:attrib1))"
+    },
+    {
+      "expression": "((/suite/5059/family/task/node4/node5 == complete and /suite/5059/family/task/node4/node6 == complete and /suite/5059/family/task/node4/node7 == complete and /suite/5059/family/task/node4/node8 == complete and (/suite/5059/family/task/node4:attrib1 == /suite/5059/family/task/node9:attrib1)) or (/suite/5059/family/task/node4:attrib1 > /suite/5059/family/task/node9:attrib1))",
+      "expected": "((((((/suite/5059/family/task/node4/node5 == complete) and (/suite/5059/family/task/node4/node6 == complete)) and (/suite/5059/family/task/node4/node7 == complete)) and (/suite/5059/family/task/node4/node8 == complete)) and (/suite/5059/family/task/node4:attrib1 == /suite/5059/family/task/node9:attrib1)) or (/suite/5059/family/task/node4:attrib1 > /suite/5059/family/task/node9:attrib1))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete and node15 == complete and node16 == complete)",
+      "expected": "((((((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete))"
+    },
+    {
+      "expression": "((suite:attrib1 or suite == complete) and /family/5004/task/node4/node5/task/node6 == complete)",
+      "expected": "((suite:attrib1 or (suite == complete)) and (/family/5004/task/node4/node5/task/node6 == complete))"
+    },
+    {
+      "expression": "(/suite/5004/family//task/node4/family == complete and /suite/5004/family//task/node4:attrib1 + 1 == /suite/5004/family/node5/node4:attrib1 or (/suite/5004/family//task/node4:attrib1 + 1 gt /suite/5004/family/node5/node4:attrib1))",
+      "expected": "(((/suite/5004/family//task/node4/family == complete) and ((/suite/5004/family//task/node4:attrib1 + 1) == /suite/5004/family/node5/node4:attrib1)) or ((/suite/5004/family//task/node4:attrib1 + 1) > /suite/5004/family/node5/node4:attrib1))"
+    },
+    {
+      "expression": "((suite eq aborted and :attrib1 - suite:attrib2 ge 7) or (suite eq complete and :attrib1 - suite:attrib2 ge 2))",
+      "expected": "(((suite == aborted) and ((:attrib1 - suite:attrib2) >= 7)) or ((suite == complete) and ((:attrib1 - suite:attrib2) >= 2)))"
+    },
+    {
+      "expression": "(../../suite/family == complete and /task/5976/node4/node5/node6:attrib1 lt /task/5970/node4/node7/node8:attrib1)",
+      "expected": "((../../suite/family == complete) and (/task/5976/node4/node5/node6:attrib1 < /task/5970/node4/node7/node8:attrib1))"
+    },
+    {
+      "expression": "(./suite:attrib1 le (../family/suite:attrib1 + /task/5751:attrib2))",
+      "expected": "(./suite:attrib1 <= (../family/suite:attrib1 + /task/5751:attrib2))"
+    },
+    {
+      "expression": "(../suite:attrib1 gt ../family:attrib1 or (../suite:attrib1 eq ../family:attrib1 and ../suite/task:attrib2 ge task:attrib2))",
+      "expected": "((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and (../suite/task:attrib2 >= task:attrib2)))"
+    },
+    {
+      "expression": "(../../../suite:attrib1 gt ../../../family:attrib1 or (../../../suite:attrib1 eq ../../../family:attrib1 and (../../../suite/task:attrib2 gt ../../task:attrib2 or (../../../suite/task:attrib2 eq ../../task:attrib2 and ((((../../../suite/task/node4 eq complete and ../../../suite/task/node5 eq complete) and ../../../suite/task/node6 eq complete) and ../../../suite/task/node7 eq complete) and ../../../suite/task/node8 eq complete)))))",
+      "expected": "((../../../suite:attrib1 > ../../../family:attrib1) or ((../../../suite:attrib1 == ../../../family:attrib1) and ((../../../suite/task:attrib2 > ../../task:attrib2) or ((../../../suite/task:attrib2 == ../../task:attrib2) and (((((../../../suite/task/node4 == complete) and (../../../suite/task/node5 == complete)) and (../../../suite/task/node6 == complete)) and (../../../suite/task/node7 == complete)) and (../../../suite/task/node8 == complete))))))"
+    },
+    {
+      "expression": "(../suite:attrib1 gt ../family:attrib1 or (../suite:attrib1 eq ../family:attrib1 and (../suite/task:attrib2 gt task:attrib2 or ../suite eq complete)))",
+      "expected": "((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and ((../suite/task:attrib2 > task:attrib2) or (../suite == complete))))"
+    },
+    {
+      "expression": "(suite eq complete and (../../family:attrib1 gt ../../task:attrib1 or (../../family:attrib1 eq ../../task:attrib1 and ((((../../family/node4 eq complete and ../../family/node5 eq complete) and ../../family/node6 eq complete) and ../../family/node7 eq complete) and ../../family/node8 eq complete))))",
+      "expected": "((suite == complete) and ((../../family:attrib1 > ../../task:attrib1) or ((../../family:attrib1 == ../../task:attrib1) and (((((../../family/node4 == complete) and (../../family/node5 == complete)) and (../../family/node6 == complete)) and (../../family/node7 == complete)) and (../../family/node8 == complete)))))"
+    },
+    {
+      "expression": "(../../suite/family/task eq complete and (../../../node4:attrib1 gt ../../../node5:attrib1 or (../../../node4:attrib1 eq ../../../node5:attrib1 and ../../../node4/task eq complete)))",
+      "expected": "((../../suite/family/task == complete) and ((../../../node4:attrib1 > ../../../node5:attrib1) or ((../../../node4:attrib1 == ../../../node5:attrib1) and (../../../node4/task == complete))))"
+    },
+    {
+      "expression": "(../../suite:attrib1 gt ../../family:attrib1 or (../../suite:attrib1 eq ../../family:attrib1 and ((../../suite/task eq complete and ../../suite/node4 eq complete) and ../../suite/node5 eq complete)))",
+      "expected": "((../../suite:attrib1 > ../../family:attrib1) or ((../../suite:attrib1 == ../../family:attrib1) and (((../../suite/task == complete) and (../../suite/node4 == complete)) and (../../suite/node5 == complete))))"
+    },
+    {
+      "expression": "(((((((((((((((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and node6 eq complete) and node7 eq complete) and node8 eq complete) and node9 eq complete) and node10 eq complete) and node11 eq complete) and node12 eq complete) and node13 eq complete) and node14 eq complete) and node15 eq complete) and node16 eq complete) and node17 eq complete) and node18 eq complete)",
+      "expected": "((((((((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)) and (node17 == complete)) and (node18 == complete))"
+    },
+    {
+      "expression": "((suite/family eq complete or suite/family:attrib1) and (task eq complete and node4 eq complete))",
+      "expected": "(((suite/family == complete) or suite/family:attrib1) and ((task == complete) and (node4 == complete)))"
+    },
+    {
+      "expression": "(../../../suite/family:attrib1 gt ../../../task:attrib1 or (../../../suite/family:attrib1 eq ../../../task:attrib1 and ((((((((((((((../../../suite/family/node4/node5/001 eq complete and ../../../suite/family/node4/node5/002 eq complete) and ../../../suite/family/node4/node5/003 eq complete) and ../../../suite/family/node4/node5/004 eq complete) and ../../../suite/family/node4/node5/005 eq complete) and ../../../suite/family/node4/node5/006 eq complete) and ../../../suite/family/node4/node5/007 eq complete) and ../../../suite/family/node4/node5/008 eq complete) and ../../../suite/family/node4/node5/009 eq complete) and ../../../suite/family/node4/node5/010 eq complete) and ../../../suite/family/node4/node5/011 eq complete) and ../../../suite/family/node4/node5/012 eq complete) and ../../../suite/family/node4/node5/013 eq complete) and ../../../suite/family/node4/node5/014 eq complete) and ../../../suite/family/node4/node5/015 eq complete)))",
+      "expected": "((../../../suite/family:attrib1 > ../../../task:attrib1) or ((../../../suite/family:attrib1 == ../../../task:attrib1) and (((((((((((((((../../../suite/family/node4/node5/001 == complete) and (../../../suite/family/node4/node5/002 == complete)) and (../../../suite/family/node4/node5/003 == complete)) and (../../../suite/family/node4/node5/004 == complete)) and (../../../suite/family/node4/node5/005 == complete)) and (../../../suite/family/node4/node5/006 == complete)) and (../../../suite/family/node4/node5/007 == complete)) and (../../../suite/family/node4/node5/008 == complete)) and (../../../suite/family/node4/node5/009 == complete)) and (../../../suite/family/node4/node5/010 == complete)) and (../../../suite/family/node4/node5/011 == complete)) and (../../../suite/family/node4/node5/012 == complete)) and (../../../suite/family/node4/node5/013 == complete)) and (../../../suite/family/node4/node5/014 == complete)) and (../../../suite/family/node4/node5/015 == complete))))"
+    },
+    {
+      "expression": "(suite eq complete and (../../../family/task:attrib1 gt ../../../node4:attrib1 or (../../../family/task:attrib1 eq ../../../node4:attrib1 and ((((((((((((((../../../family/task/node5/node6/016 eq complete and ../../../family/task/node5/node6/017 eq complete) and ../../../family/task/node5/node6/018 eq complete) and ../../../family/task/node5/node6/019 eq complete) and ../../../family/task/node5/node6/020 eq complete) and ../../../family/task/node5/node6/021 eq complete) and ../../../family/task/node5/node6/022 eq complete) and ../../../family/task/node5/node6/023 eq complete) and ../../../family/task/node5/node6/024 eq complete) and ../../../family/task/node5/node6/025 eq complete) and ../../../family/task/node5/node6/026 eq complete) and ../../../family/task/node5/node6/027 eq complete) and ../../../family/task/node5/node6/028 eq complete) and ../../../family/task/node5/node6/029 eq complete) and ../../../family/task/node5/node6/030 eq complete))))",
+      "expected": "((suite == complete) and ((../../../family/task:attrib1 > ../../../node4:attrib1) or ((../../../family/task:attrib1 == ../../../node4:attrib1) and (((((((((((((((../../../family/task/node5/node6/016 == complete) and (../../../family/task/node5/node6/017 == complete)) and (../../../family/task/node5/node6/018 == complete)) and (../../../family/task/node5/node6/019 == complete)) and (../../../family/task/node5/node6/020 == complete)) and (../../../family/task/node5/node6/021 == complete)) and (../../../family/task/node5/node6/022 == complete)) and (../../../family/task/node5/node6/023 == complete)) and (../../../family/task/node5/node6/024 == complete)) and (../../../family/task/node5/node6/025 == complete)) and (../../../family/task/node5/node6/026 == complete)) and (../../../family/task/node5/node6/027 == complete)) and (../../../family/task/node5/node6/028 == complete)) and (../../../family/task/node5/node6/029 == complete)) and (../../../family/task/node5/node6/030 == complete)))))"
+    },
+    {
+      "expression": "(suite eq complete and (../../../family/task:attrib1 gt ../../../node4:attrib1 or (../../../family/task:attrib1 eq ../../../node4:attrib1 and (((../../../family/task/node5/node6/046 eq complete and ../../../family/task/node5/node6/047 eq complete) and ../../../family/task/node5/node6/048 eq complete) and ../../../family/task/node5/node6/049 eq complete))))",
+      "expected": "((suite == complete) and ((../../../family/task:attrib1 > ../../../node4:attrib1) or ((../../../family/task:attrib1 == ../../../node4:attrib1) and ((((../../../family/task/node5/node6/046 == complete) and (../../../family/task/node5/node6/047 == complete)) and (../../../family/task/node5/node6/048 == complete)) and (../../../family/task/node5/node6/049 == complete)))))"
+    },
+    {
+      "expression": "((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and (../node5:attrib1 lt ../node6/node7:attrib1 or ../node6/node7 eq complete))",
+      "expected": "(((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and ((../node5:attrib1 < ../node6/node7:attrib1) or (../node6/node7 == complete)))"
+    },
+    {
+      "expression": "(../../../suite/family:attrib1 gt ../../../task:attrib1 or (../../../suite/family:attrib1 eq ../../../task:attrib1 and (((((((((((((((((((((((((((((((((((((((((((((((((../../../suite/family/node4/node5/001 eq complete and ../../../suite/family/node4/node5/002 eq complete) and ../../../suite/family/node4/node5/003 eq complete) and ../../../suite/family/node4/node5/004 eq complete) and ../../../suite/family/node4/node5/005 eq complete) and ../../../suite/family/node4/node5/006 eq complete) and ../../../suite/family/node4/node5/007 eq complete) and ../../../suite/family/node4/node5/008 eq complete) and ../../../suite/family/node4/node5/009 eq complete) and ../../../suite/family/node4/node5/010 eq complete) and ../../../suite/family/node4/node5/011 eq complete) and ../../../suite/family/node4/node5/012 eq complete) and ../../../suite/family/node4/node5/013 eq complete) and ../../../suite/family/node4/node5/014 eq complete) and ../../../suite/family/node4/node5/015 eq complete) and ../../../suite/family/node4/node5/016 eq complete) and ../../../suite/family/node4/node5/017 eq complete) and ../../../suite/family/node4/node5/018 eq complete) and ../../../suite/family/node4/node5/019 eq complete) and ../../../suite/family/node4/node5/020 eq complete) and ../../../suite/family/node4/node5/021 eq complete) and ../../../suite/family/node4/node5/022 eq complete) and ../../../suite/family/node4/node5/023 eq complete) and ../../../suite/family/node4/node5/024 eq complete) and ../../../suite/family/node4/node5/025 eq complete) and ../../../suite/family/node4/node5/026 eq complete) and ../../../suite/family/node4/node5/027 eq complete) and ../../../suite/family/node4/node5/028 eq complete) and ../../../suite/family/node4/node5/029 eq complete) and ../../../suite/family/node4/node5/030 eq complete) and ../../../suite/family/node4/node5/031 eq complete) and ../../../suite/family/node4/node5/032 eq complete) and ../../../suite/family/node4/node5/033 eq complete) and ../../../suite/family/node4/node5/034 eq complete) and ../../../suite/family/node4/node5/035 eq complete) and ../../../suite/family/node4/node5/036 eq complete) and ../../../suite/family/node4/node5/037 eq complete) and ../../../suite/family/node4/node5/038 eq complete) and ../../../suite/family/node4/node5/039 eq complete) and ../../../suite/family/node4/node5/040 eq complete) and ../../../suite/family/node4/node5/041 eq complete) and ../../../suite/family/node4/node5/042 eq complete) and ../../../suite/family/node4/node5/043 eq complete) and ../../../suite/family/node4/node5/044 eq complete) and ../../../suite/family/node4/node5/045 eq complete) and ../../../suite/family/node4/node5/046 eq complete) and ../../../suite/family/node4/node5/047 eq complete) and ../../../suite/family/node4/node5/048 eq complete) and ../../../suite/family/node4/node5/049 eq complete) and ../../../suite/family/node4/node5/050 eq complete)))",
+      "expected": "((../../../suite/family:attrib1 > ../../../task:attrib1) or ((../../../suite/family:attrib1 == ../../../task:attrib1) and ((((((((((((((((((((((((((((((((((((((((((((((((((../../../suite/family/node4/node5/001 == complete) and (../../../suite/family/node4/node5/002 == complete)) and (../../../suite/family/node4/node5/003 == complete)) and (../../../suite/family/node4/node5/004 == complete)) and (../../../suite/family/node4/node5/005 == complete)) and (../../../suite/family/node4/node5/006 == complete)) and (../../../suite/family/node4/node5/007 == complete)) and (../../../suite/family/node4/node5/008 == complete)) and (../../../suite/family/node4/node5/009 == complete)) and (../../../suite/family/node4/node5/010 == complete)) and (../../../suite/family/node4/node5/011 == complete)) and (../../../suite/family/node4/node5/012 == complete)) and (../../../suite/family/node4/node5/013 == complete)) and (../../../suite/family/node4/node5/014 == complete)) and (../../../suite/family/node4/node5/015 == complete)) and (../../../suite/family/node4/node5/016 == complete)) and (../../../suite/family/node4/node5/017 == complete)) and (../../../suite/family/node4/node5/018 == complete)) and (../../../suite/family/node4/node5/019 == complete)) and (../../../suite/family/node4/node5/020 == complete)) and (../../../suite/family/node4/node5/021 == complete)) and (../../../suite/family/node4/node5/022 == complete)) and (../../../suite/family/node4/node5/023 == complete)) and (../../../suite/family/node4/node5/024 == complete)) and (../../../suite/family/node4/node5/025 == complete)) and (../../../suite/family/node4/node5/026 == complete)) and (../../../suite/family/node4/node5/027 == complete)) and (../../../suite/family/node4/node5/028 == complete)) and (../../../suite/family/node4/node5/029 == complete)) and (../../../suite/family/node4/node5/030 == complete)) and (../../../suite/family/node4/node5/031 == complete)) and (../../../suite/family/node4/node5/032 == complete)) and (../../../suite/family/node4/node5/033 == complete)) and (../../../suite/family/node4/node5/034 == complete)) and (../../../suite/family/node4/node5/035 == complete)) and (../../../suite/family/node4/node5/036 == complete)) and (../../../suite/family/node4/node5/037 == complete)) and (../../../suite/family/node4/node5/038 == complete)) and (../../../suite/family/node4/node5/039 == complete)) and (../../../suite/family/node4/node5/040 == complete)) and (../../../suite/family/node4/node5/041 == complete)) and (../../../suite/family/node4/node5/042 == complete)) and (../../../suite/family/node4/node5/043 == complete)) and (../../../suite/family/node4/node5/044 == complete)) and (../../../suite/family/node4/node5/045 == complete)) and (../../../suite/family/node4/node5/046 == complete)) and (../../../suite/family/node4/node5/047 == complete)) and (../../../suite/family/node4/node5/048 == complete)) and (../../../suite/family/node4/node5/049 == complete)) and (../../../suite/family/node4/node5/050 == complete))))"
+    },
+    {
+      "expression": "(((suite eq complete and family eq complete) and task eq complete) and (../node4:attrib1 lt ../node5/node6:attrib1 or ../node5/node6 eq complete))",
+      "expected": "((((suite == complete) and (family == complete)) and (task == complete)) and ((../node4:attrib1 < ../node5/node6:attrib1) or (../node5/node6 == complete)))"
+    },
+    {
+      "expression": "((suite==complete or suite==unknown) and (family==complete or family==unknown))",
+      "expected": "(((suite == complete) or (suite == unknown)) and ((family == complete) or (family == unknown)))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5:attrib1 le /suite/family/task/node4/node6:attrib1))",
+      "expected": "(/suite/family/task/node4/node5:attrib1 <= /suite/family/task/node4/node6:attrib1)"
+    },
+    {
+      "expression": "((suite/family:attrib1 or suite/family==complete) and (task/family:attrib1 or task/family==complete) and (node4==complete))",
+      "expected": "((suite/family:attrib1 or (suite/family == complete)) and ((task/family:attrib1 or (task/family == complete)) and (node4 == complete)))"
+    },
+    {
+      "expression": "((( /suite/family/task/node4/node5:attrib1 gt /suite/family/task/node4/node6:attrib1 ) or ( /suite/family/task/node4/node5:attrib1 eq /suite/family/task/node4/node6:attrib1 and /suite/family/task/node4/node5==complete ) and /suite/family/task/node4/node6:attrib1 le /suite/family/task/node4/node7:attrib1 and 1 ))",
+      "expected": "((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or (((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and (/suite/family/task/node4/node5 == complete)) and ((/suite/family/task/node4/node6:attrib1 <= /suite/family/task/node4/node7:attrib1) and 1)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5:attrib1 gt /suite/family/task/node4/node6:attrib1 ) or ( /suite/family/task/node4/node5:attrib1 eq /suite/family/task/node4/node6:attrib1 and /suite/family/task/node4/node5==complete) ))",
+      "expected": "((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and (/suite/family/task/node4/node5 == complete)))"
+    },
+    {
+      "expression": "((1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (suite==complete or suite==unknown) and (1 or 1) and (1 or 1) and (1 or 1))",
+      "expected": "((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and (((suite == complete) or (suite == unknown)) and ((1 or 1) and ((1 or 1) and (1 or 1)))))))))))))))))))))"
+    },
+    {
+      "expression": "((((((((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and node6 eq complete) and node7 eq complete) and node8 eq complete) and node9 eq complete) and node10 eq complete) and node11 eq complete)",
+      "expected": "(((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete))"
+    },
+    {
+      "expression": "(((((((((((((((((((((((((((((((((((((((((((((((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and node6 eq complete) and node7 eq complete) and node8 eq complete) and node9 eq complete) and node10 eq complete) and node11 eq complete) and node12 eq complete) and node13 eq complete) and node14 eq complete) and node15 eq complete) and node16 eq complete) and node17 eq complete) and node18 eq complete) and node19 eq complete) and node20 eq complete) and node21 eq complete) and node22 eq complete) and node23 eq complete) and node24 eq complete) and node25 eq complete) and node26 eq complete) and node27 eq complete) and node28 eq complete) and node29 eq complete) and node30 eq complete) and node31 eq complete) and node32 eq complete) and node33 eq complete) and node34 eq complete) and node35 eq complete) and node36 eq complete) and node37 eq complete) and node38 eq complete) and node39 eq complete) and node40 eq complete) and node41 eq complete) and node42 eq complete) and node43 eq complete) and node44 eq complete) and node45 eq complete) and node46 eq complete) and node47 eq complete) and node48 eq complete) and node49 eq complete) and node50 eq complete)",
+      "expected": "((((((((((((((((((((((((((((((((((((((((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)) and (node17 == complete)) and (node18 == complete)) and (node19 == complete)) and (node20 == complete)) and (node21 == complete)) and (node22 == complete)) and (node23 == complete)) and (node24 == complete)) and (node25 == complete)) and (node26 == complete)) and (node27 == complete)) and (node28 == complete)) and (node29 == complete)) and (node30 == complete)) and (node31 == complete)) and (node32 == complete)) and (node33 == complete)) and (node34 == complete)) and (node35 == complete)) and (node36 == complete)) and (node37 == complete)) and (node38 == complete)) and (node39 == complete)) and (node40 == complete)) and (node41 == complete)) and (node42 == complete)) and (node43 == complete)) and (node44 == complete)) and (node45 == complete)) and (node46 == complete)) and (node47 == complete)) and (node48 == complete)) and (node49 == complete)) and (node50 == complete))"
+    },
+    {
+      "expression": "(../../../suite/family:attrib1 gt ../../../task:attrib1 or (../../../suite/family:attrib1 eq ../../../task:attrib1 and (((((((((../../../suite/family/node4/node5/001 eq complete and ../../../suite/family/node4/node5/002 eq complete) and ../../../suite/family/node4/node5/003 eq complete) and ../../../suite/family/node4/node5/004 eq complete) and ../../../suite/family/node4/node5/005 eq complete) and ../../../suite/family/node4/node5/006 eq complete) and ../../../suite/family/node4/node5/007 eq complete) and ../../../suite/family/node4/node5/008 eq complete) and ../../../suite/family/node4/node5/009 eq complete) and ../../../suite/family/node4/node5/010 eq complete)))",
+      "expected": "((../../../suite/family:attrib1 > ../../../task:attrib1) or ((../../../suite/family:attrib1 == ../../../task:attrib1) and ((((((((((../../../suite/family/node4/node5/001 == complete) and (../../../suite/family/node4/node5/002 == complete)) and (../../../suite/family/node4/node5/003 == complete)) and (../../../suite/family/node4/node5/004 == complete)) and (../../../suite/family/node4/node5/005 == complete)) and (../../../suite/family/node4/node5/006 == complete)) and (../../../suite/family/node4/node5/007 == complete)) and (../../../suite/family/node4/node5/008 == complete)) and (../../../suite/family/node4/node5/009 == complete)) and (../../../suite/family/node4/node5/010 == complete))))"
+    },
+    {
+      "expression": "((../../suite/family/task == complete and ../../suite/family:attrib1 == ../../node4/family:attrib1) or (../../suite/family:attrib1 gt ../../node4/family:attrib1))",
+      "expected": "(((../../suite/family/task == complete) and (../../suite/family:attrib1 == ../../node4/family:attrib1)) or (../../suite/family:attrib1 > ../../node4/family:attrib1))"
+    },
+    {
+      "expression": "(suite eq complete and family:attrib1 le task:attrib1 + 4)",
+      "expected": "((suite == complete) and (family:attrib1 <= (task:attrib1 + 4)))"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 >= ./task:attrib1 or (/suite/family:attrib1 == ./task:attrib1-1 and /suite/family/00/node4/node5 == complete))) and (./task:attrib1 le (../node6/task:attrib1 + /node7/node8:attrib2)))",
+      "expected": "(((/suite/family:attrib1 >= ./task:attrib1) or ((/suite/family:attrib1 == (./task:attrib1 - 1)) and (/suite/family/00/node4/node5 == complete))) and (./task:attrib1 <= (../node6/task:attrib1 + /node7/node8:attrib2)))"
+    },
+    {
+      "expression": "((((/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1-1) and /suite/family/task/node4/node5/node7/node8:attrib2 >= 12 and /suite/family/task/node4/node5/node7/node9==complete and /suite/family/task/node4/node5/task==complete)) and /suite/family/task/node4/node10/task/node11/node12/node13/node14 == complete and (/suite/family/task/node4/node10:attrib1 == /suite/family/task/node4/node6:attrib1)) or (/suite/family/task/node4/node10:attrib1 > /suite/family/task/node4/node6:attrib1))",
+      "expected": "((((/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node6:attrib1 - 1)) and (((/suite/family/task/node4/node5/node7/node8:attrib2 >= 12) and (/suite/family/task/node4/node5/node7/node9 == complete)) and (/suite/family/task/node4/node5/task == complete)))) and ((/suite/family/task/node4/node10/task/node11/node12/node13/node14 == complete) and (/suite/family/task/node4/node10:attrib1 == /suite/family/task/node4/node6:attrib1))) or (/suite/family/task/node4/node10:attrib1 > /suite/family/task/node4/node6:attrib1))"
+    },
+    {
+      "expression": "((((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and /suite/family/task/node4/node5/node7/node8:attrib2 >= 12 and /suite/family/task/node4/node5/node7/node9==complete and /suite/family/task/node4/node5/task==complete))))",
+      "expected": "((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and (((/suite/family/task/node4/node5/node7/node8:attrib2 >= 12) and (/suite/family/task/node4/node5/node7/node9 == complete)) and (/suite/family/task/node4/node5/task == complete))))"
+    },
+    {
+      "expression": "(suite eq complete and (../../../family/task:attrib1 gt ../../../node4:attrib1 or (../../../family/task:attrib1 eq ../../../node4:attrib1 and ((../../../family/task/node5/node6/004 eq complete and ../../../family/task/node5/node6/005 eq complete) and ../../../family/task/node5/node6/006 eq complete))))",
+      "expected": "((suite == complete) and ((../../../family/task:attrib1 > ../../../node4:attrib1) or ((../../../family/task:attrib1 == ../../../node4:attrib1) and (((../../../family/task/node5/node6/004 == complete) and (../../../family/task/node5/node6/005 == complete)) and (../../../family/task/node5/node6/006 == complete)))))"
+    },
+    {
+      "expression": "((00 == complete) and (12 == complete))",
+      "expected": "((00 == complete) and (12 == complete))"
+    },
+    {
+      "expression": "((../suite/00:attrib1 gt :attrib1))",
+      "expected": "(../suite/00:attrib1 > :attrib1)"
+    },
+    {
+      "expression": "((../suite/family/00==complete) and (../suite/family:attrib1==:attrib1))",
+      "expected": "((../suite/family/00 == complete) and (../suite/family:attrib1 == :attrib1))"
+    },
+    {
+      "expression": "(((../suite==complete) and (../family/00:attrib1 gt :attrib1)))",
+      "expected": "((../suite == complete) and (../family/00:attrib1 > :attrib1))"
+    },
+    {
+      "expression": "(((../suite/family/00 == complete) and (../suite/family:attrib1==:attrib1)) or (../suite/family:attrib1>:attrib1))",
+      "expected": "(((../suite/family/00 == complete) and (../suite/family:attrib1 == :attrib1)) or (../suite/family:attrib1 > :attrib1))"
+    },
+    {
+      "expression": "((./00:attrib1 le ../suite/00:attrib1 + 2 or ../suite/00 eq complete) and (./00:attrib1 le ./12:attrib1 or ./12 eq complete))",
+      "expected": "(((./00:attrib1 <= (../suite/00:attrib1 + 2)) or (../suite/00 == complete)) and ((./00:attrib1 <= ./12:attrib1) or (./12 == complete)))"
+    },
+    {
+      "expression": "((./12:attrib1 le ../suite/12:attrib1 + 2 or ../suite/12 eq complete) and (./12:attrib1 lt ./00:attrib1 or ./00 eq complete))",
+      "expected": "(((./12:attrib1 <= (../suite/12:attrib1 + 2)) or (../suite/12 == complete)) and ((./12:attrib1 < ./00:attrib1) or (./00 == complete)))"
+    },
+    {
+      "expression": "(((./00:attrib1 lt ../suite/00:attrib1 or ../suite/00 eq complete) and (./00:attrib1 le ../../family/00:attrib1 + 1 or ../../family/00 eq complete)) and (./00:attrib1 le ./12:attrib1 or ./12 eq complete))",
+      "expected": "((((./00:attrib1 < ../suite/00:attrib1) or (../suite/00 == complete)) and ((./00:attrib1 <= (../../family/00:attrib1 + 1)) or (../../family/00 == complete))) and ((./00:attrib1 <= ./12:attrib1) or (./12 == complete)))"
+    },
+    {
+      "expression": "(((./12:attrib1 lt ../suite/12:attrib1 or ../suite/12 eq complete) and (./12:attrib1 le ../../family/12:attrib1 + 1 or ../../family/12 eq complete)) and (./12:attrib1 lt ./00:attrib1 or ./00 eq complete))",
+      "expected": "((((./12:attrib1 < ../suite/12:attrib1) or (../suite/12 == complete)) and ((./12:attrib1 <= (../../family/12:attrib1 + 1)) or (../../family/12 == complete))) and ((./12:attrib1 < ./00:attrib1) or (./00 == complete)))"
+    },
+    {
+      "expression": "((./00:attrib1 lt ../suite/family/00:attrib1 or ../suite/family/00 eq complete) and (./00:attrib1 le ./12:attrib1 or ./12 eq complete))",
+      "expected": "(((./00:attrib1 < ../suite/family/00:attrib1) or (../suite/family/00 == complete)) and ((./00:attrib1 <= ./12:attrib1) or (./12 == complete)))"
+    },
+    {
+      "expression": "((./12:attrib1 lt ../suite/family/12:attrib1 or ../suite/family/12 eq complete) and (./12:attrib1 lt ./00:attrib1 or ./00 eq complete))",
+      "expected": "(((./12:attrib1 < ../suite/family/12:attrib1) or (../suite/family/12 == complete)) and ((./12:attrib1 < ./00:attrib1) or (./00 == complete)))"
+    },
+    {
+      "expression": "(((suite:attrib1 gt family:attrib1 or suite eq complete) and (task:attrib1 gt family:attrib1 or task eq complete)) and family:attrib1 le node4:attrib1 + 3)",
+      "expected": "((((suite:attrib1 > family:attrib1) or (suite == complete)) and ((task:attrib1 > family:attrib1) or (task == complete))) and (family:attrib1 <= (node4:attrib1 + 3)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1-1) and /suite/family/task/node4/node5/node7/node8==complete and /suite/family/task/node4/node5/node7/node9==complete and /suite/family/task/node4/node5/task==complete)) and node10 == complete)",
+      "expected": "(((/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node6:attrib1 - 1)) and (((/suite/family/task/node4/node5/node7/node8 == complete) and (/suite/family/task/node4/node5/node7/node9 == complete)) and (/suite/family/task/node4/node5/task == complete)))) and (node10 == complete))"
+    },
+    {
+      "expression": "((suite/family/task:attrib1 or suite/family == complete) and suite/family/task:attrib2)",
+      "expected": "((suite/family/task:attrib1 or (suite/family == complete)) and suite/family/task:attrib2)"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and /suite/family/task/node4/node5/node7/node8==complete and /suite/family/task/node4/node5/node7/node9==complete and /suite/family/task/node4/node5/task==complete)) and node10 == complete)",
+      "expected": "(((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and (((/suite/family/task/node4/node5/node7/node8 == complete) and (/suite/family/task/node4/node5/node7/node9 == complete)) and (/suite/family/task/node4/node5/task == complete)))) and (node10 == complete))"
+    },
+    {
+      "expression": "(((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and (../node6:attrib1 gt ../node7:attrib1 or ../node6 eq complete))",
+      "expected": "((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and ((../node6:attrib1 > ../node7:attrib1) or (../node6 == complete)))"
+    },
+    {
+      "expression": "((../suite:attrib1 eq 2015 and ./01:attrib2 lt 1) or (../suite:attrib1 eq 2025 and ./01:attrib2 gt 12))",
+      "expected": "(((../suite:attrib1 == 2015) and (./01:attrib2 < 1)) or ((../suite:attrib1 == 2025) and (./01:attrib2 > 12)))"
+    },
+    {
+      "expression": "(suite:attrib1 le family:attrib1 + 3)",
+      "expected": "(suite:attrib1 <= (family:attrib1 + 3))"
+    },
+    {
+      "expression": "(( suite:attrib1 gt 17 ))",
+      "expected": "(suite:attrib1 > 17)"
+    },
+    {
+      "expression": "(( ../suite:attrib1 le 5 ))",
+      "expected": "(../suite:attrib1 <= 5)"
+    },
+    {
+      "expression": "(../../../../suite/family/00:attrib1 gt ../../../00:attrib1 or (../../../../suite/family/00:attrib1 eq ../../../00:attrib1 and (((((((../../../../suite/family/00/task/node4/001 eq complete and ../../../../suite/family/00/task/node4/002 eq complete) and ../../../../suite/family/00/task/node4/003 eq complete) and ../../../../suite/family/00/task/node4/004 eq complete) and ../../../../suite/family/00/task/node4/005 eq complete) and ../../../../suite/family/00/task/node4/006 eq complete) and ../../../../suite/family/00/task/node4/007 eq complete) and ../../../../suite/family/00/task/node4/008 eq complete)))",
+      "expected": "((../../../../suite/family/00:attrib1 > ../../../00:attrib1) or ((../../../../suite/family/00:attrib1 == ../../../00:attrib1) and ((((((((../../../../suite/family/00/task/node4/001 == complete) and (../../../../suite/family/00/task/node4/002 == complete)) and (../../../../suite/family/00/task/node4/003 == complete)) and (../../../../suite/family/00/task/node4/004 == complete)) and (../../../../suite/family/00/task/node4/005 == complete)) and (../../../../suite/family/00/task/node4/006 == complete)) and (../../../../suite/family/00/task/node4/007 == complete)) and (../../../../suite/family/00/task/node4/008 == complete))))"
+    },
+    {
+      "expression": "(../../../../suite/30/family:attrib1 gt ../../../30:attrib1 or (../../../../suite/30/family:attrib1 eq ../../../30:attrib1 and ((((((((../../../../suite/30/family/task/node4/001 eq complete and ../../../../suite/30/family/task/node4/002 eq complete) and ../../../../suite/30/family/task/node4/003 eq complete) and ../../../../suite/30/family/task/node4/004 eq complete) and ../../../../suite/30/family/task/node4/005 eq complete) and ../../../../suite/30/family/task/node4/006 eq complete) and ../../../../suite/30/family/task/node4/007 eq complete) and ../../../../suite/30/family/task/node4/008 eq complete) and ../../../../suite/30/family/task/node4/009 eq complete)))",
+      "expected": "((../../../../suite/30/family:attrib1 > ../../../30:attrib1) or ((../../../../suite/30/family:attrib1 == ../../../30:attrib1) and (((((((((../../../../suite/30/family/task/node4/001 == complete) and (../../../../suite/30/family/task/node4/002 == complete)) and (../../../../suite/30/family/task/node4/003 == complete)) and (../../../../suite/30/family/task/node4/004 == complete)) and (../../../../suite/30/family/task/node4/005 == complete)) and (../../../../suite/30/family/task/node4/006 == complete)) and (../../../../suite/30/family/task/node4/007 == complete)) and (../../../../suite/30/family/task/node4/008 == complete)) and (../../../../suite/30/family/task/node4/009 == complete))))"
+    },
+    {
+      "expression": "(../../../../suite/family/00:attrib1 gt ../../../00:attrib1 or (../../../../suite/family/00:attrib1 eq ../../../00:attrib1 and (../../../../suite/family/00/task/node4/001 eq complete and ../../../../suite/family/00/task/node4/002 eq complete)))",
+      "expected": "((../../../../suite/family/00:attrib1 > ../../../00:attrib1) or ((../../../../suite/family/00:attrib1 == ../../../00:attrib1) and ((../../../../suite/family/00/task/node4/001 == complete) and (../../../../suite/family/00/task/node4/002 == complete))))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12 and /suite/family/task/node4/node5/node6/node7/node9 eq complete and /suite/family/task/node4/node5/task/node7 == complete and (/suite/family/task/node4/node5:attrib2 == /suite/family/task/node4/node10:attrib2-1)) or (/suite/family/task/node4/node5:attrib2 >= /suite/family/task/node4/node10:attrib2))",
+      "expected": "(((((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5/task/node7 == complete)) and (/suite/family/task/node4/node5:attrib2 == (/suite/family/task/node4/node10:attrib2 - 1))) or (/suite/family/task/node4/node5:attrib2 >= /suite/family/task/node4/node10:attrib2))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12 and /suite/family/task/node4/node5/node6/node7/node9 eq complete and /suite/family/task/node4/node5/task/node7 == complete and (/suite/family/task/node4/node5:attrib2 == /suite/family/task/node4/node10:attrib2)) or (/suite/family/task/node4/node5:attrib2 > /suite/family/task/node4/node10:attrib2))",
+      "expected": "(((((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5/task/node7 == complete)) and (/suite/family/task/node4/node5:attrib2 == /suite/family/task/node4/node10:attrib2)) or (/suite/family/task/node4/node5:attrib2 > /suite/family/task/node4/node10:attrib2))"
+    },
+    {
+      "expression": "((suite/family eq complete or suite/family:attrib1) and task eq complete)",
+      "expected": "(((suite/family == complete) or suite/family:attrib1) and (task == complete))"
+    },
+    {
+      "expression": "(((((((((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and node6 eq complete) and node7 eq complete) and node8 eq complete) and node9 eq complete) and node10 eq complete) and node11 eq complete) and node12 eq complete)",
+      "expected": "((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete))"
+    },
+    {
+      "expression": "((suite:attrib1 or suite == complete) and /family/task/node4/node5/node6/node4/node7/node8 == complete and ../../node7/node9/node10 == complete)",
+      "expected": "((suite:attrib1 or (suite == complete)) and ((/family/task/node4/node5/node6/node4/node7/node8 == complete) and (../../node7/node9/node10 == complete)))"
+    },
+    {
+      "expression": "(../suite:attrib1 le 12)",
+      "expected": "(../suite:attrib1 <= 12)"
+    },
+    {
+      "expression": "(suite/family/task eq complete and suite/node4/task eq complete and suite/node5/task eq complete and suite/node6/task eq complete and suite/node7/task eq complete and suite/node8/task eq complete)",
+      "expected": "((((((suite/family/task == complete) and (suite/node4/task == complete)) and (suite/node5/task == complete)) and (suite/node6/task == complete)) and (suite/node7/task == complete)) and (suite/node8/task == complete))"
+    },
+    {
+      "expression": "((((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and /suite/family/task/node4/node5/node7/node8:attrib2 >= 12 and /suite/family/task/node4/node5/node7/node9==complete and /suite/family/task/node4/node5/task==complete)) and /suite/family/task/node4/node10/task/node11/node12/node13/node14 == complete and (/suite/family/task/node4/node10:attrib1 == /suite/family/task/node4/node6:attrib1)) or (/suite/family/task/node4/node10:attrib1 > /suite/family/task/node4/node6:attrib1))",
+      "expected": "((((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and (((/suite/family/task/node4/node5/node7/node8:attrib2 >= 12) and (/suite/family/task/node4/node5/node7/node9 == complete)) and (/suite/family/task/node4/node5/task == complete)))) and ((/suite/family/task/node4/node10/task/node11/node12/node13/node14 == complete) and (/suite/family/task/node4/node10:attrib1 == /suite/family/task/node4/node6:attrib1))) or (/suite/family/task/node4/node10:attrib1 > /suite/family/task/node4/node6:attrib1))"
+    },
+    {
+      "expression": "(/suite/family/task/node4/node5 == complete and /suite/family/task/node4/node5:attrib1 == /suite/family/task/node6/node5:attrib1 or (/suite/family/task/node4/node5:attrib1 gt /suite/family/task/node6/node5:attrib1) and (/suite/family/task/node6/node5:attrib1 le /suite/family/task/node7/node5:attrib1 + /suite/family:attrib2) and /suite/family/task/node8/node5 == complete and /suite/family/task/node8/node5:attrib1 == /suite/family/task/node6/node5:attrib1 or (/suite/family/task/node8/node5:attrib1 gt /suite/family/task/node6/node5:attrib1))",
+      "expected": "(((/suite/family/task/node4/node5 == complete) and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node6/node5:attrib1)) or ((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node6/node5:attrib1) and ((/suite/family/task/node6/node5:attrib1 <= (/suite/family/task/node7/node5:attrib1 + /suite/family:attrib2)) and (((/suite/family/task/node8/node5 == complete) and (/suite/family/task/node8/node5:attrib1 == /suite/family/task/node6/node5:attrib1)) or (/suite/family/task/node8/node5:attrib1 > /suite/family/task/node6/node5:attrib1)))))"
+    },
+    {
+      "expression": "(./suite:attrib1 le (../family/suite:attrib1 + 6))",
+      "expected": "(./suite:attrib1 <= (../family/suite:attrib1 + 6))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and (./task/node4 == complete or ./task/node4/node5:attrib1) and /node6/node7/node8/node9/node10 == complete)",
+      "expected": "(((suite == complete) and (family == complete)) and (((./task/node4 == complete) or ./task/node4/node5:attrib1) and (/node6/node7/node8/node9/node10 == complete)))"
+    },
+    {
+      "expression": "((((/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1-1) and /suite/family/task/node4/node5/node7/node8:attrib2 >= 12 and /suite/family/task/node4/node5/task==complete)) and /suite/family/task/node4/node9/task/node10/node11/node12 == complete and (/suite/family/task/node4/node9:attrib1 == /suite/family/task/node4/node6:attrib1)) or (/suite/family/task/node4/node9:attrib1 > /suite/family/task/node4/node6:attrib1))",
+      "expected": "((((/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node6:attrib1 - 1)) and ((/suite/family/task/node4/node5/node7/node8:attrib2 >= 12) and (/suite/family/task/node4/node5/task == complete)))) and ((/suite/family/task/node4/node9/task/node10/node11/node12 == complete) and (/suite/family/task/node4/node9:attrib1 == /suite/family/task/node4/node6:attrib1))) or (/suite/family/task/node4/node9:attrib1 > /suite/family/task/node4/node6:attrib1))"
+    },
+    {
+      "expression": "((((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and /suite/family/task/node4/node5/node7/node8:attrib2 >= 12 and /suite/family/task/node4/node5/task==complete)) and /suite/family/task/node4/node9/task/node10/node11/node12 == complete and (/suite/family/task/node4/node9:attrib1 == /suite/family/task/node4/node6:attrib1)) or (/suite/family/task/node4/node9:attrib1 > /suite/family/task/node4/node6:attrib1))",
+      "expected": "((((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and ((/suite/family/task/node4/node5/node7/node8:attrib2 >= 12) and (/suite/family/task/node4/node5/task == complete)))) and ((/suite/family/task/node4/node9/task/node10/node11/node12 == complete) and (/suite/family/task/node4/node9:attrib1 == /suite/family/task/node4/node6:attrib1))) or (/suite/family/task/node4/node9:attrib1 > /suite/family/task/node4/node6:attrib1))"
+    },
+    {
+      "expression": "(../../../suite/family/task/node4/node5:attrib1 >= ../node4:attrib1 or ../../../suite/family/task/node4/node5 == complete)",
+      "expected": "((../../../suite/family/task/node4/node5:attrib1 >= ../node4:attrib1) or (../../../suite/family/task/node4/node5 == complete))"
+    },
+    {
+      "expression": "((suite/family:attrib1 > task:attrib1 or suite/family == complete) and (suite/node4:attrib1 > task:attrib1 or suite/node4 == complete) and (suite/node5:attrib1 > task:attrib1 or suite/node5 == complete) and (suite/node6:attrib1 > task:attrib1 or suite/node6 == complete) and (suite/node7:attrib1 > task:attrib1 or suite/node7 == complete) and (suite/node8:attrib1 > task:attrib1 or suite/node8 == complete) and (suite/node9:attrib1 > task:attrib1 or suite/node9 == complete) and (suite/node10:attrib1 > task:attrib1 or suite/node10 == complete) and (suite/node11:attrib1 > task:attrib1 or suite/node11 == complete) and (suite/node12:attrib1 > task:attrib1 or suite/node12 == complete) and (suite/node13:attrib1 > task:attrib1 or suite/node13 == complete))",
+      "expected": "(((suite/family:attrib1 > task:attrib1) or (suite/family == complete)) and (((suite/node4:attrib1 > task:attrib1) or (suite/node4 == complete)) and (((suite/node5:attrib1 > task:attrib1) or (suite/node5 == complete)) and (((suite/node6:attrib1 > task:attrib1) or (suite/node6 == complete)) and (((suite/node7:attrib1 > task:attrib1) or (suite/node7 == complete)) and (((suite/node8:attrib1 > task:attrib1) or (suite/node8 == complete)) and (((suite/node9:attrib1 > task:attrib1) or (suite/node9 == complete)) and (((suite/node10:attrib1 > task:attrib1) or (suite/node10 == complete)) and (((suite/node11:attrib1 > task:attrib1) or (suite/node11 == complete)) and (((suite/node12:attrib1 > task:attrib1) or (suite/node12 == complete)) and ((suite/node13:attrib1 > task:attrib1) or (suite/node13 == complete))))))))))))"
+    },
+    {
+      "expression": "(((../../suite/family == complete and (../../suite:attrib1 == ../../task:attrib1-1)) or (../../suite:attrib1 >= ../../task:attrib1)) and ../../../node4/family == complete and ./node5/node6 == complete and ./node7/node6 == complete and ./node8/node6 == complete and ./node9/node6 == complete and ./node10/node6 == complete and ./node11/node6 == complete)",
+      "expected": "((((../../suite/family == complete) and (../../suite:attrib1 == (../../task:attrib1 - 1))) or (../../suite:attrib1 >= ../../task:attrib1)) and (((((((../../../node4/family == complete) and (./node5/node6 == complete)) and (./node7/node6 == complete)) and (./node8/node6 == complete)) and (./node9/node6 == complete)) and (./node10/node6 == complete)) and (./node11/node6 == complete)))"
+    },
+    {
+      "expression": "(suite/family/task eq complete and suite/node4/task eq complete and suite/node5/task eq complete and suite/node6/task eq complete and suite/node7/task eq complete and suite/node8/task eq complete and suite/node9/task eq complete and suite/node10/task eq complete and suite/node11/task eq complete and suite/node12/task eq complete and suite/node13/task eq complete)",
+      "expected": "(((((((((((suite/family/task == complete) and (suite/node4/task == complete)) and (suite/node5/task == complete)) and (suite/node6/task == complete)) and (suite/node7/task == complete)) and (suite/node8/task == complete)) and (suite/node9/task == complete)) and (suite/node10/task == complete)) and (suite/node11/task == complete)) and (suite/node12/task == complete)) and (suite/node13/task == complete))"
+    },
+    {
+      "expression": "(((../../suite/family == complete and (../../suite:attrib1 == ../../task:attrib1)) or (../../suite:attrib1 > ../../task:attrib1)) and ../../../node4/family == complete and ./node5/node6 == complete and ./node7/node6 == complete and ./node8/node6 == complete and ./node9/node6 == complete and ./node10/node6 == complete and ./node11/node6 == complete)",
+      "expected": "((((../../suite/family == complete) and (../../suite:attrib1 == ../../task:attrib1)) or (../../suite:attrib1 > ../../task:attrib1)) and (((((((../../../node4/family == complete) and (./node5/node6 == complete)) and (./node7/node6 == complete)) and (./node8/node6 == complete)) and (./node9/node6 == complete)) and (./node10/node6 == complete)) and (./node11/node6 == complete)))"
+    },
+    {
+      "expression": "(../../suite//family/task eq complete or ../../suite//family/task:attrib1 >= family:attrib1)",
+      "expected": "((../../suite//family/task == complete) or (../../suite//family/task:attrib1 >= family:attrib1))"
+    },
+    {
+      "expression": "(((((((((((suite/family:attrib1 > task:attrib1 OR suite/family == complete)) and ((suite/node4:attrib1 > task:attrib1 OR suite/node4 == complete))) and ((suite/node5:attrib1 > task:attrib1 OR suite/node5 == complete))) and ((suite/node6:attrib1 > task:attrib1 OR suite/node6 == complete))) and ((suite/node7:attrib1 > task:attrib1 OR suite/node7 == complete))) and ((suite/node8:attrib1 > task:attrib1 OR suite/node8 == complete))) and ((suite/node9:attrib1 > task:attrib1 OR suite/node9 == complete))) and ((suite/node10:attrib1 > task:attrib1 OR suite/node10 == complete))) and ((suite/node11:attrib1 > task:attrib1 OR suite/node11 == complete))) and ((suite/node12:attrib1 > task:attrib1 OR suite/node12 == complete)))",
+      "expected": "(((((((((((suite/family:attrib1 > task:attrib1) or (suite/family == complete)) and ((suite/node4:attrib1 > task:attrib1) or (suite/node4 == complete))) and ((suite/node5:attrib1 > task:attrib1) or (suite/node5 == complete))) and ((suite/node6:attrib1 > task:attrib1) or (suite/node6 == complete))) and ((suite/node7:attrib1 > task:attrib1) or (suite/node7 == complete))) and ((suite/node8:attrib1 > task:attrib1) or (suite/node8 == complete))) and ((suite/node9:attrib1 > task:attrib1) or (suite/node9 == complete))) and ((suite/node10:attrib1 > task:attrib1) or (suite/node10 == complete))) and ((suite/node11:attrib1 > task:attrib1) or (suite/node11 == complete))) and ((suite/node12:attrib1 > task:attrib1) or (suite/node12 == complete)))"
+    },
+    {
+      "expression": "(((suite/family == complete and task/family == complete and node4/family == complete and node5/family == complete and node6/family == complete and node7/family == complete) and (node8 == complete)) and ((/node9/node10/node11/node12/node13/node14 == complete and (/node9/node10/node11/node12/node13:attrib1 == /node9/node10/node11/node12/node15:attrib1-1)) or (/node9/node10/node11/node12/node13:attrib1 >= /node9/node10/node11/node12/node15:attrib1)))",
+      "expected": "((((((((suite/family == complete) and (task/family == complete)) and (node4/family == complete)) and (node5/family == complete)) and (node6/family == complete)) and (node7/family == complete)) and (node8 == complete)) and (((/node9/node10/node11/node12/node13/node14 == complete) and (/node9/node10/node11/node12/node13:attrib1 == (/node9/node10/node11/node12/node15:attrib1 - 1))) or (/node9/node10/node11/node12/node13:attrib1 >= /node9/node10/node11/node12/node15:attrib1)))"
+    },
+    {
+      "expression": "((((((((((((suite/family:attrib1 > task:attrib1 OR suite/family == complete)) and ((suite/node4:attrib1 > task:attrib1 OR suite/node4 == complete))) and ((suite/node5:attrib1 > task:attrib1 OR suite/node5 == complete))) and ((suite/node6:attrib1 > task:attrib1 OR suite/node6 == complete))) and ((suite/node7:attrib1 > task:attrib1 OR suite/node7 == complete))) and ((suite/node8:attrib1 > task:attrib1 OR suite/node8 == complete))) and ((suite/node9:attrib1 > task:attrib1 OR suite/node9 == complete))) and ((suite/node10:attrib1 > task:attrib1 OR suite/node10 == complete))) and ((suite/node11:attrib1 > task:attrib1 OR suite/node11 == complete))) and ((suite/node12:attrib1 > task:attrib1 OR suite/node12 == complete))) and ((suite/node13:attrib1 > task:attrib1 OR suite/node13 == complete)))",
+      "expected": "((((((((((((suite/family:attrib1 > task:attrib1) or (suite/family == complete)) and ((suite/node4:attrib1 > task:attrib1) or (suite/node4 == complete))) and ((suite/node5:attrib1 > task:attrib1) or (suite/node5 == complete))) and ((suite/node6:attrib1 > task:attrib1) or (suite/node6 == complete))) and ((suite/node7:attrib1 > task:attrib1) or (suite/node7 == complete))) and ((suite/node8:attrib1 > task:attrib1) or (suite/node8 == complete))) and ((suite/node9:attrib1 > task:attrib1) or (suite/node9 == complete))) and ((suite/node10:attrib1 > task:attrib1) or (suite/node10 == complete))) and ((suite/node11:attrib1 > task:attrib1) or (suite/node11 == complete))) and ((suite/node12:attrib1 > task:attrib1) or (suite/node12 == complete))) and ((suite/node13:attrib1 > task:attrib1) or (suite/node13 == complete)))"
+    },
+    {
+      "expression": "(((suite/family == complete and task/family == complete and node4/family == complete and node5/family == complete and node6/family == complete and node7/family == complete) and (node8 == complete)) and ((/node9/node10/node11/node12/node13/node14 == complete and (/node9/node10/node11/node12/node13:attrib1 == /node9/node10/node11/node12/node15:attrib1)) or (/node9/node10/node11/node12/node13:attrib1 > /node9/node10/node11/node12/node15:attrib1)))",
+      "expected": "((((((((suite/family == complete) and (task/family == complete)) and (node4/family == complete)) and (node5/family == complete)) and (node6/family == complete)) and (node7/family == complete)) and (node8 == complete)) and (((/node9/node10/node11/node12/node13/node14 == complete) and (/node9/node10/node11/node12/node13:attrib1 == /node9/node10/node11/node12/node15:attrib1)) or (/node9/node10/node11/node12/node13:attrib1 > /node9/node10/node11/node12/node15:attrib1)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12 and /suite/family/task/node4/node5/task/node7 == complete and (/suite/family/task/node4/node5:attrib2 == /suite/family/task/node4/node9:attrib2-1)) or (/suite/family/task/node4/node5:attrib2 >= /suite/family/task/node4/node9:attrib2)) and node10 == complete and node11 == complete)",
+      "expected": "(((((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12) and (/suite/family/task/node4/node5/task/node7 == complete)) and (/suite/family/task/node4/node5:attrib2 == (/suite/family/task/node4/node9:attrib2 - 1))) or (/suite/family/task/node4/node5:attrib2 >= /suite/family/task/node4/node9:attrib2)) and ((node10 == complete) and (node11 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12 and /suite/family/task/node4/node5/task/node7 == complete and (/suite/family/task/node4/node5:attrib2 == /suite/family/task/node4/node9:attrib2)) or (/suite/family/task/node4/node5:attrib2 > /suite/family/task/node4/node9:attrib2)) and node10 == complete and node11 == complete)",
+      "expected": "(((((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12) and (/suite/family/task/node4/node5/task/node7 == complete)) and (/suite/family/task/node4/node5:attrib2 == /suite/family/task/node4/node9:attrib2)) or (/suite/family/task/node4/node5:attrib2 > /suite/family/task/node4/node9:attrib2)) and ((node10 == complete) and (node11 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12 and /suite/family/task/node4/node5/node6/node7/node9 eq complete and (/suite/family/task/node4/node5:attrib2 == /suite/family/task/node4/node10:attrib2-1)) or (/suite/family/task/node4/node5:attrib2 >= /suite/family/task/node4/node10:attrib2)) and ../node11/node12==complete)",
+      "expected": "(((((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5:attrib2 == (/suite/family/task/node4/node10:attrib2 - 1))) or (/suite/family/task/node4/node5:attrib2 >= /suite/family/task/node4/node10:attrib2)) and (../node11/node12 == complete))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12 and /suite/family/task/node4/node5/node6/node7/node9 eq complete and (/suite/family/task/node4/node5:attrib2 == /suite/family/task/node4/node10:attrib2)) or (/suite/family/task/node4/node5:attrib2 > /suite/family/task/node4/node10:attrib2)) and ../node11/node12==complete)",
+      "expected": "(((((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5:attrib2 == /suite/family/task/node4/node10:attrib2)) or (/suite/family/task/node4/node5:attrib2 > /suite/family/task/node4/node10:attrib2)) and (../node11/node12 == complete))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1-1 and /suite/family/task/node4/node5/task == complete) or /suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1-1)",
+      "expected": "(((/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node6:attrib1 - 1)) and (/suite/family/task/node4/node5/task == complete)) or (/suite/family/task/node4/node5:attrib1 > (/suite/family/task/node4/node6:attrib1 - 1)))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1 and /suite/family/task/node4/node5/task == complete) or /suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1)",
+      "expected": "(((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and (/suite/family/task/node4/node5/task == complete)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1))"
+    },
+    {
+      "expression": "(../../../suite/family:attrib1 gt ../../../task:attrib1 or (../../../suite/family:attrib1 eq ../../../task:attrib1 and (((((((((((((((((((((((((((((../../../suite/family/node4/node5/001 eq complete and ../../../suite/family/node4/node5/002 eq complete) and ../../../suite/family/node4/node5/003 eq complete) and ../../../suite/family/node4/node5/004 eq complete) and ../../../suite/family/node4/node5/005 eq complete) and ../../../suite/family/node4/node5/006 eq complete) and ../../../suite/family/node4/node5/007 eq complete) and ../../../suite/family/node4/node5/008 eq complete) and ../../../suite/family/node4/node5/009 eq complete) and ../../../suite/family/node4/node5/010 eq complete) and ../../../suite/family/node4/node5/011 eq complete) and ../../../suite/family/node4/node5/012 eq complete) and ../../../suite/family/node4/node5/013 eq complete) and ../../../suite/family/node4/node5/014 eq complete) and ../../../suite/family/node4/node5/015 eq complete) and ../../../suite/family/node4/node5/016 eq complete) and ../../../suite/family/node4/node5/017 eq complete) and ../../../suite/family/node4/node5/018 eq complete) and ../../../suite/family/node4/node5/019 eq complete) and ../../../suite/family/node4/node5/020 eq complete) and ../../../suite/family/node4/node5/021 eq complete) and ../../../suite/family/node4/node5/022 eq complete) and ../../../suite/family/node4/node5/023 eq complete) and ../../../suite/family/node4/node5/024 eq complete) and ../../../suite/family/node4/node5/025 eq complete) and ../../../suite/family/node4/node5/026 eq complete) and ../../../suite/family/node4/node5/027 eq complete) and ../../../suite/family/node4/node5/028 eq complete) and ../../../suite/family/node4/node5/029 eq complete) and ../../../suite/family/node4/node5/030 eq complete)))",
+      "expected": "((../../../suite/family:attrib1 > ../../../task:attrib1) or ((../../../suite/family:attrib1 == ../../../task:attrib1) and ((((((((((((((((((((((((((((((../../../suite/family/node4/node5/001 == complete) and (../../../suite/family/node4/node5/002 == complete)) and (../../../suite/family/node4/node5/003 == complete)) and (../../../suite/family/node4/node5/004 == complete)) and (../../../suite/family/node4/node5/005 == complete)) and (../../../suite/family/node4/node5/006 == complete)) and (../../../suite/family/node4/node5/007 == complete)) and (../../../suite/family/node4/node5/008 == complete)) and (../../../suite/family/node4/node5/009 == complete)) and (../../../suite/family/node4/node5/010 == complete)) and (../../../suite/family/node4/node5/011 == complete)) and (../../../suite/family/node4/node5/012 == complete)) and (../../../suite/family/node4/node5/013 == complete)) and (../../../suite/family/node4/node5/014 == complete)) and (../../../suite/family/node4/node5/015 == complete)) and (../../../suite/family/node4/node5/016 == complete)) and (../../../suite/family/node4/node5/017 == complete)) and (../../../suite/family/node4/node5/018 == complete)) and (../../../suite/family/node4/node5/019 == complete)) and (../../../suite/family/node4/node5/020 == complete)) and (../../../suite/family/node4/node5/021 == complete)) and (../../../suite/family/node4/node5/022 == complete)) and (../../../suite/family/node4/node5/023 == complete)) and (../../../suite/family/node4/node5/024 == complete)) and (../../../suite/family/node4/node5/025 == complete)) and (../../../suite/family/node4/node5/026 == complete)) and (../../../suite/family/node4/node5/027 == complete)) and (../../../suite/family/node4/node5/028 == complete)) and (../../../suite/family/node4/node5/029 == complete)) and (../../../suite/family/node4/node5/030 == complete))))"
+    },
+    {
+      "expression": "(../../suite/family == complete and ../../suite/family:attrib1 == ../family:attrib1 or (../../suite/family:attrib1 gt ../family:attrib1) and ../../task/node4 == complete)",
+      "expected": "(((../../suite/family == complete) and (../../suite/family:attrib1 == ../family:attrib1)) or ((../../suite/family:attrib1 > ../family:attrib1) and (../../task/node4 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5 == complete and /suite/family/task/node6/node5 == complete and /suite/family/task/node4/node5:attrib1 == /suite/family/task/node7/node5:attrib1 and /suite/family/task/node6/node5:attrib1 == /suite/family/task/node7/node5:attrib1) or (/suite/family/task/node4/node5:attrib1 gt /suite/family/task/node7/node5:attrib1 and /suite/family/task/node6/node5:attrib1 gt /suite/family/task/node7/node5:attrib1) and (/suite/family/task/node7/node5:attrib1 le /suite/family/task/node8/node5:attrib1 + /suite/family:attrib2))",
+      "expected": "(((((/suite/family/task/node4/node5 == complete) and (/suite/family/task/node6/node5 == complete)) and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node7/node5:attrib1)) and (/suite/family/task/node6/node5:attrib1 == /suite/family/task/node7/node5:attrib1)) or (((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node7/node5:attrib1) and (/suite/family/task/node6/node5:attrib1 > /suite/family/task/node7/node5:attrib1)) and (/suite/family/task/node7/node5:attrib1 <= (/suite/family/task/node8/node5:attrib1 + /suite/family:attrib2))))"
+    },
+    {
+      "expression": "((((((((((((((((((((((((((((((((((((((((((((((((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and node6 eq complete) and node7 eq complete) and node8 eq complete) and node9 eq complete) and node10 eq complete) and node11 eq complete) and node12 eq complete) and node13 eq complete) and node14 eq complete) and node15 eq complete) and node16 eq complete) and node17 eq complete) and node18 eq complete) and node19 eq complete) and node20 eq complete) and node21 eq complete) and node22 eq complete) and node23 eq complete) and node24 eq complete) and node25 eq complete) and node26 eq complete) and node27 eq complete) and node28 eq complete) and node29 eq complete) and node30 eq complete) and node31 eq complete) and node32 eq complete) and node33 eq complete) and node34 eq complete) and node35 eq complete) and node36 eq complete) and node37 eq complete) and node38 eq complete) and node39 eq complete) and node40 eq complete) and node41 eq complete) and node42 eq complete) and node43 eq complete) and node44 eq complete) and node45 eq complete) and node46 eq complete) and node47 eq complete) and node48 eq complete) and node49 eq complete) and node50 eq complete) and node51 eq complete)",
+      "expected": "(((((((((((((((((((((((((((((((((((((((((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)) and (node17 == complete)) and (node18 == complete)) and (node19 == complete)) and (node20 == complete)) and (node21 == complete)) and (node22 == complete)) and (node23 == complete)) and (node24 == complete)) and (node25 == complete)) and (node26 == complete)) and (node27 == complete)) and (node28 == complete)) and (node29 == complete)) and (node30 == complete)) and (node31 == complete)) and (node32 == complete)) and (node33 == complete)) and (node34 == complete)) and (node35 == complete)) and (node36 == complete)) and (node37 == complete)) and (node38 == complete)) and (node39 == complete)) and (node40 == complete)) and (node41 == complete)) and (node42 == complete)) and (node43 == complete)) and (node44 == complete)) and (node45 == complete)) and (node46 == complete)) and (node47 == complete)) and (node48 == complete)) and (node49 == complete)) and (node50 == complete)) and (node51 == complete))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1-1) and /suite/family/task/node4/node5/node7/node8==complete and /suite/family/task/node4/node5/task==complete)) and node9 == complete)",
+      "expected": "(((/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node6:attrib1 - 1)) and ((/suite/family/task/node4/node5/node7/node8 == complete) and (/suite/family/task/node4/node5/task == complete)))) and (node9 == complete))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and /suite/family/task/node4/node5/node7/node8==complete and /suite/family/task/node4/node5/task==complete)) and node9 == complete)",
+      "expected": "(((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and ((/suite/family/task/node4/node5/node7/node8 == complete) and (/suite/family/task/node4/node5/task == complete)))) and (node9 == complete))"
+    },
+    {
+      "expression": "((:attrib1 lt /suite/family/task/node4/node5:attrib1 or (/suite/family/task/node6/node5:attrib1 == /suite/family/task/node4/node5:attrib1 and /suite/family/task/node6/node5 == complete) or /suite/family/task/node6/node5:attrib1 gt /suite/family/task/node4/node5:attrib1))",
+      "expected": "((:attrib1 < /suite/family/task/node4/node5:attrib1) or (((/suite/family/task/node6/node5:attrib1 == /suite/family/task/node4/node5:attrib1) and (/suite/family/task/node6/node5 == complete)) or (/suite/family/task/node6/node5:attrib1 > /suite/family/task/node4/node5:attrib1)))"
+    },
+    {
+      "expression": "(((../suite:attrib1 >= ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1-1) and ../suite/task == complete)) and node4 == complete and node5 == complete and node6 == complete)",
+      "expected": "(((../suite:attrib1 >= ../family:attrib1) or ((../suite:attrib1 == (../family:attrib1 - 1)) and (../suite/task == complete))) and (((node4 == complete) and (node5 == complete)) and (node6 == complete)))"
+    },
+    {
+      "expression": "((((../suite:attrib1 >= ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1-1) and ../suite/task == complete)) and node4 == complete and node5 == complete and node6 == complete) and (node7 == complete))",
+      "expected": "((((../suite:attrib1 >= ../family:attrib1) or ((../suite:attrib1 == (../family:attrib1 - 1)) and (../suite/task == complete))) and (((node4 == complete) and (node5 == complete)) and (node6 == complete))) and (node7 == complete))"
+    },
+    {
+      "expression": "(((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and ../suite/task == complete)) and node4 == complete and node5 == complete and node6 == complete)",
+      "expected": "(((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and (../suite/task == complete))) and (((node4 == complete) and (node5 == complete)) and (node6 == complete)))"
+    },
+    {
+      "expression": "((((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and ../suite/task == complete)) and node4 == complete and node5 == complete and node6 == complete) and (node7 == complete))",
+      "expected": "((((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and (../suite/task == complete))) and (((node4 == complete) and (node5 == complete)) and (node6 == complete))) and (node7 == complete))"
+    },
+    {
+      "expression": "((:attrib1 lt /suite/family/task/node4/node5:attrib1 or (/suite/family/task/node6/node5/task == complete and :attrib1 == /suite/family/task/node4/node5:attrib1)))",
+      "expected": "((:attrib1 < /suite/family/task/node4/node5:attrib1) or ((/suite/family/task/node6/node5/task == complete) and (:attrib1 == /suite/family/task/node4/node5:attrib1)))"
+    },
+    {
+      "expression": "((:attrib1 lt /suite/family/task/node4/node5:attrib1 or /suite/family/task/node4/node5/node6 == active))",
+      "expected": "((:attrib1 < /suite/family/task/node4/node5:attrib1) or (/suite/family/task/node4/node5/node6 == active))"
+    },
+    {
+      "expression": "(suite eq complete and family:attrib1 lt task:attrib1 + 3)",
+      "expected": "((suite == complete) and (family:attrib1 < (task:attrib1 + 3)))"
+    },
+    {
+      "expression": "((suite:attrib1 le family:attrib1 + 3 or family eq complete) and (task:attrib1 gt suite:attrib1 or task eq complete))",
+      "expected": "(((suite:attrib1 <= (family:attrib1 + 3)) or (family == complete)) and ((task:attrib1 > suite:attrib1) or (task == complete)))"
+    },
+    {
+      "expression": "((../../../../../suite:attrib1 / 100) % 100 eq 2 and (((../../../../../suite:attrib1 / 10000) % 4 ne 0 or (../../../../../suite:attrib1 / 10000) % 100 eq 0) and (../../../../../suite:attrib1 / 10000) % 400 ne 0))",
+      "expected": "((((../../../../../suite:attrib1 / 100) % 100) == 2) and (((((../../../../../suite:attrib1 / 10000) % 4) != 0) or (((../../../../../suite:attrib1 / 10000) % 100) == 0)) and (((../../../../../suite:attrib1 / 10000) % 400) != 0)))"
+    },
+    {
+      "expression": "((../../../../../suite:attrib1 / 100) % 100 eq 2)",
+      "expected": "(((../../../../../suite:attrib1 / 100) % 100) == 2)"
+    },
+    {
+      "expression": "(((((../../../../../suite:attrib1 / 100) % 100 eq 2 or (../../../../../suite:attrib1 / 100) % 100 eq 4) or (../../../../../suite:attrib1 / 100) % 100 eq 6) or (../../../../../suite:attrib1 / 100) % 100 eq 9) or (../../../../../suite:attrib1 / 100) % 100 eq 11)",
+      "expected": "(((((((../../../../../suite:attrib1 / 100) % 100) == 2) or (((../../../../../suite:attrib1 / 100) % 100) == 4)) or (((../../../../../suite:attrib1 / 100) % 100) == 6)) or (((../../../../../suite:attrib1 / 100) % 100) == 9)) or (((../../../../../suite:attrib1 / 100) % 100) == 11))"
+    },
+    {
+      "expression": "(((./00:attrib1 lt ../suite/00:attrib1 or ../suite/00 eq complete) and (./00:attrib1 lt ../family/00:attrib1 or ../family/00 eq complete)) and (./00:attrib1 le ../../task/00:attrib1 + 1 or ../../task/00 eq complete))",
+      "expected": "((((./00:attrib1 < ../suite/00:attrib1) or (../suite/00 == complete)) and ((./00:attrib1 < ../family/00:attrib1) or (../family/00 == complete))) and ((./00:attrib1 <= (../../task/00:attrib1 + 1)) or (../../task/00 == complete)))"
+    },
+    {
+      "expression": "(suite == complete and ((/family/task/node4/node5/node6:attrib1 gt :attrib1 - 1) or (/family/task/node4/node5/node6:attrib1 eq :attrib1 - 1 and /family/task/node4/node5/node6/node7/node8/node9/node10 == complete)))",
+      "expected": "((suite == complete) and ((/family/task/node4/node5/node6:attrib1 > (:attrib1 - 1)) or ((/family/task/node4/node5/node6:attrib1 == (:attrib1 - 1)) and (/family/task/node4/node5/node6/node7/node8/node9/node10 == complete))))"
+    },
+    {
+      "expression": "(suite == complete and ((/family/task/node4/node5/node6:attrib1 gt :attrib1) or (/family/task/node4/node5/node6:attrib1 eq :attrib1 and /family/task/node4/node5/node6/node7/node8/node9/node10 == complete)))",
+      "expected": "((suite == complete) and ((/family/task/node4/node5/node6:attrib1 > :attrib1) or ((/family/task/node4/node5/node6:attrib1 == :attrib1) and (/family/task/node4/node5/node6/node7/node8/node9/node10 == complete))))"
+    },
+    {
+      "expression": "(../suite/family/task/node4 == complete and node5:attrib1 >= 3)",
+      "expected": "((../suite/family/task/node4 == complete) and (node5:attrib1 >= 3))"
+    },
+    {
+      "expression": "((../suite eq complete or ../suite:attrib1) and (../family eq complete or ../family:attrib1))",
+      "expected": "(((../suite == complete) or ../suite:attrib1) and ((../family == complete) or ../family:attrib1))"
+    },
+    {
+      "expression": "(suite eq complete and ((../../family/task:attrib1 gt 1 or ../../family:attrib2 gt ../../node4:attrib2) or ../../family eq complete))",
+      "expected": "((suite == complete) and (((../../family/task:attrib1 > 1) or (../../family:attrib2 > ../../node4:attrib2)) or (../../family == complete)))"
+    },
+    {
+      "expression": "((../suite:attrib1 gt ../family:attrib1 or (../suite:attrib1 eq ../family:attrib1 and ../suite/task:attrib2 ge task:attrib2)) and ((../node4:attrib1 gt ../family:attrib1 or ../node4/task:attrib2 gt task:attrib2) or (../node4/task:attrib2 eq task:attrib2 and ../node4 eq complete)))",
+      "expected": "(((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and (../suite/task:attrib2 >= task:attrib2))) and (((../node4:attrib1 > ../family:attrib1) or (../node4/task:attrib2 > task:attrib2)) or ((../node4/task:attrib2 == task:attrib2) and (../node4 == complete))))"
+    },
+    {
+      "expression": "(suite eq complete and (../../../family:attrib1 gt ../../../task:attrib1 or (../../../family:attrib1 eq ../../../task:attrib1 and (../../../family/node4:attrib2 gt ../../node4:attrib2 or (../../../family/node4:attrib2 eq ../../node4:attrib2 and ((((../../../family/node4/node5 eq complete and ../../../family/node4/node6 eq complete) and ../../../family/node4/node7 eq complete) and ../../../family/node4/node8 eq complete) and ../../../family/node4/node9 eq complete))))))",
+      "expected": "((suite == complete) and ((../../../family:attrib1 > ../../../task:attrib1) or ((../../../family:attrib1 == ../../../task:attrib1) and ((../../../family/node4:attrib2 > ../../node4:attrib2) or ((../../../family/node4:attrib2 == ../../node4:attrib2) and (((((../../../family/node4/node5 == complete) and (../../../family/node4/node6 == complete)) and (../../../family/node4/node7 == complete)) and (../../../family/node4/node8 == complete)) and (../../../family/node4/node9 == complete)))))))"
+    },
+    {
+      "expression": "(((../suite eq complete or ../suite:attrib1 gt ../family:attrib1) or (../suite:attrib1 eq ../family:attrib1 and ../suite/task:attrib2 gt task:attrib2)) and ((../node4 eq complete or ../node4:attrib1 gt ../family:attrib1) or (../node4:attrib1 eq ../family:attrib1 and ../node4/task:attrib2 gt task:attrib2)))",
+      "expected": "((((../suite == complete) or (../suite:attrib1 > ../family:attrib1)) or ((../suite:attrib1 == ../family:attrib1) and (../suite/task:attrib2 > task:attrib2))) and (((../node4 == complete) or (../node4:attrib1 > ../family:attrib1)) or ((../node4:attrib1 == ../family:attrib1) and (../node4/task:attrib2 > task:attrib2))))"
+    },
+    {
+      "expression": "((../suite/family:attrib1 or ../suite/family == complete) and (../suite/task == complete))",
+      "expected": "((../suite/family:attrib1 or (../suite/family == complete)) and (../suite/task == complete))"
+    },
+    {
+      "expression": "(/suite/family/task/node4/node5 == complete and /suite/family/task/node4/node5:attrib1 == /suite/family/task/node6/node5:attrib1 or (/suite/family/task/node4/node5:attrib1 gt /suite/family/task/node6/node5:attrib1) and (/suite/family/task/node6/node5:attrib1 le /suite/family/task/node7/node5:attrib1 + /suite/family:attrib2 + 3))",
+      "expected": "(((/suite/family/task/node4/node5 == complete) and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node6/node5:attrib1)) or ((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node6/node5:attrib1) and (/suite/family/task/node6/node5:attrib1 <= ((/suite/family/task/node7/node5:attrib1 + /suite/family:attrib2) + 3))))"
+    },
+    {
+      "expression": "(../suite:attrib1 gt ../family:attrib1 or (../suite:attrib1 eq ../family:attrib1 and ../suite/01 eq complete) and ../task eq complete)",
+      "expected": "((../suite:attrib1 > ../family:attrib1) or (((../suite:attrib1 == ../family:attrib1) and (../suite/01 == complete)) and (../task == complete)))"
+    },
+    {
+      "expression": "(suite:attrib1 le family:attrib1 + 3 and task eq complete)",
+      "expected": "((suite:attrib1 <= (family:attrib1 + 3)) and (task == complete))"
+    },
+    {
+      "expression": "(( ../suite:attrib1 gt ../family:attrib1 or (../suite:attrib1 eq ../family:attrib1 and ../suite/01 eq complete) ) and ../task == complete and ../node4 == complete)",
+      "expected": "(((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and (../suite/01 == complete))) and ((../task == complete) and (../node4 == complete)))"
+    },
+    {
+      "expression": "(../../../../suite/family/00:attrib1 gt ../../../00:attrib1 or (../../../../suite/family/00:attrib1 eq ../../../00:attrib1 and (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((../../../../suite/family/00/task/node4/001 eq complete and ../../../../suite/family/00/task/node4/002 eq complete) and ../../../../suite/family/00/task/node4/003 eq complete) and ../../../../suite/family/00/task/node4/004 eq complete) and ../../../../suite/family/00/task/node4/005 eq complete) and ../../../../suite/family/00/task/node4/006 eq complete) and ../../../../suite/family/00/task/node4/007 eq complete) and ../../../../suite/family/00/task/node4/008 eq complete) and ../../../../suite/family/00/task/node4/009 eq complete) and ../../../../suite/family/00/task/node4/010 eq complete) and ../../../../suite/family/00/task/node4/011 eq complete) and ../../../../suite/family/00/task/node4/012 eq complete) and ../../../../suite/family/00/task/node4/013 eq complete) and ../../../../suite/family/00/task/node4/014 eq complete) and ../../../../suite/family/00/task/node4/015 eq complete) and ../../../../suite/family/00/task/node4/016 eq complete) and ../../../../suite/family/00/task/node4/017 eq complete) and ../../../../suite/family/00/task/node4/018 eq complete) and ../../../../suite/family/00/task/node4/019 eq complete) and ../../../../suite/family/00/task/node4/020 eq complete) and ../../../../suite/family/00/task/node4/021 eq complete) and ../../../../suite/family/00/task/node4/022 eq complete) and ../../../../suite/family/00/task/node4/023 eq complete) and ../../../../suite/family/00/task/node4/024 eq complete) and ../../../../suite/family/00/task/node4/025 eq complete) and ../../../../suite/family/00/task/node4/026 eq complete) and ../../../../suite/family/00/task/node4/027 eq complete) and ../../../../suite/family/00/task/node4/028 eq complete) and ../../../../suite/family/00/task/node4/029 eq complete) and ../../../../suite/family/00/task/node4/030 eq complete) and ../../../../suite/family/00/task/node4/031 eq complete) and ../../../../suite/family/00/task/node4/032 eq complete) and ../../../../suite/family/00/task/node4/033 eq complete) and ../../../../suite/family/00/task/node4/034 eq complete) and ../../../../suite/family/00/task/node4/035 eq complete) and ../../../../suite/family/00/task/node4/036 eq complete) and ../../../../suite/family/00/task/node4/037 eq complete) and ../../../../suite/family/00/task/node4/038 eq complete) and ../../../../suite/family/00/task/node4/039 eq complete) and ../../../../suite/family/00/task/node4/040 eq complete) and ../../../../suite/family/00/task/node4/041 eq complete) and ../../../../suite/family/00/task/node4/042 eq complete) and ../../../../suite/family/00/task/node4/043 eq complete) and ../../../../suite/family/00/task/node4/044 eq complete) and ../../../../suite/family/00/task/node4/045 eq complete) and ../../../../suite/family/00/task/node4/046 eq complete) and ../../../../suite/family/00/task/node4/047 eq complete) and ../../../../suite/family/00/task/node4/048 eq complete) and ../../../../suite/family/00/task/node4/049 eq complete) and ../../../../suite/family/00/task/node4/050 eq complete) and ../../../../suite/family/00/task/node4/051 eq complete) and ../../../../suite/family/00/task/node4/052 eq complete) and ../../../../suite/family/00/task/node4/053 eq complete) and ../../../../suite/family/00/task/node4/054 eq complete) and ../../../../suite/family/00/task/node4/055 eq complete) and ../../../../suite/family/00/task/node4/056 eq complete) and ../../../../suite/family/00/task/node4/057 eq complete) and ../../../../suite/family/00/task/node4/058 eq complete) and ../../../../suite/family/00/task/node4/059 eq complete) and ../../../../suite/family/00/task/node4/060 eq complete) and ../../../../suite/family/00/task/node4/061 eq complete) and ../../../../suite/family/00/task/node4/062 eq complete) and ../../../../suite/family/00/task/node4/063 eq complete) and ../../../../suite/family/00/task/node4/064 eq complete) and ../../../../suite/family/00/task/node4/065 eq complete) and ../../../../suite/family/00/task/node4/066 eq complete) and ../../../../suite/family/00/task/node4/067 eq complete) and ../../../../suite/family/00/task/node4/068 eq complete) and ../../../../suite/family/00/task/node4/069 eq complete) and ../../../../suite/family/00/task/node4/070 eq complete) and ../../../../suite/family/00/task/node4/071 eq complete) and ../../../../suite/family/00/task/node4/072 eq complete) and ../../../../suite/family/00/task/node4/073 eq complete) and ../../../../suite/family/00/task/node4/074 eq complete) and ../../../../suite/family/00/task/node4/075 eq complete) and ../../../../suite/family/00/task/node4/076 eq complete) and ../../../../suite/family/00/task/node4/077 eq complete) and ../../../../suite/family/00/task/node4/078 eq complete) and ../../../../suite/family/00/task/node4/079 eq complete) and ../../../../suite/family/00/task/node4/080 eq complete) and ../../../../suite/family/00/task/node4/081 eq complete) and ../../../../suite/family/00/task/node4/082 eq complete) and ../../../../suite/family/00/task/node4/083 eq complete) and ../../../../suite/family/00/task/node4/084 eq complete) and ../../../../suite/family/00/task/node4/085 eq complete) and ../../../../suite/family/00/task/node4/086 eq complete) and ../../../../suite/family/00/task/node4/087 eq complete) and ../../../../suite/family/00/task/node4/088 eq complete) and ../../../../suite/family/00/task/node4/089 eq complete) and ../../../../suite/family/00/task/node4/090 eq complete) and ../../../../suite/family/00/task/node4/091 eq complete) and ../../../../suite/family/00/task/node4/092 eq complete) and ../../../../suite/family/00/task/node4/093 eq complete) and ../../../../suite/family/00/task/node4/094 eq complete) and ../../../../suite/family/00/task/node4/095 eq complete) and ../../../../suite/family/00/task/node4/096 eq complete) and ../../../../suite/family/00/task/node4/097 eq complete) and ../../../../suite/family/00/task/node4/098 eq complete) and ../../../../suite/family/00/task/node4/099 eq complete) and ../../../../suite/family/00/task/node4/100 eq complete)))",
+      "expected": "((../../../../suite/family/00:attrib1 > ../../../00:attrib1) or ((../../../../suite/family/00:attrib1 == ../../../00:attrib1) and ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((../../../../suite/family/00/task/node4/001 == complete) and (../../../../suite/family/00/task/node4/002 == complete)) and (../../../../suite/family/00/task/node4/003 == complete)) and (../../../../suite/family/00/task/node4/004 == complete)) and (../../../../suite/family/00/task/node4/005 == complete)) and (../../../../suite/family/00/task/node4/006 == complete)) and (../../../../suite/family/00/task/node4/007 == complete)) and (../../../../suite/family/00/task/node4/008 == complete)) and (../../../../suite/family/00/task/node4/009 == complete)) and (../../../../suite/family/00/task/node4/010 == complete)) and (../../../../suite/family/00/task/node4/011 == complete)) and (../../../../suite/family/00/task/node4/012 == complete)) and (../../../../suite/family/00/task/node4/013 == complete)) and (../../../../suite/family/00/task/node4/014 == complete)) and (../../../../suite/family/00/task/node4/015 == complete)) and (../../../../suite/family/00/task/node4/016 == complete)) and (../../../../suite/family/00/task/node4/017 == complete)) and (../../../../suite/family/00/task/node4/018 == complete)) and (../../../../suite/family/00/task/node4/019 == complete)) and (../../../../suite/family/00/task/node4/020 == complete)) and (../../../../suite/family/00/task/node4/021 == complete)) and (../../../../suite/family/00/task/node4/022 == complete)) and (../../../../suite/family/00/task/node4/023 == complete)) and (../../../../suite/family/00/task/node4/024 == complete)) and (../../../../suite/family/00/task/node4/025 == complete)) and (../../../../suite/family/00/task/node4/026 == complete)) and (../../../../suite/family/00/task/node4/027 == complete)) and (../../../../suite/family/00/task/node4/028 == complete)) and (../../../../suite/family/00/task/node4/029 == complete)) and (../../../../suite/family/00/task/node4/030 == complete)) and (../../../../suite/family/00/task/node4/031 == complete)) and (../../../../suite/family/00/task/node4/032 == complete)) and (../../../../suite/family/00/task/node4/033 == complete)) and (../../../../suite/family/00/task/node4/034 == complete)) and (../../../../suite/family/00/task/node4/035 == complete)) and (../../../../suite/family/00/task/node4/036 == complete)) and (../../../../suite/family/00/task/node4/037 == complete)) and (../../../../suite/family/00/task/node4/038 == complete)) and (../../../../suite/family/00/task/node4/039 == complete)) and (../../../../suite/family/00/task/node4/040 == complete)) and (../../../../suite/family/00/task/node4/041 == complete)) and (../../../../suite/family/00/task/node4/042 == complete)) and (../../../../suite/family/00/task/node4/043 == complete)) and (../../../../suite/family/00/task/node4/044 == complete)) and (../../../../suite/family/00/task/node4/045 == complete)) and (../../../../suite/family/00/task/node4/046 == complete)) and (../../../../suite/family/00/task/node4/047 == complete)) and (../../../../suite/family/00/task/node4/048 == complete)) and (../../../../suite/family/00/task/node4/049 == complete)) and (../../../../suite/family/00/task/node4/050 == complete)) and (../../../../suite/family/00/task/node4/051 == complete)) and (../../../../suite/family/00/task/node4/052 == complete)) and (../../../../suite/family/00/task/node4/053 == complete)) and (../../../../suite/family/00/task/node4/054 == complete)) and (../../../../suite/family/00/task/node4/055 == complete)) and (../../../../suite/family/00/task/node4/056 == complete)) and (../../../../suite/family/00/task/node4/057 == complete)) and (../../../../suite/family/00/task/node4/058 == complete)) and (../../../../suite/family/00/task/node4/059 == complete)) and (../../../../suite/family/00/task/node4/060 == complete)) and (../../../../suite/family/00/task/node4/061 == complete)) and (../../../../suite/family/00/task/node4/062 == complete)) and (../../../../suite/family/00/task/node4/063 == complete)) and (../../../../suite/family/00/task/node4/064 == complete)) and (../../../../suite/family/00/task/node4/065 == complete)) and (../../../../suite/family/00/task/node4/066 == complete)) and (../../../../suite/family/00/task/node4/067 == complete)) and (../../../../suite/family/00/task/node4/068 == complete)) and (../../../../suite/family/00/task/node4/069 == complete)) and (../../../../suite/family/00/task/node4/070 == complete)) and (../../../../suite/family/00/task/node4/071 == complete)) and (../../../../suite/family/00/task/node4/072 == complete)) and (../../../../suite/family/00/task/node4/073 == complete)) and (../../../../suite/family/00/task/node4/074 == complete)) and (../../../../suite/family/00/task/node4/075 == complete)) and (../../../../suite/family/00/task/node4/076 == complete)) and (../../../../suite/family/00/task/node4/077 == complete)) and (../../../../suite/family/00/task/node4/078 == complete)) and (../../../../suite/family/00/task/node4/079 == complete)) and (../../../../suite/family/00/task/node4/080 == complete)) and (../../../../suite/family/00/task/node4/081 == complete)) and (../../../../suite/family/00/task/node4/082 == complete)) and (../../../../suite/family/00/task/node4/083 == complete)) and (../../../../suite/family/00/task/node4/084 == complete)) and (../../../../suite/family/00/task/node4/085 == complete)) and (../../../../suite/family/00/task/node4/086 == complete)) and (../../../../suite/family/00/task/node4/087 == complete)) and (../../../../suite/family/00/task/node4/088 == complete)) and (../../../../suite/family/00/task/node4/089 == complete)) and (../../../../suite/family/00/task/node4/090 == complete)) and (../../../../suite/family/00/task/node4/091 == complete)) and (../../../../suite/family/00/task/node4/092 == complete)) and (../../../../suite/family/00/task/node4/093 == complete)) and (../../../../suite/family/00/task/node4/094 == complete)) and (../../../../suite/family/00/task/node4/095 == complete)) and (../../../../suite/family/00/task/node4/096 == complete)) and (../../../../suite/family/00/task/node4/097 == complete)) and (../../../../suite/family/00/task/node4/098 == complete)) and (../../../../suite/family/00/task/node4/099 == complete)) and (../../../../suite/family/00/task/node4/100 == complete))))"
+    },
+    {
+      "expression": "(/suite/family/task/node4/node5 == complete and /suite/family/task/node4/node5:attrib1 == /suite/family/task/node6/node5:attrib1 or (/suite/family/task/node4/node5:attrib1 gt /suite/family/task/node6/node5:attrib1) and (/suite/family/task/node6/node5:attrib1 le /suite/family/task/node7/node5:attrib1 + /suite/family:attrib2) and /suite/family/task/node6/node5:attrib1 lt 20230101)",
+      "expected": "(((/suite/family/task/node4/node5 == complete) and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node6/node5:attrib1)) or ((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node6/node5:attrib1) and ((/suite/family/task/node6/node5:attrib1 <= (/suite/family/task/node7/node5:attrib1 + /suite/family:attrib2)) and (/suite/family/task/node6/node5:attrib1 < 20230101))))"
+    },
+    {
+      "expression": "(( suite:attrib1 le family:attrib1 + 3 ) and ( task eq complete ) and ( node4 eq complete ))",
+      "expected": "((suite:attrib1 <= (family:attrib1 + 3)) and ((task == complete) and (node4 == complete)))"
+    },
+    {
+      "expression": "(../suite:attrib1 gt ../family:attrib1 or (../suite:attrib1 eq ../family:attrib1 and ../suite/01 eq complete) and ( ../task eq complete ))",
+      "expected": "((../suite:attrib1 > ../family:attrib1) or (((../suite:attrib1 == ../family:attrib1) and (../suite/01 == complete)) and (../task == complete)))"
+    },
+    {
+      "expression": "(suite eq complete and family:attrib1 le task:attrib1 + 6 and node4 eq complete)",
+      "expected": "(((suite == complete) and (family:attrib1 <= (task:attrib1 + 6))) and (node4 == complete))"
+    },
+    {
+      "expression": "((suite eq complete and family:attrib1 le task/node4:attrib1 + 5) and (/node5/node6:attrib1 ge family:attrib1 + 4 or (/node5/node6:attrib1 eq family:attrib1 + 3 and /node5/node6/00/node7/family eq complete)))",
+      "expected": "(((suite == complete) and (family:attrib1 <= (task/node4:attrib1 + 5))) and ((/node5/node6:attrib1 >= (family:attrib1 + 4)) or ((/node5/node6:attrib1 == (family:attrib1 + 3)) and (/node5/node6/00/node7/family == complete))))"
+    },
+    {
+      "expression": "((suite eq complete and family:attrib1 le task/node4:attrib1 + 4) and (/node5/node6:attrib1 ge family:attrib1 + 1 or (/node5/node6:attrib1 eq family:attrib1 and /node5/node6/00/node7/node8 eq complete)))",
+      "expected": "(((suite == complete) and (family:attrib1 <= (task/node4:attrib1 + 4))) and ((/node5/node6:attrib1 >= (family:attrib1 + 1)) or ((/node5/node6:attrib1 == family:attrib1) and (/node5/node6/00/node7/node8 == complete))))"
+    },
+    {
+      "expression": "((((../suite:attrib1 gt family:attrib1 or ../suite eq complete) and (../task:attrib1 gt family:attrib1 or ../task eq complete)) and family:attrib1 le ../node4/family:attrib1 + 3) and (family:attrib1 eq node5:attrib1 or node5 eq complete))",
+      "expected": "(((((../suite:attrib1 > family:attrib1) or (../suite == complete)) and ((../task:attrib1 > family:attrib1) or (../task == complete))) and (family:attrib1 <= (../node4/family:attrib1 + 3))) and ((family:attrib1 == node5:attrib1) or (node5 == complete)))"
+    },
+    {
+      "expression": "((../suite/family:attrib1 gt family:attrib1 or ../suite eq complete) and (family:attrib1 eq task:attrib1 or task eq complete))",
+      "expected": "(((../suite/family:attrib1 > family:attrib1) or (../suite == complete)) and ((family:attrib1 == task:attrib1) or (task == complete)))"
+    },
+    {
+      "expression": "(((((((((((((((((((((((((((((((((((((((((((((((((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and node6 eq complete) and node7 eq complete) and node8 eq complete) and node9 eq complete) and node10 eq complete) and node11 eq complete) and node12 eq complete) and node13 eq complete) and node14 eq complete) and node15 eq complete) and node16 eq complete) and node17 eq complete) and node18 eq complete) and node19 eq complete) and node20 eq complete) and node21 eq complete) and node22 eq complete) and node23 eq complete) and node24 eq complete) and node25 eq complete) and node26 eq complete) and node27 eq complete) and node28 eq complete) and node29 eq complete) and node30 eq complete) and node31 eq complete) and node32 eq complete) and node33 eq complete) and node34 eq complete) and node35 eq complete) and node36 eq complete) and node37 eq complete) and node38 eq complete) and node39 eq complete) and node40 eq complete) and node41 eq complete) and node42 eq complete) and node43 eq complete) and node44 eq complete) and node45 eq complete) and node46 eq complete) and node47 eq complete) and node48 eq complete) and node49 eq complete) and node50 eq complete) and node51 eq complete) and node52 eq complete)",
+      "expected": "((((((((((((((((((((((((((((((((((((((((((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)) and (node17 == complete)) and (node18 == complete)) and (node19 == complete)) and (node20 == complete)) and (node21 == complete)) and (node22 == complete)) and (node23 == complete)) and (node24 == complete)) and (node25 == complete)) and (node26 == complete)) and (node27 == complete)) and (node28 == complete)) and (node29 == complete)) and (node30 == complete)) and (node31 == complete)) and (node32 == complete)) and (node33 == complete)) and (node34 == complete)) and (node35 == complete)) and (node36 == complete)) and (node37 == complete)) and (node38 == complete)) and (node39 == complete)) and (node40 == complete)) and (node41 == complete)) and (node42 == complete)) and (node43 == complete)) and (node44 == complete)) and (node45 == complete)) and (node46 == complete)) and (node47 == complete)) and (node48 == complete)) and (node49 == complete)) and (node50 == complete)) and (node51 == complete)) and (node52 == complete))"
+    },
+    {
+      "expression": "(suite eq complete and family:attrib1 lt 20230901)",
+      "expected": "((suite == complete) and (family:attrib1 < 20230901))"
+    },
+    {
+      "expression": "(./suite:attrib1 lt /family/task/node4/node5/node6:attrib1-10)",
+      "expected": "(./suite:attrib1 < (/family/task/node4/node5/node6:attrib1 - 10))"
+    },
+    {
+      "expression": "((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and node6 eq complete) and node7 eq complete) and node8 eq complete) and node9 eq complete) and node10 eq complete) and node11 eq complete) and node12 eq complete) and node13 eq complete) and node14 eq complete) and node15 eq complete) and node16 eq complete) and node17 eq complete) and node18 eq complete) and node19 eq complete) and node20 eq complete) and node21 eq complete) and node22 eq complete) and node23 eq complete) and node24 eq complete) and node25 eq complete) and node26 eq complete) and node27 eq complete) and node28 eq complete) and node29 eq complete) and node30 eq complete) and node31 eq complete) and node32 eq complete) and node33 eq complete) and node34 eq complete) and node35 eq complete) and node36 eq complete) and node37 eq complete) and node38 eq complete) and node39 eq complete) and node40 eq complete) and node41 eq complete) and node42 eq complete) and node43 eq complete) and node44 eq complete) and node45 eq complete) and node46 eq complete) and node47 eq complete) and node48 eq complete) and node49 eq complete) and node50 eq complete) and node51 eq complete) and node52 eq complete) and node53 eq complete) and node54 eq complete) and node55 eq complete) and node56 eq complete) and node57 eq complete) and node58 eq complete) and node59 eq complete) and node60 eq complete) and node61 eq complete) and node62 eq complete) and node63 eq complete) and node64 eq complete) and node65 eq complete) and node66 eq complete) and node67 eq complete) and node68 eq complete) and node69 eq complete) and node70 eq complete) and node71 eq complete) and node72 eq complete) and node73 eq complete) and node74 eq complete) and node75 eq complete) and node76 eq complete) and node77 eq complete) and node78 eq complete) and node79 eq complete) and node80 eq complete) and node81 eq complete) and node82 eq complete) and node83 eq complete) and node84 eq complete) and node85 eq complete) and node86 eq complete) and node87 eq complete) and node88 eq complete) and node89 eq complete) and node90 eq complete) and node91 eq complete) and node92 eq complete) and node93 eq complete) and node94 eq complete) and node95 eq complete) and node96 eq complete) and node97 eq complete) and node98 eq complete) and node99 eq complete) and node100 eq complete) and node101 eq complete)",
+      "expected": "(((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)) and (node17 == complete)) and (node18 == complete)) and (node19 == complete)) and (node20 == complete)) and (node21 == complete)) and (node22 == complete)) and (node23 == complete)) and (node24 == complete)) and (node25 == complete)) and (node26 == complete)) and (node27 == complete)) and (node28 == complete)) and (node29 == complete)) and (node30 == complete)) and (node31 == complete)) and (node32 == complete)) and (node33 == complete)) and (node34 == complete)) and (node35 == complete)) and (node36 == complete)) and (node37 == complete)) and (node38 == complete)) and (node39 == complete)) and (node40 == complete)) and (node41 == complete)) and (node42 == complete)) and (node43 == complete)) and (node44 == complete)) and (node45 == complete)) and (node46 == complete)) and (node47 == complete)) and (node48 == complete)) and (node49 == complete)) and (node50 == complete)) and (node51 == complete)) and (node52 == complete)) and (node53 == complete)) and (node54 == complete)) and (node55 == complete)) and (node56 == complete)) and (node57 == complete)) and (node58 == complete)) and (node59 == complete)) and (node60 == complete)) and (node61 == complete)) and (node62 == complete)) and (node63 == complete)) and (node64 == complete)) and (node65 == complete)) and (node66 == complete)) and (node67 == complete)) and (node68 == complete)) and (node69 == complete)) and (node70 == complete)) and (node71 == complete)) and (node72 == complete)) and (node73 == complete)) and (node74 == complete)) and (node75 == complete)) and (node76 == complete)) and (node77 == complete)) and (node78 == complete)) and (node79 == complete)) and (node80 == complete)) and (node81 == complete)) and (node82 == complete)) and (node83 == complete)) and (node84 == complete)) and (node85 == complete)) and (node86 == complete)) and (node87 == complete)) and (node88 == complete)) and (node89 == complete)) and (node90 == complete)) and (node91 == complete)) and (node92 == complete)) and (node93 == complete)) and (node94 == complete)) and (node95 == complete)) and (node96 == complete)) and (node97 == complete)) and (node98 == complete)) and (node99 == complete)) and (node100 == complete)) and (node101 == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 > ./task:attrib1 or (/suite/family:attrib1 == ./task:attrib1 and /suite/family/node4/node5/node6 == complete)) and (./task:attrib1 le (../node7/task:attrib1 + /node8/node9:attrib2)))",
+      "expected": "(((/suite/family:attrib1 > ./task:attrib1) or ((/suite/family:attrib1 == ./task:attrib1) and (/suite/family/node4/node5/node6 == complete))) and (./task:attrib1 <= (../node7/task:attrib1 + /node8/node9:attrib2)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 >= ./task:attrib1 or (/suite/family:attrib1 == ./task:attrib1-1 and /suite/family/00/node4/node5 == complete)) and (./task:attrib1 le (../node6/task:attrib1 + /node7/node8:attrib2)))",
+      "expected": "(((/suite/family:attrib1 >= ./task:attrib1) or ((/suite/family:attrib1 == (./task:attrib1 - 1)) and (/suite/family/00/node4/node5 == complete))) and (./task:attrib1 <= (../node6/task:attrib1 + /node7/node8:attrib2)))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 == 0 and /suite/task:attrib1 == 00 and /suite/family/00/node4 == complete and /suite/family/12/node4 == complete and /suite/family/00/node5/node6 == complete and /suite/family/12/node5/node6 == complete and /suite/task == complete)",
+      "expected": "(((((((/suite/family:attrib1 == 0) and (/suite/task:attrib1 == 0)) and (/suite/family/00/node4 == complete)) and (/suite/family/12/node4 == complete)) and (/suite/family/00/node5/node6 == complete)) and (/suite/family/12/node5/node6 == complete)) and (/suite/task == complete))"
+    },
+    {
+      "expression": "((((((((../../suite/family/task eq complete and not (../../suite/family/task:attrib1)) and (../../node4/family/task eq complete and not (../../node4/family/task:attrib1))) and (../../node5/family/task eq complete and not (../../node5/family/task:attrib1))) and (../../node6/family/task eq complete and not (../../node6/family/task:attrib1))) and (../../node7/family/task eq complete and not (../../node7/family/task:attrib1))) and (../../node8/family/task eq complete and not (../../node8/family/task:attrib1))) and ((((((../../suite/node9/task eq complete and not (../../suite/node9/task:attrib1)) and (../../node4/node9/task eq complete and not (../../node4/node9/task:attrib1))) and (../../node5/node9/task eq complete and not (../../node5/node9/task:attrib1))) and (../../node6/node9/task eq complete and not (../../node6/node9/task:attrib1))) and (../../node7/node9/task eq complete and not (../../node7/node9/task:attrib1))) and (../../node8/node9/task eq complete and not (../../node8/node9/task:attrib1)))) and ((((((../../suite/node10/task eq complete and not (../../suite/node10/task:attrib1)) and (../../node4/node10/task eq complete and not (../../node4/node10/task:attrib1))) and (../../node5/node10/task eq complete and not (../../node5/node10/task:attrib1))) and (../../node6/node10/task eq complete and not (../../node6/node10/task:attrib1))) and (../../node7/node10/task eq complete and not (../../node7/node10/task:attrib1))) and (../../node8/node10/task eq complete and not (../../node8/node10/task:attrib1))))",
+      "expected": "(((((((((../../suite/family/task == complete) and not (../../suite/family/task:attrib1)) and ((../../node4/family/task == complete) and not (../../node4/family/task:attrib1))) and ((../../node5/family/task == complete) and not (../../node5/family/task:attrib1))) and ((../../node6/family/task == complete) and not (../../node6/family/task:attrib1))) and ((../../node7/family/task == complete) and not (../../node7/family/task:attrib1))) and ((../../node8/family/task == complete) and not (../../node8/family/task:attrib1))) and (((((((../../suite/node9/task == complete) and not (../../suite/node9/task:attrib1)) and ((../../node4/node9/task == complete) and not (../../node4/node9/task:attrib1))) and ((../../node5/node9/task == complete) and not (../../node5/node9/task:attrib1))) and ((../../node6/node9/task == complete) and not (../../node6/node9/task:attrib1))) and ((../../node7/node9/task == complete) and not (../../node7/node9/task:attrib1))) and ((../../node8/node9/task == complete) and not (../../node8/node9/task:attrib1)))) and (((((((../../suite/node10/task == complete) and not (../../suite/node10/task:attrib1)) and ((../../node4/node10/task == complete) and not (../../node4/node10/task:attrib1))) and ((../../node5/node10/task == complete) and not (../../node5/node10/task:attrib1))) and ((../../node6/node10/task == complete) and not (../../node6/node10/task:attrib1))) and ((../../node7/node10/task == complete) and not (../../node7/node10/task:attrib1))) and ((../../node8/node10/task == complete) and not (../../node8/node10/task:attrib1))))"
+    },
+    {
+      "expression": "((((((((../../suite/family/task eq complete and ../../suite/family/task:attrib1) or (../../node4/family/task eq complete and ../../node4/family/task:attrib1)) or (../../node5/family/task eq complete and ../../node5/family/task:attrib1)) or (../../node6/family/task eq complete and ../../node6/family/task:attrib1)) or (../../node7/family/task eq complete and ../../node7/family/task:attrib1)) or (../../node8/family/task eq complete and ../../node8/family/task:attrib1)) or ((((((../../suite/node9/task eq complete and ../../suite/node9/task:attrib1) or (../../node4/node9/task eq complete and ../../node4/node9/task:attrib1)) or (../../node5/node9/task eq complete and ../../node5/node9/task:attrib1)) or (../../node6/node9/task eq complete and ../../node6/node9/task:attrib1)) or (../../node7/node9/task eq complete and ../../node7/node9/task:attrib1)) or (../../node8/node9/task eq complete and ../../node8/node9/task:attrib1))) or ((((((../../suite/node10/task eq complete and ../../suite/node10/task:attrib1) or (../../node4/node10/task eq complete and ../../node4/node10/task:attrib1)) or (../../node5/node10/task eq complete and ../../node5/node10/task:attrib1)) or (../../node6/node10/task eq complete and ../../node6/node10/task:attrib1)) or (../../node7/node10/task eq complete and ../../node7/node10/task:attrib1)) or (../../node8/node10/task eq complete and ../../node8/node10/task:attrib1)))",
+      "expected": "(((((((((../../suite/family/task == complete) and ../../suite/family/task:attrib1) or ((../../node4/family/task == complete) and ../../node4/family/task:attrib1)) or ((../../node5/family/task == complete) and ../../node5/family/task:attrib1)) or ((../../node6/family/task == complete) and ../../node6/family/task:attrib1)) or ((../../node7/family/task == complete) and ../../node7/family/task:attrib1)) or ((../../node8/family/task == complete) and ../../node8/family/task:attrib1)) or (((((((../../suite/node9/task == complete) and ../../suite/node9/task:attrib1) or ((../../node4/node9/task == complete) and ../../node4/node9/task:attrib1)) or ((../../node5/node9/task == complete) and ../../node5/node9/task:attrib1)) or ((../../node6/node9/task == complete) and ../../node6/node9/task:attrib1)) or ((../../node7/node9/task == complete) and ../../node7/node9/task:attrib1)) or ((../../node8/node9/task == complete) and ../../node8/node9/task:attrib1))) or (((((((../../suite/node10/task == complete) and ../../suite/node10/task:attrib1) or ((../../node4/node10/task == complete) and ../../node4/node10/task:attrib1)) or ((../../node5/node10/task == complete) and ../../node5/node10/task:attrib1)) or ((../../node6/node10/task == complete) and ../../node6/node10/task:attrib1)) or ((../../node7/node10/task == complete) and ../../node7/node10/task:attrib1)) or ((../../node8/node10/task == complete) and ../../node8/node10/task:attrib1)))"
+    },
+    {
+      "expression": "(((((((((../../suite/family/task eq complete and not (../../suite/family/task:attrib1)) and (../../node4/family/task eq complete and not (../../node4/family/task:attrib1))) and (../../node5/family/task eq complete and not (../../node5/family/task:attrib1))) and (../../node6/family/task eq complete and not (../../node6/family/task:attrib1))) and (../../node7/family/task eq complete and not (../../node7/family/task:attrib1))) and (../../node8/family/task eq complete and not (../../node8/family/task:attrib1))) and ((((((../../suite/node9/task eq complete and not (../../suite/node9/task:attrib1)) and (../../node4/node9/task eq complete and not (../../node4/node9/task:attrib1))) and (../../node5/node9/task eq complete and not (../../node5/node9/task:attrib1))) and (../../node6/node9/task eq complete and not (../../node6/node9/task:attrib1))) and (../../node7/node9/task eq complete and not (../../node7/node9/task:attrib1))) and (../../node8/node9/task eq complete and not (../../node8/node9/task:attrib1)))) and ((((((../../suite/node10/task eq complete and not (../../suite/node10/task:attrib1)) and (../../node4/node10/task eq complete and not (../../node4/node10/task:attrib1))) and (../../node5/node10/task eq complete and not (../../node5/node10/task:attrib1))) and (../../node6/node10/task eq complete and not (../../node6/node10/task:attrib1))) and (../../node7/node10/task eq complete and not (../../node7/node10/task:attrib1))) and (../../node8/node10/task eq complete and not (../../node8/node10/task:attrib1)))) or (task eq complete and not (task:attrib2)))",
+      "expected": "((((((((((../../suite/family/task == complete) and not (../../suite/family/task:attrib1)) and ((../../node4/family/task == complete) and not (../../node4/family/task:attrib1))) and ((../../node5/family/task == complete) and not (../../node5/family/task:attrib1))) and ((../../node6/family/task == complete) and not (../../node6/family/task:attrib1))) and ((../../node7/family/task == complete) and not (../../node7/family/task:attrib1))) and ((../../node8/family/task == complete) and not (../../node8/family/task:attrib1))) and (((((((../../suite/node9/task == complete) and not (../../suite/node9/task:attrib1)) and ((../../node4/node9/task == complete) and not (../../node4/node9/task:attrib1))) and ((../../node5/node9/task == complete) and not (../../node5/node9/task:attrib1))) and ((../../node6/node9/task == complete) and not (../../node6/node9/task:attrib1))) and ((../../node7/node9/task == complete) and not (../../node7/node9/task:attrib1))) and ((../../node8/node9/task == complete) and not (../../node8/node9/task:attrib1)))) and (((((((../../suite/node10/task == complete) and not (../../suite/node10/task:attrib1)) and ((../../node4/node10/task == complete) and not (../../node4/node10/task:attrib1))) and ((../../node5/node10/task == complete) and not (../../node5/node10/task:attrib1))) and ((../../node6/node10/task == complete) and not (../../node6/node10/task:attrib1))) and ((../../node7/node10/task == complete) and not (../../node7/node10/task:attrib1))) and ((../../node8/node10/task == complete) and not (../../node8/node10/task:attrib1)))) or ((task == complete) and not (task:attrib2)))"
+    },
+    {
+      "expression": "((((((../../suite/family/task eq complete and not (../../suite/family/task:attrib1)) and (../../node4/family/task eq complete and not (../../node4/family/task:attrib1))) and (../../node5/family/task eq complete and not (../../node5/family/task:attrib1))) and (../../node6/family/task eq complete and not (../../node6/family/task:attrib1))) and (../../node7/family/task eq complete and not (../../node7/family/task:attrib1))) and (../../node8/family/task eq complete and not (../../node8/family/task:attrib1)))",
+      "expected": "(((((((../../suite/family/task == complete) and not (../../suite/family/task:attrib1)) and ((../../node4/family/task == complete) and not (../../node4/family/task:attrib1))) and ((../../node5/family/task == complete) and not (../../node5/family/task:attrib1))) and ((../../node6/family/task == complete) and not (../../node6/family/task:attrib1))) and ((../../node7/family/task == complete) and not (../../node7/family/task:attrib1))) and ((../../node8/family/task == complete) and not (../../node8/family/task:attrib1)))"
+    },
+    {
+      "expression": "((((((../../suite/family/task eq complete and ../../suite/family/task:attrib1) or (../../node4/family/task eq complete and ../../node4/family/task:attrib1)) or (../../node5/family/task eq complete and ../../node5/family/task:attrib1)) or (../../node6/family/task eq complete and ../../node6/family/task:attrib1)) or (../../node7/family/task eq complete and ../../node7/family/task:attrib1)) or (../../node8/family/task eq complete and ../../node8/family/task:attrib1))",
+      "expected": "(((((((../../suite/family/task == complete) and ../../suite/family/task:attrib1) or ((../../node4/family/task == complete) and ../../node4/family/task:attrib1)) or ((../../node5/family/task == complete) and ../../node5/family/task:attrib1)) or ((../../node6/family/task == complete) and ../../node6/family/task:attrib1)) or ((../../node7/family/task == complete) and ../../node7/family/task:attrib1)) or ((../../node8/family/task == complete) and ../../node8/family/task:attrib1))"
+    },
+    {
+      "expression": "(((((((../../suite/family/task eq complete and not (../../suite/family/task:attrib1)) and (../../node4/family/task eq complete and not (../../node4/family/task:attrib1))) and (../../node5/family/task eq complete and not (../../node5/family/task:attrib1))) and (../../node6/family/task eq complete and not (../../node6/family/task:attrib1))) and (../../node7/family/task eq complete and not (../../node7/family/task:attrib1))) and (../../node8/family/task eq complete and not (../../node8/family/task:attrib1))) or (task eq complete and not (task:attrib2)))",
+      "expected": "((((((((../../suite/family/task == complete) and not (../../suite/family/task:attrib1)) and ((../../node4/family/task == complete) and not (../../node4/family/task:attrib1))) and ((../../node5/family/task == complete) and not (../../node5/family/task:attrib1))) and ((../../node6/family/task == complete) and not (../../node6/family/task:attrib1))) and ((../../node7/family/task == complete) and not (../../node7/family/task:attrib1))) and ((../../node8/family/task == complete) and not (../../node8/family/task:attrib1))) or ((task == complete) and not (task:attrib2)))"
+    },
+    {
+      "expression": "(suite eq complete and not (suite:attrib1))",
+      "expected": "((suite == complete) and not (suite:attrib1))"
+    },
+    {
+      "expression": "((../../suite/family eq complete and (task eq complete and task:attrib1)) and (../node4/node5 eq complete or ../node4/task:attrib2))",
+      "expected": "(((../../suite/family == complete) and ((task == complete) and task:attrib1)) and ((../node4/node5 == complete) or ../node4/task:attrib2))"
+    },
+    {
+      "expression": "((../../suite/family eq complete and task:attrib1) and (../node4/node5 eq complete or ../node4/task:attrib2))",
+      "expected": "(((../../suite/family == complete) and task:attrib1) and ((../node4/node5 == complete) or ../node4/task:attrib2))"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 > ./task:attrib1 or (/suite/family:attrib1 == ./task:attrib1 and /suite/family/node4/node5/node6 == complete))) and (./task:attrib1 le (../node7/task:attrib1 - 99)))",
+      "expected": "(((/suite/family:attrib1 > ./task:attrib1) or ((/suite/family:attrib1 == ./task:attrib1) and (/suite/family/node4/node5/node6 == complete))) and (./task:attrib1 <= (../node7/task:attrib1 - 99)))"
+    },
+    {
+      "expression": "(./suite:attrib1 le (../family/suite:attrib1 - 999))",
+      "expected": "(./suite:attrib1 <= (../family/suite:attrib1 - 999))"
+    },
+    {
+      "expression": "((:attrib1 ge 1400 and :attrib2 eq :attrib3) or (:attrib2 gt :attrib3))",
+      "expected": "(((:attrib1 >= 1400) and (:attrib2 == :attrib3)) or (:attrib2 > :attrib3))"
+    },
+    {
+      "expression": "((:attrib1 ge 1400 and :attrib2 eq :attrib3) or (:attrib2 gt :attrib3) or (:attrib4 == 0))",
+      "expected": "(((:attrib1 >= 1400) and (:attrib2 == :attrib3)) or ((:attrib2 > :attrib3) or (:attrib4 == 0)))"
+    },
+    {
+      "expression": "(((((((((((((((((((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and node6 eq complete) and node7 eq complete) and node8 eq complete) and node9 eq complete) and node10 eq complete) and node11 eq complete) and node12 eq complete) and node13 eq complete) and node14 eq complete) and node15 eq complete) and node16 eq complete) and node17 eq complete) and node18 eq complete) and node19 eq complete) and node20 eq complete) and node21 eq complete) and node22 eq complete)",
+      "expected": "((((((((((((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)) and (node17 == complete)) and (node18 == complete)) and (node19 == complete)) and (node20 == complete)) and (node21 == complete)) and (node22 == complete))"
+    },
+    {
+      "expression": "(suite eq complete and (../../family:attrib1 gt ../../task:attrib1 or (../../family:attrib1 eq ../../task:attrib1 and (../../family/node4 eq complete and ../../family/node5 eq complete))))",
+      "expected": "((suite == complete) and ((../../family:attrib1 > ../../task:attrib1) or ((../../family:attrib1 == ../../task:attrib1) and ((../../family/node4 == complete) and (../../family/node5 == complete)))))"
+    },
+    {
+      "expression": "((suite:attrib1 le family:attrib1 + 3 or family eq complete) and (task:attrib1 gt suite:attrib1 or task eq complete) and node4 eq complete)",
+      "expected": "(((suite:attrib1 <= (family:attrib1 + 3)) or (family == complete)) and (((task:attrib1 > suite:attrib1) or (task == complete)) and (node4 == complete)))"
+    },
+    {
+      "expression": "((../../suite/family/task eq complete or ../../suite/family/task:attrib1 >= 3) and (node4 == complete))",
+      "expected": "(((../../suite/family/task == complete) or (../../suite/family/task:attrib1 >= 3)) and (node4 == complete))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12 and /suite/family/task/node4/node5/node6/node7/node9 eq complete and /suite/family/task/node4/node5/task/node7 == complete and (/suite/family/task/node4/node5:attrib2 == /suite/family/task/node4/node10:attrib2-1)) or (/suite/family/task/node4/node5:attrib2 >= /suite/family/task/node4/node10:attrib2)) and node11 == complete and node12 == complete)",
+      "expected": "((((((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5/task/node7 == complete)) and (/suite/family/task/node4/node5:attrib2 == (/suite/family/task/node4/node10:attrib2 - 1))) or (/suite/family/task/node4/node5:attrib2 >= /suite/family/task/node4/node10:attrib2)) and ((node11 == complete) and (node12 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12 and /suite/family/task/node4/node5/node6/node7/node9 eq complete and /suite/family/task/node4/node5/task/node7 == complete and (/suite/family/task/node4/node5:attrib2 == /suite/family/task/node4/node10:attrib2)) or (/suite/family/task/node4/node5:attrib2 > /suite/family/task/node4/node10:attrib2)) and node11 == complete and node12 == complete)",
+      "expected": "((((((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5/task/node7 == complete)) and (/suite/family/task/node4/node5:attrib2 == /suite/family/task/node4/node10:attrib2)) or (/suite/family/task/node4/node5:attrib2 > /suite/family/task/node4/node10:attrib2)) and ((node11 == complete) and (node12 == complete)))"
+    },
+    {
+      "expression": "((./00:attrib1 le ../suite/00:attrib1 + 2 or ../suite/00 eq complete) and (/family/task:attrib1 ge ./00:attrib1 or (/family/task:attrib1 eq ./00:attrib1 - 1 and /family/node4/00/node5 eq complete)))",
+      "expected": "(((./00:attrib1 <= (../suite/00:attrib1 + 2)) or (../suite/00 == complete)) and ((/family/task:attrib1 >= ./00:attrib1) or ((/family/task:attrib1 == (./00:attrib1 - 1)) and (/family/node4/00/node5 == complete))))"
+    },
+    {
+      "expression": "(((((((((((((((((((((((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and node6 eq complete) and node7 eq complete) and node8 eq complete) and node9 eq complete) and node10 eq complete) and node11 eq complete) and node12 eq complete) and node13 eq complete) and node14 eq complete) and node15 eq complete) and node16 eq complete) and node17 eq complete) and node18 eq complete) and node19 eq complete) and node20 eq complete) and node21 eq complete) and node22 eq complete) and node23 eq complete) and node24 eq complete) and node25 eq complete) and node26 eq complete)",
+      "expected": "((((((((((((((((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)) and (node17 == complete)) and (node18 == complete)) and (node19 == complete)) and (node20 == complete)) and (node21 == complete)) and (node22 == complete)) and (node23 == complete)) and (node24 == complete)) and (node25 == complete)) and (node26 == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 > /task/node4/node5/node6/node7:attrib1 or (/suite/family:attrib1 == /task/node4/node5/node6/node7:attrib1 and /suite/family/node8/node9/node6 == complete)))",
+      "expected": "((/suite/family:attrib1 > /task/node4/node5/node6/node7:attrib1) or ((/suite/family:attrib1 == /task/node4/node5/node6/node7:attrib1) and (/suite/family/node8/node9/node6 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5/node6/node7/node8 eq complete and /suite/family/task/node4/node5/node9 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node5:attrib1-1)) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node5:attrib1))",
+      "expected": "((((/suite/family/task/node4/node5/node6/node7/node8 == complete) and (/suite/family/task/node4/node5/node9 == complete)) and (/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node5:attrib1 - 1))) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node5:attrib1))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5:attrib1 gt /suite/family/task/node6/node5:attrib1) or (/suite/family/task/node4/node5/node7 == complete)))",
+      "expected": "((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node6/node5:attrib1) or (/suite/family/task/node4/node5/node7 == complete))"
+    },
+    {
+      "expression": "(cal::date_to_julian(suite:attrib1) lt cal::date_to_julian(family:attrib1) + suite:attrib2)",
+      "expected": "(date_to_julian(arg:0) = 0 < (date_to_julian(arg:0) = 0 + suite:attrib2))"
+    },
+    {
+      "expression": "(../../../../suite/20/family:attrib1 gt ../../../20:attrib1 or (../../../../suite/20/family:attrib1 eq ../../../20:attrib1 and (((../../../../suite/20/family/task/node4/001 eq complete and ../../../../suite/20/family/task/node4/002 eq complete) and ../../../../suite/20/family/task/node4/003 eq complete) and ../../../../suite/20/family/task/node4/004 eq complete)))",
+      "expected": "((../../../../suite/20/family:attrib1 > ../../../20:attrib1) or ((../../../../suite/20/family:attrib1 == ../../../20:attrib1) and ((((../../../../suite/20/family/task/node4/001 == complete) and (../../../../suite/20/family/task/node4/002 == complete)) and (../../../../suite/20/family/task/node4/003 == complete)) and (../../../../suite/20/family/task/node4/004 == complete))))"
+    },
+    {
+      "expression": "(suite eq complete and (../../../family/task:attrib1 gt ../../../node4:attrib1 or (../../../family/task:attrib1 eq ../../../node4:attrib1 and (((((((((../../../family/task/node5/node6/011 eq complete and ../../../family/task/node5/node6/012 eq complete) and ../../../family/task/node5/node6/013 eq complete) and ../../../family/task/node5/node6/014 eq complete) and ../../../family/task/node5/node6/015 eq complete) and ../../../family/task/node5/node6/016 eq complete) and ../../../family/task/node5/node6/017 eq complete) and ../../../family/task/node5/node6/018 eq complete) and ../../../family/task/node5/node6/019 eq complete) and ../../../family/task/node5/node6/020 eq complete))))",
+      "expected": "((suite == complete) and ((../../../family/task:attrib1 > ../../../node4:attrib1) or ((../../../family/task:attrib1 == ../../../node4:attrib1) and ((((((((((../../../family/task/node5/node6/011 == complete) and (../../../family/task/node5/node6/012 == complete)) and (../../../family/task/node5/node6/013 == complete)) and (../../../family/task/node5/node6/014 == complete)) and (../../../family/task/node5/node6/015 == complete)) and (../../../family/task/node5/node6/016 == complete)) and (../../../family/task/node5/node6/017 == complete)) and (../../../family/task/node5/node6/018 == complete)) and (../../../family/task/node5/node6/019 == complete)) and (../../../family/task/node5/node6/020 == complete)))))"
+    },
+    {
+      "expression": "(../../../../suite/20/family:attrib1 gt ../../../20:attrib1 or (../../../../suite/20/family:attrib1 eq ../../../20:attrib1 and (((((((((((((../../../../suite/20/family/task/node4/001 eq complete and ../../../../suite/20/family/task/node4/002 eq complete) and ../../../../suite/20/family/task/node4/003 eq complete) and ../../../../suite/20/family/task/node4/004 eq complete) and ../../../../suite/20/family/task/node4/005 eq complete) and ../../../../suite/20/family/task/node4/006 eq complete) and ../../../../suite/20/family/task/node4/007 eq complete) and ../../../../suite/20/family/task/node4/008 eq complete) and ../../../../suite/20/family/task/node4/009 eq complete) and ../../../../suite/20/family/task/node4/010 eq complete) and ../../../../suite/20/family/task/node4/011 eq complete) and ../../../../suite/20/family/task/node4/012 eq complete) and ../../../../suite/20/family/task/node4/013 eq complete) and ../../../../suite/20/family/task/node4/014 eq complete)))",
+      "expected": "((../../../../suite/20/family:attrib1 > ../../../20:attrib1) or ((../../../../suite/20/family:attrib1 == ../../../20:attrib1) and ((((((((((((((../../../../suite/20/family/task/node4/001 == complete) and (../../../../suite/20/family/task/node4/002 == complete)) and (../../../../suite/20/family/task/node4/003 == complete)) and (../../../../suite/20/family/task/node4/004 == complete)) and (../../../../suite/20/family/task/node4/005 == complete)) and (../../../../suite/20/family/task/node4/006 == complete)) and (../../../../suite/20/family/task/node4/007 == complete)) and (../../../../suite/20/family/task/node4/008 == complete)) and (../../../../suite/20/family/task/node4/009 == complete)) and (../../../../suite/20/family/task/node4/010 == complete)) and (../../../../suite/20/family/task/node4/011 == complete)) and (../../../../suite/20/family/task/node4/012 == complete)) and (../../../../suite/20/family/task/node4/013 == complete)) and (../../../../suite/20/family/task/node4/014 == complete))))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8==complete and /suite/family/task/node4/node5/task/node7 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node9:attrib1-1)) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node9:attrib1)) and node10 == complete and node11 == complete)",
+      "expected": "(((((/suite/family/task/node4/node5/node6/node7/node8 == complete) and (/suite/family/task/node4/node5/task/node7 == complete)) and (/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node9:attrib1 - 1))) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node9:attrib1)) and ((node10 == complete) and (node11 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8==complete and /suite/family/task/node4/node5/task/node9 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node10:attrib1-1)) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node10:attrib1)) and node11 == complete and node12 == complete and ../node9/node13 == complete)",
+      "expected": "(((((/suite/family/task/node4/node5/node6/node7/node8 == complete) and (/suite/family/task/node4/node5/task/node9 == complete)) and (/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node10:attrib1 - 1))) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node10:attrib1)) and (((node11 == complete) and (node12 == complete)) and (../node9/node13 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8==complete and /suite/family/task/node4/node5/task/node7 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node9:attrib1)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node9:attrib1)) and node10 == complete and node11 == complete)",
+      "expected": "(((((/suite/family/task/node4/node5/node6/node7/node8 == complete) and (/suite/family/task/node4/node5/task/node7 == complete)) and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node9:attrib1)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node9:attrib1)) and ((node10 == complete) and (node11 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8==complete and /suite/family/task/node4/node5/task/node9 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node10:attrib1)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node10:attrib1)) and node11 == complete and node12 == complete and ../node9/node13 == complete)",
+      "expected": "(((((/suite/family/task/node4/node5/node6/node7/node8 == complete) and (/suite/family/task/node4/node5/task/node9 == complete)) and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node10:attrib1)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node10:attrib1)) and (((node11 == complete) and (node12 == complete)) and (../node9/node13 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12 and /suite/family/task/node4/node5/node6/node7/node9 eq complete and /suite/family/task/node4/node5/node6/node7/node10==complete and /suite/family/task/node4/node5/task/node7 == complete and (/suite/family/task/node4/node5:attrib2 == /suite/family/task/node4/node11:attrib2-1)) or (/suite/family/task/node4/node5:attrib2 >= /suite/family/task/node4/node11:attrib2)) and node12 == complete and node13 == complete)",
+      "expected": "(((((((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5/node6/node7/node10 == complete)) and (/suite/family/task/node4/node5/task/node7 == complete)) and (/suite/family/task/node4/node5:attrib2 == (/suite/family/task/node4/node11:attrib2 - 1))) or (/suite/family/task/node4/node5:attrib2 >= /suite/family/task/node4/node11:attrib2)) and ((node12 == complete) and (node13 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8==complete and /suite/family/task/node4/node5/node6/node7/node9 eq complete and /suite/family/task/node4/node5/node6/node7/node10==complete and /suite/family/task/node4/node5/task/node7 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node11:attrib1-1)) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node11:attrib1)) and node12 == complete and node13 == complete)",
+      "expected": "(((((((/suite/family/task/node4/node5/node6/node7/node8 == complete) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5/node6/node7/node10 == complete)) and (/suite/family/task/node4/node5/task/node7 == complete)) and (/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node11:attrib1 - 1))) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node11:attrib1)) and ((node12 == complete) and (node13 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8==complete and /suite/family/task/node4/node5/node6/node7/node9 eq complete and /suite/family/task/node4/node5/node6/node7/node10==complete and /suite/family/task/node4/node5/task/node11 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node12:attrib1-1)) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node12:attrib1)) and node13 == complete and node14 == complete and ../node11/node15 == complete)",
+      "expected": "(((((((/suite/family/task/node4/node5/node6/node7/node8 == complete) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5/node6/node7/node10 == complete)) and (/suite/family/task/node4/node5/task/node11 == complete)) and (/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node12:attrib1 - 1))) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node12:attrib1)) and (((node13 == complete) and (node14 == complete)) and (../node11/node15 == complete)))"
+    },
+    {
+      "expression": "((../../suite/family/task eq complete or ../../suite/family/task:attrib1 >= 14) and (../../node4/family/node5/node6 eq complete))",
+      "expected": "(((../../suite/family/task == complete) or (../../suite/family/task:attrib1 >= 14)) and (../../node4/family/node5/node6 == complete))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12 and /suite/family/task/node4/node5/node6/node7/node9 eq complete and /suite/family/task/node4/node5/node6/node7/node10==complete and /suite/family/task/node4/node5/task/node7 == complete and (/suite/family/task/node4/node5:attrib2 == /suite/family/task/node4/node11:attrib2)) or (/suite/family/task/node4/node5:attrib2 > /suite/family/task/node4/node11:attrib2)) and node12 == complete and node13 == complete)",
+      "expected": "(((((((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5/node6/node7/node10 == complete)) and (/suite/family/task/node4/node5/task/node7 == complete)) and (/suite/family/task/node4/node5:attrib2 == /suite/family/task/node4/node11:attrib2)) or (/suite/family/task/node4/node5:attrib2 > /suite/family/task/node4/node11:attrib2)) and ((node12 == complete) and (node13 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8==complete and /suite/family/task/node4/node5/node6/node7/node9 eq complete and /suite/family/task/node4/node5/node6/node7/node10==complete and /suite/family/task/node4/node5/task/node7 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node11:attrib1)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node11:attrib1)) and node12 == complete and node13 == complete)",
+      "expected": "(((((((/suite/family/task/node4/node5/node6/node7/node8 == complete) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5/node6/node7/node10 == complete)) and (/suite/family/task/node4/node5/task/node7 == complete)) and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node11:attrib1)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node11:attrib1)) and ((node12 == complete) and (node13 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8==complete and /suite/family/task/node4/node5/node6/node7/node9 eq complete and /suite/family/task/node4/node5/node6/node7/node10==complete and /suite/family/task/node4/node5/task/node11 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node12:attrib1)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node12:attrib1)) and node13 == complete and node14 == complete and ../node11/node15 == complete)",
+      "expected": "(((((((/suite/family/task/node4/node5/node6/node7/node8 == complete) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5/node6/node7/node10 == complete)) and (/suite/family/task/node4/node5/task/node11 == complete)) and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node12:attrib1)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node12:attrib1)) and (((node13 == complete) and (node14 == complete)) and (../node11/node15 == complete)))"
+    },
+    {
+      "expression": "((((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12 and /suite/family/task/node4/node5/node6/node7/node9 eq complete and /suite/family/task/node4/node5/node6/node7/node10==complete and /suite/family/task/node4/node5/task/node11 == complete and (/suite/family/task/node4/node5:attrib2 == /suite/family/task/node4/node12:attrib2-1)) or (/suite/family/task/node4/node5:attrib2 >= /suite/family/task/node4/node12:attrib2)) and ../node11/node13 == complete) and node14 == complete and node15 == complete)",
+      "expected": "((((((((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5/node6/node7/node10 == complete)) and (/suite/family/task/node4/node5/task/node11 == complete)) and (/suite/family/task/node4/node5:attrib2 == (/suite/family/task/node4/node12:attrib2 - 1))) or (/suite/family/task/node4/node5:attrib2 >= /suite/family/task/node4/node12:attrib2)) and (../node11/node13 == complete)) and ((node14 == complete) and (node15 == complete)))"
+    },
+    {
+      "expression": "((((/suite/family/task/node4/node5/node6/node7/node8==complete and /suite/family/task/node4/node5/node6/node7/node9 eq complete and /suite/family/task/node4/node5/node6/node7/node10==complete and /suite/family/task/node4/node5/task/node11 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node12:attrib1-1)) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node12:attrib1)) and ../node11/node13 == complete) and node13 == complete and node14 == complete and ../node11/node15 == complete)",
+      "expected": "((((((((/suite/family/task/node4/node5/node6/node7/node8 == complete) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5/node6/node7/node10 == complete)) and (/suite/family/task/node4/node5/task/node11 == complete)) and (/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node12:attrib1 - 1))) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node12:attrib1)) and (../node11/node13 == complete)) and (((node13 == complete) and (node14 == complete)) and (../node11/node15 == complete)))"
+    },
+    {
+      "expression": "((((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12 and /suite/family/task/node4/node5/node6/node7/node9 eq complete and /suite/family/task/node4/node5/node6/node7/node10==complete and /suite/family/task/node4/node5/task/node11 == complete and (/suite/family/task/node4/node5:attrib2 == /suite/family/task/node4/node12:attrib2)) or (/suite/family/task/node4/node5:attrib2 > /suite/family/task/node4/node12:attrib2)) and ../node11/node13 == complete) and node14 == complete and node15 == complete)",
+      "expected": "((((((((/suite/family/task/node4/node5/node6/node7/node8:attrib1 >= 12) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5/node6/node7/node10 == complete)) and (/suite/family/task/node4/node5/task/node11 == complete)) and (/suite/family/task/node4/node5:attrib2 == /suite/family/task/node4/node12:attrib2)) or (/suite/family/task/node4/node5:attrib2 > /suite/family/task/node4/node12:attrib2)) and (../node11/node13 == complete)) and ((node14 == complete) and (node15 == complete)))"
+    },
+    {
+      "expression": "((((/suite/family/task/node4/node5/node6/node7/node8==complete and /suite/family/task/node4/node5/node6/node7/node9 eq complete and /suite/family/task/node4/node5/node6/node7/node10==complete and /suite/family/task/node4/node5/task/node11 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node12:attrib1)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node12:attrib1)) and ../node11/node13 == complete) and node13 == complete and node14 == complete and ../node11/node15 == complete)",
+      "expected": "((((((((/suite/family/task/node4/node5/node6/node7/node8 == complete) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5/node6/node7/node10 == complete)) and (/suite/family/task/node4/node5/task/node11 == complete)) and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node12:attrib1)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node12:attrib1)) and (../node11/node13 == complete)) and (((node13 == complete) and (node14 == complete)) and (../node11/node15 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8==complete and /suite/family/task/node4/node5/node6/node7/node9 eq complete and /suite/family/task/node4/node5/task/node7 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node10:attrib1-1)) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node10:attrib1)) and node11 == complete and node12 == complete)",
+      "expected": "((((((/suite/family/task/node4/node5/node6/node7/node8 == complete) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5/task/node7 == complete)) and (/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node10:attrib1 - 1))) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node10:attrib1)) and ((node11 == complete) and (node12 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8==complete and /suite/family/task/node4/node5/node6/node7/node9 eq complete and /suite/family/task/node4/node5/task/node10 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node11:attrib1-1)) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node11:attrib1)) and node12 == complete and node13 == complete and ../node10/node14 == complete)",
+      "expected": "((((((/suite/family/task/node4/node5/node6/node7/node8 == complete) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5/task/node10 == complete)) and (/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node11:attrib1 - 1))) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node11:attrib1)) and (((node12 == complete) and (node13 == complete)) and (../node10/node14 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8==complete and /suite/family/task/node4/node5/node6/node7/node9 eq complete and /suite/family/task/node4/node5/task/node7 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node10:attrib1)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node10:attrib1)) and node11 == complete and node12 == complete)",
+      "expected": "((((((/suite/family/task/node4/node5/node6/node7/node8 == complete) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5/task/node7 == complete)) and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node10:attrib1)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node10:attrib1)) and ((node11 == complete) and (node12 == complete)))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5/node6/node7/node8==complete and /suite/family/task/node4/node5/node6/node7/node9 eq complete and /suite/family/task/node4/node5/task/node10 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node11:attrib1)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node11:attrib1)) and node12 == complete and node13 == complete and ../node10/node14 == complete)",
+      "expected": "((((((/suite/family/task/node4/node5/node6/node7/node8 == complete) and (/suite/family/task/node4/node5/node6/node7/node9 == complete)) and (/suite/family/task/node4/node5/task/node10 == complete)) and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node11:attrib1)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node11:attrib1)) and (((node12 == complete) and (node13 == complete)) and (../node10/node14 == complete)))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5/node6 == complete and /suite/family/task/node4/node5/node7 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node8:attrib1-1)) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node8:attrib1))",
+      "expected": "((((/suite/family/task/node4/node5/node6 == complete) and (/suite/family/task/node4/node5/node7 == complete)) and (/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node8:attrib1 - 1))) or (/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node8:attrib1))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5/node6 == complete and /suite/family/task/node4/node5/node7 == complete and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node8:attrib1)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node8:attrib1))",
+      "expected": "((((/suite/family/task/node4/node5/node6 == complete) and (/suite/family/task/node4/node5/node7 == complete)) and (/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node8:attrib1)) or (/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node8:attrib1))"
+    },
+    {
+      "expression": "(((../suite:attrib1 gt family:attrib1 or ../suite eq complete) and family:attrib1 le ../task/family:attrib1 + 3) and (family:attrib1 eq node4:attrib1 or node4 eq complete))",
+      "expected": "((((../suite:attrib1 > family:attrib1) or (../suite == complete)) and (family:attrib1 <= (../task/family:attrib1 + 3))) and ((family:attrib1 == node4:attrib1) or (node4 == complete)))"
+    },
+    {
+      "expression": "(../suite == complete and (1 or 1))",
+      "expected": "((../suite == complete) and (1 or 1))"
+    },
+    {
+      "expression": "((suite:attrib1 lt ( family:attrib1 + 3 )) and (/task/node4/node5/node6/node7:attrib1 - suite:attrib1 gt 20260101 or (/task/node4/node5/node6/node7:attrib1 - suite:attrib1 eq 20260101 and /task/node4/node5/node6/node7/node8/node9 eq complete) or /task/node4/node5/node6/node7 eq complete))",
+      "expected": "((suite:attrib1 < (family:attrib1 + 3)) and (((/task/node4/node5/node6/node7:attrib1 - suite:attrib1) > 20260101) or ((((/task/node4/node5/node6/node7:attrib1 - suite:attrib1) == 20260101) and (/task/node4/node5/node6/node7/node8/node9 == complete)) or (/task/node4/node5/node6/node7 == complete))))"
+    },
+    {
+      "expression": "((suite == complete and family == complete and task == complete and node4 == complete) and (node5==complete))",
+      "expected": "(((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete))"
+    },
+    {
+      "expression": "((../../suite/family == complete) and (( ../task:attrib1 le ../node4:attrib1 or (../task:attrib1 eq ../node4:attrib1+1 and ../node4/node5 == complete) )))",
+      "expected": "((../../suite/family == complete) and ((../task:attrib1 <= ../node4:attrib1) or ((../task:attrib1 == (../node4:attrib1 + 1)) and (../node4/node5 == complete))))"
+    },
+    {
+      "expression": "(( (( suite:attrib1 le ( family:attrib1 + 5 ) ) or family == complete ) and (( task:attrib1 gt suite:attrib1 ) or ( task:attrib1 eq suite:attrib1 and task/node4 == complete ) or task == complete ) ))",
+      "expected": "(((suite:attrib1 <= (family:attrib1 + 5)) or (family == complete)) and ((task:attrib1 > suite:attrib1) or (((task:attrib1 == suite:attrib1) and (task/node4 == complete)) or (task == complete))))"
+    },
+    {
+      "expression": "(suite:attrib1 lt family:attrib1 or ( family/task == complete and family:attrib1 eq suite:attrib1 ))",
+      "expected": "((suite:attrib1 < family:attrib1) or ((family/task == complete) and (family:attrib1 == suite:attrib1)))"
+    },
+    {
+      "expression": "(( suite:attrib1 > 12 ))",
+      "expected": "(suite:attrib1 > 12)"
+    },
+    {
+      "expression": "(( suite == complete ) or ( family:attrib1 lt suite:attrib1 ) or ( family:attrib1 eq suite:attrib1 and suite/task == complete and suite/node4 == complete and suite/node5 == complete ))",
+      "expected": "((suite == complete) or ((family:attrib1 < suite:attrib1) or ((((family:attrib1 == suite:attrib1) and (suite/task == complete)) and (suite/node4 == complete)) and (suite/node5 == complete))))"
+    },
+    {
+      "expression": "((./suite:attrib1 or ./suite==complete) and (./family:attrib1 or ./family==complete) and (./suite==complete or ./family==complete))",
+      "expected": "((./suite:attrib1 or (./suite == complete)) and ((./family:attrib1 or (./family == complete)) and ((./suite == complete) or (./family == complete))))"
+    },
+    {
+      "expression": "((suite==complete or suite==unknown) and (family==complete or family==unknown) and (task==complete or task==unknown))",
+      "expected": "(((suite == complete) or (suite == unknown)) and (((family == complete) or (family == unknown)) and ((task == complete) or (task == unknown))))"
+    },
+    {
+      "expression": "((suite == complete) and (../../family:attrib1 gt ../../task:attrib1 or (../../family:attrib1 eq ../../task:attrib1 and ../../family/node4==complete)))",
+      "expected": "((suite == complete) and ((../../family:attrib1 > ../../task:attrib1) or ((../../family:attrib1 == ../../task:attrib1) and (../../family/node4 == complete))))"
+    },
+    {
+      "expression": "((1 or 1) and (1 or 1) and (suite==complete or suite==unknown) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1) and (1 or 1))",
+      "expected": "((1 or 1) and ((1 or 1) and (((suite == complete) or (suite == unknown)) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and ((1 or 1) and (1 or 1)))))))))))))))))))))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1-1) and /suite/family/task/node4/node5/node7/node8:attrib2 >= 12 and /suite/family/task/node4/node5/task == complete)))",
+      "expected": "((/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node6:attrib1 - 1)) and ((/suite/family/task/node4/node5/node7/node8:attrib2 >= 12) and (/suite/family/task/node4/node5/task == complete))))"
+    },
+    {
+      "expression": "((((/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1-1) and /suite/family/task/node4/node5/node7/node8:attrib2 >= 12 and /suite/family/task/node4/node5/task == complete))) and (/suite/family/task/node4/node6/task/node9 == complete))",
+      "expected": "(((/suite/family/task/node4/node5:attrib1 >= /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == (/suite/family/task/node4/node6:attrib1 - 1)) and ((/suite/family/task/node4/node5/node7/node8:attrib2 >= 12) and (/suite/family/task/node4/node5/task == complete)))) and (/suite/family/task/node4/node6/task/node9 == complete))"
+    },
+    {
+      "expression": "(((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and /suite/family/task/node4/node5/node7/node8:attrib2 >= 12 and /suite/family/task/node4/node5/task == complete)))",
+      "expected": "((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and ((/suite/family/task/node4/node5/node7/node8:attrib2 >= 12) and (/suite/family/task/node4/node5/task == complete))))"
+    },
+    {
+      "expression": "((((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and /suite/family/task/node4/node5/node7/node8:attrib2 >= 12 and /suite/family/task/node4/node5/task == complete))) and (/suite/family/task/node4/node6/task/node9 == complete))",
+      "expected": "(((/suite/family/task/node4/node5:attrib1 > /suite/family/task/node4/node6:attrib1) or ((/suite/family/task/node4/node5:attrib1 == /suite/family/task/node4/node6:attrib1) and ((/suite/family/task/node4/node5/node7/node8:attrib2 >= 12) and (/suite/family/task/node4/node5/task == complete)))) and (/suite/family/task/node4/node6/task/node9 == complete))"
+    },
+    {
+      "expression": "(((../suite == complete and ../suite/family:attrib1 == ./family:attrib1) or (../suite/family:attrib1 gt ./family:attrib1)))",
+      "expected": "(((../suite == complete) and (../suite/family:attrib1 == ./family:attrib1)) or (../suite/family:attrib1 > ./family:attrib1))"
+    },
+    {
+      "expression": "(/suite/family/task/node4/node5/node6/node7:attrib1 > /suite/family/task/node4/node8/node6/node7:attrib1 or /suite/family/task/node4/node5/node6/node7 == complete)",
+      "expected": "((/suite/family/task/node4/node5/node6/node7:attrib1 > /suite/family/task/node4/node8/node6/node7:attrib1) or (/suite/family/task/node4/node5/node6/node7 == complete))"
+    },
+    {
+      "expression": "((suite eq complete and family:attrib1 le task:attrib1 + 4) and (/node4/node5:attrib1 ge family:attrib1 or (/node4/node5:attrib1 eq family:attrib1 - 1 and (/node4/task/00/node6/node7 eq complete))))",
+      "expected": "(((suite == complete) and (family:attrib1 <= (task:attrib1 + 4))) and ((/node4/node5:attrib1 >= family:attrib1) or ((/node4/node5:attrib1 == (family:attrib1 - 1)) and (/node4/task/00/node6/node7 == complete))))"
+    },
+    {
+      "expression": "(suite:attrib1 eq family:attrib1 and (task:attrib1 gt suite:attrib1 or task eq complete))",
+      "expected": "((suite:attrib1 == family:attrib1) and ((task:attrib1 > suite:attrib1) or (task == complete)))"
+    },
+    {
+      "expression": "((suite eq complete and family:attrib1 le task/node4:attrib1 + 4) and (/node5/node6:attrib1 ge family:attrib1 + 4))",
+      "expected": "(((suite == complete) and (family:attrib1 <= (task/node4:attrib1 + 4))) and (/node5/node6:attrib1 >= (family:attrib1 + 4)))"
+    },
+    {
+      "expression": "((suite/family eq complete or suite/family:attrib1) and ((task eq complete and node4 eq complete) and node5 eq complete))",
+      "expected": "(((suite/family == complete) or suite/family:attrib1) and (((task == complete) and (node4 == complete)) and (node5 == complete)))"
+    },
+    {
+      "expression": "(((suite eq complete and family eq complete) and task eq complete) and ((../node4/node5:attrib1 gt ../node6:attrib1 + 1 or (../node4/node5:attrib1 eq ../node6:attrib1 + 1 and ../node4/node5/node7/node8 eq complete)) or ../node4/node5 eq complete))",
+      "expected": "((((suite == complete) and (family == complete)) and (task == complete)) and (((../node4/node5:attrib1 > (../node6:attrib1 + 1)) or ((../node4/node5:attrib1 == (../node6:attrib1 + 1)) and (../node4/node5/node7/node8 == complete))) or (../node4/node5 == complete)))"
+    },
+    {
+      "expression": "((suite eq complete and family eq complete) and ((../../task/node4/00:attrib1 gt ../00:attrib1 + 1 or (../../task/node4/00:attrib1 eq ../00:attrib1 + 1 and ../../task/node4/00/node5/node6 eq complete)) or ../../task/node4/00 eq complete))",
+      "expected": "(((suite == complete) and (family == complete)) and (((../../task/node4/00:attrib1 > (../00:attrib1 + 1)) or ((../../task/node4/00:attrib1 == (../00:attrib1 + 1)) and (../../task/node4/00/node5/node6 == complete))) or (../../task/node4/00 == complete)))"
+    },
+    {
+      "expression": "((suite eq complete and family eq complete) and ((../../task/node4/00:attrib1 gt ../00:attrib1 or (../../task/node4/00:attrib1 eq ../00:attrib1 and ../../task/node4/00/node5/node6 eq complete)) or ../../task/node4/00 eq complete))",
+      "expected": "(((suite == complete) and (family == complete)) and (((../../task/node4/00:attrib1 > ../00:attrib1) or ((../../task/node4/00:attrib1 == ../00:attrib1) and (../../task/node4/00/node5/node6 == complete))) or (../../task/node4/00 == complete)))"
+    },
+    {
+      "expression": "(((suite eq complete and family eq complete) and task eq complete) and ((../../node4/node5/00:attrib1 gt ../00:attrib1 or (../../node4/node5/00:attrib1 eq ../00:attrib1 and ../../node4/node5/00/node6/node7 eq complete)) or ../../node4/node5/00 eq complete))",
+      "expected": "((((suite == complete) and (family == complete)) and (task == complete)) and (((../../node4/node5/00:attrib1 > ../00:attrib1) or ((../../node4/node5/00:attrib1 == ../00:attrib1) and (../../node4/node5/00/node6/node7 == complete))) or (../../node4/node5/00 == complete)))"
+    },
+    {
+      "expression": "((suite eq complete and family eq complete) and (../task:attrib1 lt ../node4/node5:attrib1 or ../node4/node5 eq complete))",
+      "expected": "(((suite == complete) and (family == complete)) and ((../task:attrib1 < ../node4/node5:attrib1) or (../node4/node5 == complete)))"
+    },
+    {
+      "expression": "((((((((((((((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and node6 eq complete) and node7 eq complete) and node8 eq complete) and node9 eq complete) and node10 eq complete) and node11 eq complete) and node12 eq complete) and node13 eq complete) and node14 eq complete) and node15 eq complete) and node16 eq complete) and node17 eq complete)",
+      "expected": "(((((((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)) and (node17 == complete))"
+    },
+    {
+      "expression": "(((suite eq complete) and ((:attrib1 lt :attrib2 or (:attrib1 eq :attrib2 and :attrib3 ge 1800 )))) and (:attrib1 lt (family:attrib1 + 3)))",
+      "expected": "(((suite == complete) and ((:attrib1 < :attrib2) or ((:attrib1 == :attrib2) and (:attrib3 >= 1800)))) and (:attrib1 < (family:attrib1 + 3)))"
+    },
+    {
+      "expression": "(suite eq complete and (:attrib1 lt family:attrib1 or (:attrib1 eq family:attrib1 and family/task eq complete and family/node4 eq complete)))",
+      "expected": "((suite == complete) and ((:attrib1 < family:attrib1) or (((:attrib1 == family:attrib1) and (family/task == complete)) and (family/node4 == complete))))"
+    },
+    {
+      "expression": "(suite/family:attrib1 and suite/family:attrib2 and task/node4 == complete)",
+      "expected": "((suite/family:attrib1 and suite/family:attrib2) and (task/node4 == complete))"
+    },
+    {
+      "expression": "(../suite/family/task/node4/node5 == complete and ../suite/family/task/node4/node6 == complete and ((../suite/node7/task/node8:attrib1 and not ../suite/node7/task/node8:attrib2) or ../suite/node9 == complete))",
+      "expected": "(((../suite/family/task/node4/node5 == complete) and (../suite/family/task/node4/node6 == complete)) and ((../suite/node7/task/node8:attrib1 and not (../suite/node7/task/node8:attrib2)) or (../suite/node9 == complete)))"
+    },
+    {
+      "expression": "((suite eq complete and family:attrib1 le task:attrib1 + 4) and (/node4/node5/node6/node7:attrib1 ge family:attrib1) and (/node8/node7:attrib1 ge family:attrib1 or (/node8/node7:attrib1 eq family:attrib1 - 1 and (/node8/task/00/node9/node10 eq complete))))",
+      "expected": "(((suite == complete) and (family:attrib1 <= (task:attrib1 + 4))) and ((/node4/node5/node6/node7:attrib1 >= family:attrib1) and ((/node8/node7:attrib1 >= family:attrib1) or ((/node8/node7:attrib1 == (family:attrib1 - 1)) and (/node8/task/00/node9/node10 == complete)))))"
+    },
+    {
+      "expression": "(suite:attrib1 le family:attrib1 + 3 and (task:attrib1 gt suite:attrib1 or task eq complete) and (/node4/node5/node6/family:attrib1 ge task:attrib1))",
+      "expected": "((suite:attrib1 <= (family:attrib1 + 3)) and (((task:attrib1 > suite:attrib1) or (task == complete)) and (/node4/node5/node6/family:attrib1 >= task:attrib1)))"
+    },
+    {
+      "expression": "((suite == complete) and /family/task/node4/node5/node6/node4/node7 == complete)",
+      "expected": "((suite == complete) and (/family/task/node4/node5/node6/node4/node7 == complete))"
+    },
+    {
+      "expression": "(((../../../suite/family/00:attrib1 gt ../../00:attrib1 + 1 or (../../../suite/family/00:attrib1 eq ../../00:attrib1 + 1 and ../../../suite/family/00/task eq complete)) or ../../../suite/family/00 eq complete) and ((../../../suite/node4/00:attrib1 gt ../../00:attrib1 + 1 or (../../../suite/node4/00:attrib1 eq ../../00:attrib1 + 1 and ../../../suite/node4/00/task eq complete)) or ../../../suite/node4/00 eq complete))",
+      "expected": "((((../../../suite/family/00:attrib1 > (../../00:attrib1 + 1)) or ((../../../suite/family/00:attrib1 == (../../00:attrib1 + 1)) and (../../../suite/family/00/task == complete))) or (../../../suite/family/00 == complete)) and (((../../../suite/node4/00:attrib1 > (../../00:attrib1 + 1)) or ((../../../suite/node4/00:attrib1 == (../../00:attrib1 + 1)) and (../../../suite/node4/00/task == complete))) or (../../../suite/node4/00 == complete)))"
+    },
+    {
+      "expression": "(/suite/family/task/node4/node5/00:attrib1 == 0 and /suite/family/task/node4/node5/00 == complete and /node6/node7/task/node4/node5/00 == complete and /node6/node7/task/node4/node5/00:attrib1 > 0 and /node6/node8/node9/node4/node10:attrib1 > 0 and /node6/node8/node9/node4/node10 == complete and /node11/node12/node9/node4/node10:attrib1 > 0 and /node11/node12/node9/node4/node10 == complete)",
+      "expected": "((((((((/suite/family/task/node4/node5/00:attrib1 == 0) and (/suite/family/task/node4/node5/00 == complete)) and (/node6/node7/task/node4/node5/00 == complete)) and (/node6/node7/task/node4/node5/00:attrib1 > 0)) and (/node6/node8/node9/node4/node10:attrib1 > 0)) and (/node6/node8/node9/node4/node10 == complete)) and (/node11/node12/node9/node4/node10:attrib1 > 0)) and (/node11/node12/node9/node4/node10 == complete))"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and (../../../node8/node9:attrib1 == :attrib1 or (../../../node8/node9:attrib1 + 1 == :attrib1 and ../../../node8/node9/node10/node11/node12 == complete)))",
+      "expected": "((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and ((../../../node8/node9:attrib1 == :attrib1) or (((../../../node8/node9:attrib1 + 1) == :attrib1) and (../../../node8/node9/node10/node11/node12 == complete))))"
+    },
+    {
+      "expression": "((../suite/00:attrib1 gt :attrib1) and (../family/task == complete))",
+      "expected": "((../suite/00:attrib1 > :attrib1) and (../family/task == complete))"
+    },
+    {
+      "expression": "((/suite/family:attrib1 > ./task:attrib1 or (/suite/family:attrib1 == ./task:attrib1 and /suite/family/node4/node5/node6 == complete)) AND ./task:attrib1 le (../node7/task:attrib1 + /node8/node9:attrib2))",
+      "expected": "(((/suite/family:attrib1 > ./task:attrib1) or ((/suite/family:attrib1 == ./task:attrib1) and (/suite/family/node4/node5/node6 == complete))) and (./task:attrib1 <= (../node7/task:attrib1 + /node8/node9:attrib2)))"
+    },
+    {
+      "expression": "((./suite:attrib1 lt /family/task/node4/node5/node6:attrib1 - 10) or (./suite:attrib1 == /family/task/node4/node5/node6:attrib1 - 10 and /family/task/node4/node5/node6 == complete) or (./suite:attrib1 == /family/task/node4/node5/node6:attrib1 - 10 and /family/task/node4/node5/node6/node7/node8/node9/node10:attrib2 and /family/task/node4/node5/node6/node7/node8/node9/node11:attrib2))",
+      "expected": "((./suite:attrib1 < (/family/task/node4/node5/node6:attrib1 - 10)) or (((./suite:attrib1 == (/family/task/node4/node5/node6:attrib1 - 10)) and (/family/task/node4/node5/node6 == complete)) or (((./suite:attrib1 == (/family/task/node4/node5/node6:attrib1 - 10)) and /family/task/node4/node5/node6/node7/node8/node9/node10:attrib2) and /family/task/node4/node5/node6/node7/node8/node9/node11:attrib2)))"
+    },
+    {
+      "expression": "((./suite:attrib1 lt /family/task/node4/node5/node6:attrib1 ) or (./suite:attrib1 == /family/task/node4/node5/node6:attrib1 and /family/task/node4/node5/node6 == complete) or (./suite:attrib1 == /family/task/node4/node5/node6:attrib1 and /family/task/node4/node5/node6/node7/node8/node9/node10:attrib2 and /family/task/node4/node5/node6/node7/node8/node9/node11:attrib2))",
+      "expected": "((./suite:attrib1 < /family/task/node4/node5/node6:attrib1) or (((./suite:attrib1 == /family/task/node4/node5/node6:attrib1) and (/family/task/node4/node5/node6 == complete)) or (((./suite:attrib1 == /family/task/node4/node5/node6:attrib1) and /family/task/node4/node5/node6/node7/node8/node9/node10:attrib2) and /family/task/node4/node5/node6/node7/node8/node9/node11:attrib2)))"
+    },
+    {
+      "expression": "((./suite:attrib1 lt 20240831 - 10))",
+      "expected": "(./suite:attrib1 < (20240831 - 10))"
+    },
+    {
+      "expression": "(suite eq complete and ../../family/task:attrib1 gt 1)",
+      "expected": "((suite == complete) and (../../family/task:attrib1 > 1))"
+    },
+    {
+      "expression": "((../suite:attrib1 gt ../family:attrib1 or (../suite:attrib1 eq ../family:attrib1 and ../suite/task:attrib2 ge task:attrib2)) and ../node4/task:attrib2 gt task:attrib2)",
+      "expected": "(((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and (../suite/task:attrib2 >= task:attrib2))) and (../node4/task:attrib2 > task:attrib2))"
+    },
+    {
+      "expression": "(suite:attrib1 le family:attrib1 and suite/task:attrib2 le family/task:attrib2 + 1)",
+      "expected": "((suite:attrib1 <= family:attrib1) and (suite/task:attrib2 <= (family/task:attrib2 + 1)))"
+    },
+    {
+      "expression": "(suite eq complete and (family/task eq complete or family/task:attrib1))",
+      "expected": "((suite == complete) and ((family/task == complete) or family/task:attrib1))"
+    },
+    {
+      "expression": "(../../../suite/family:attrib1 gt ../../../task:attrib1 or (../../../suite/family:attrib1 eq ../../../task:attrib1 and (((((((((((((((((((../../../suite/family/node4/node5/001 eq complete and ../../../suite/family/node4/node5/002 eq complete) and ../../../suite/family/node4/node5/003 eq complete) and ../../../suite/family/node4/node5/004 eq complete) and ../../../suite/family/node4/node5/005 eq complete) and ../../../suite/family/node4/node5/006 eq complete) and ../../../suite/family/node4/node5/007 eq complete) and ../../../suite/family/node4/node5/008 eq complete) and ../../../suite/family/node4/node5/009 eq complete) and ../../../suite/family/node4/node5/010 eq complete) and ../../../suite/family/node4/node5/011 eq complete) and ../../../suite/family/node4/node5/012 eq complete) and ../../../suite/family/node4/node5/013 eq complete) and ../../../suite/family/node4/node5/014 eq complete) and ../../../suite/family/node4/node5/015 eq complete) and ../../../suite/family/node4/node5/016 eq complete) and ../../../suite/family/node4/node5/017 eq complete) and ../../../suite/family/node4/node5/018 eq complete) and ../../../suite/family/node4/node5/019 eq complete) and ../../../suite/family/node4/node5/020 eq complete)))",
+      "expected": "((../../../suite/family:attrib1 > ../../../task:attrib1) or ((../../../suite/family:attrib1 == ../../../task:attrib1) and ((((((((((((((((((((../../../suite/family/node4/node5/001 == complete) and (../../../suite/family/node4/node5/002 == complete)) and (../../../suite/family/node4/node5/003 == complete)) and (../../../suite/family/node4/node5/004 == complete)) and (../../../suite/family/node4/node5/005 == complete)) and (../../../suite/family/node4/node5/006 == complete)) and (../../../suite/family/node4/node5/007 == complete)) and (../../../suite/family/node4/node5/008 == complete)) and (../../../suite/family/node4/node5/009 == complete)) and (../../../suite/family/node4/node5/010 == complete)) and (../../../suite/family/node4/node5/011 == complete)) and (../../../suite/family/node4/node5/012 == complete)) and (../../../suite/family/node4/node5/013 == complete)) and (../../../suite/family/node4/node5/014 == complete)) and (../../../suite/family/node4/node5/015 == complete)) and (../../../suite/family/node4/node5/016 == complete)) and (../../../suite/family/node4/node5/017 == complete)) and (../../../suite/family/node4/node5/018 == complete)) and (../../../suite/family/node4/node5/019 == complete)) and (../../../suite/family/node4/node5/020 == complete))))"
+    },
+    {
+      "expression": "(../../../suite/family:attrib1 gt ../../../task:attrib1 or (../../../suite/family:attrib1 eq ../../../task:attrib1 and (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((../../../suite/family/node4/node5/001 eq complete and ../../../suite/family/node4/node5/002 eq complete) and ../../../suite/family/node4/node5/003 eq complete) and ../../../suite/family/node4/node5/004 eq complete) and ../../../suite/family/node4/node5/005 eq complete) and ../../../suite/family/node4/node5/006 eq complete) and ../../../suite/family/node4/node5/007 eq complete) and ../../../suite/family/node4/node5/008 eq complete) and ../../../suite/family/node4/node5/009 eq complete) and ../../../suite/family/node4/node5/010 eq complete) and ../../../suite/family/node4/node5/011 eq complete) and ../../../suite/family/node4/node5/012 eq complete) and ../../../suite/family/node4/node5/013 eq complete) and ../../../suite/family/node4/node5/014 eq complete) and ../../../suite/family/node4/node5/015 eq complete) and ../../../suite/family/node4/node5/016 eq complete) and ../../../suite/family/node4/node5/017 eq complete) and ../../../suite/family/node4/node5/018 eq complete) and ../../../suite/family/node4/node5/019 eq complete) and ../../../suite/family/node4/node5/020 eq complete) and ../../../suite/family/node4/node5/021 eq complete) and ../../../suite/family/node4/node5/022 eq complete) and ../../../suite/family/node4/node5/023 eq complete) and ../../../suite/family/node4/node5/024 eq complete) and ../../../suite/family/node4/node5/025 eq complete) and ../../../suite/family/node4/node5/026 eq complete) and ../../../suite/family/node4/node5/027 eq complete) and ../../../suite/family/node4/node5/028 eq complete) and ../../../suite/family/node4/node5/029 eq complete) and ../../../suite/family/node4/node5/030 eq complete) and ../../../suite/family/node4/node5/031 eq complete) and ../../../suite/family/node4/node5/032 eq complete) and ../../../suite/family/node4/node5/033 eq complete) and ../../../suite/family/node4/node5/034 eq complete) and ../../../suite/family/node4/node5/035 eq complete) and ../../../suite/family/node4/node5/036 eq complete) and ../../../suite/family/node4/node5/037 eq complete) and ../../../suite/family/node4/node5/038 eq complete) and ../../../suite/family/node4/node5/039 eq complete) and ../../../suite/family/node4/node5/040 eq complete) and ../../../suite/family/node4/node5/041 eq complete) and ../../../suite/family/node4/node5/042 eq complete) and ../../../suite/family/node4/node5/043 eq complete) and ../../../suite/family/node4/node5/044 eq complete) and ../../../suite/family/node4/node5/045 eq complete) and ../../../suite/family/node4/node5/046 eq complete) and ../../../suite/family/node4/node5/047 eq complete) and ../../../suite/family/node4/node5/048 eq complete) and ../../../suite/family/node4/node5/049 eq complete) and ../../../suite/family/node4/node5/050 eq complete) and ../../../suite/family/node4/node5/051 eq complete) and ../../../suite/family/node4/node5/052 eq complete) and ../../../suite/family/node4/node5/053 eq complete) and ../../../suite/family/node4/node5/054 eq complete) and ../../../suite/family/node4/node5/055 eq complete) and ../../../suite/family/node4/node5/056 eq complete) and ../../../suite/family/node4/node5/057 eq complete) and ../../../suite/family/node4/node5/058 eq complete) and ../../../suite/family/node4/node5/059 eq complete) and ../../../suite/family/node4/node5/060 eq complete) and ../../../suite/family/node4/node5/061 eq complete) and ../../../suite/family/node4/node5/062 eq complete) and ../../../suite/family/node4/node5/063 eq complete) and ../../../suite/family/node4/node5/064 eq complete) and ../../../suite/family/node4/node5/065 eq complete) and ../../../suite/family/node4/node5/066 eq complete) and ../../../suite/family/node4/node5/067 eq complete) and ../../../suite/family/node4/node5/068 eq complete) and ../../../suite/family/node4/node5/069 eq complete) and ../../../suite/family/node4/node5/070 eq complete) and ../../../suite/family/node4/node5/071 eq complete) and ../../../suite/family/node4/node5/072 eq complete) and ../../../suite/family/node4/node5/073 eq complete) and ../../../suite/family/node4/node5/074 eq complete) and ../../../suite/family/node4/node5/075 eq complete) and ../../../suite/family/node4/node5/076 eq complete) and ../../../suite/family/node4/node5/077 eq complete) and ../../../suite/family/node4/node5/078 eq complete) and ../../../suite/family/node4/node5/079 eq complete) and ../../../suite/family/node4/node5/080 eq complete) and ../../../suite/family/node4/node5/081 eq complete) and ../../../suite/family/node4/node5/082 eq complete) and ../../../suite/family/node4/node5/083 eq complete) and ../../../suite/family/node4/node5/084 eq complete) and ../../../suite/family/node4/node5/085 eq complete) and ../../../suite/family/node4/node5/086 eq complete) and ../../../suite/family/node4/node5/087 eq complete) and ../../../suite/family/node4/node5/088 eq complete) and ../../../suite/family/node4/node5/089 eq complete) and ../../../suite/family/node4/node5/090 eq complete) and ../../../suite/family/node4/node5/091 eq complete) and ../../../suite/family/node4/node5/092 eq complete) and ../../../suite/family/node4/node5/093 eq complete) and ../../../suite/family/node4/node5/094 eq complete) and ../../../suite/family/node4/node5/095 eq complete) and ../../../suite/family/node4/node5/096 eq complete) and ../../../suite/family/node4/node5/097 eq complete) and ../../../suite/family/node4/node5/098 eq complete) and ../../../suite/family/node4/node5/099 eq complete) and ../../../suite/family/node4/node5/100 eq complete) and ../../../suite/family/node4/node5/101 eq complete) and ../../../suite/family/node4/node5/102 eq complete) and ../../../suite/family/node4/node5/103 eq complete) and ../../../suite/family/node4/node5/104 eq complete) and ../../../suite/family/node4/node5/105 eq complete) and ../../../suite/family/node4/node5/106 eq complete) and ../../../suite/family/node4/node5/107 eq complete) and ../../../suite/family/node4/node5/108 eq complete) and ../../../suite/family/node4/node5/109 eq complete) and ../../../suite/family/node4/node5/110 eq complete) and ../../../suite/family/node4/node5/111 eq complete) and ../../../suite/family/node4/node5/112 eq complete) and ../../../suite/family/node4/node5/113 eq complete) and ../../../suite/family/node4/node5/114 eq complete) and ../../../suite/family/node4/node5/115 eq complete) and ../../../suite/family/node4/node5/116 eq complete) and ../../../suite/family/node4/node5/117 eq complete) and ../../../suite/family/node4/node5/118 eq complete) and ../../../suite/family/node4/node5/119 eq complete) and ../../../suite/family/node4/node5/120 eq complete) and ../../../suite/family/node4/node5/121 eq complete) and ../../../suite/family/node4/node5/122 eq complete) and ../../../suite/family/node4/node5/123 eq complete) and ../../../suite/family/node4/node5/124 eq complete) and ../../../suite/family/node4/node5/125 eq complete) and ../../../suite/family/node4/node5/126 eq complete) and ../../../suite/family/node4/node5/127 eq complete) and ../../../suite/family/node4/node5/128 eq complete) and ../../../suite/family/node4/node5/129 eq complete) and ../../../suite/family/node4/node5/130 eq complete) and ../../../suite/family/node4/node5/131 eq complete) and ../../../suite/family/node4/node5/132 eq complete) and ../../../suite/family/node4/node5/133 eq complete) and ../../../suite/family/node4/node5/134 eq complete) and ../../../suite/family/node4/node5/135 eq complete) and ../../../suite/family/node4/node5/136 eq complete) and ../../../suite/family/node4/node5/137 eq complete) and ../../../suite/family/node4/node5/138 eq complete) and ../../../suite/family/node4/node5/139 eq complete) and ../../../suite/family/node4/node5/140 eq complete) and ../../../suite/family/node4/node5/141 eq complete) and ../../../suite/family/node4/node5/142 eq complete) and ../../../suite/family/node4/node5/143 eq complete) and ../../../suite/family/node4/node5/144 eq complete) and ../../../suite/family/node4/node5/145 eq complete) and ../../../suite/family/node4/node5/146 eq complete) and ../../../suite/family/node4/node5/147 eq complete) and ../../../suite/family/node4/node5/148 eq complete) and ../../../suite/family/node4/node5/149 eq complete) and ../../../suite/family/node4/node5/150 eq complete) and ../../../suite/family/node4/node5/151 eq complete) and ../../../suite/family/node4/node5/152 eq complete) and ../../../suite/family/node4/node5/153 eq complete) and ../../../suite/family/node4/node5/154 eq complete) and ../../../suite/family/node4/node5/155 eq complete) and ../../../suite/family/node4/node5/156 eq complete) and ../../../suite/family/node4/node5/157 eq complete) and ../../../suite/family/node4/node5/158 eq complete) and ../../../suite/family/node4/node5/159 eq complete) and ../../../suite/family/node4/node5/160 eq complete) and ../../../suite/family/node4/node5/161 eq complete) and ../../../suite/family/node4/node5/162 eq complete) and ../../../suite/family/node4/node5/163 eq complete) and ../../../suite/family/node4/node5/164 eq complete) and ../../../suite/family/node4/node5/165 eq complete) and ../../../suite/family/node4/node5/166 eq complete) and ../../../suite/family/node4/node5/167 eq complete) and ../../../suite/family/node4/node5/168 eq complete) and ../../../suite/family/node4/node5/169 eq complete) and ../../../suite/family/node4/node5/170 eq complete) and ../../../suite/family/node4/node5/171 eq complete) and ../../../suite/family/node4/node5/172 eq complete) and ../../../suite/family/node4/node5/173 eq complete) and ../../../suite/family/node4/node5/174 eq complete) and ../../../suite/family/node4/node5/175 eq complete) and ../../../suite/family/node4/node5/176 eq complete) and ../../../suite/family/node4/node5/177 eq complete) and ../../../suite/family/node4/node5/178 eq complete) and ../../../suite/family/node4/node5/179 eq complete) and ../../../suite/family/node4/node5/180 eq complete) and ../../../suite/family/node4/node5/181 eq complete) and ../../../suite/family/node4/node5/182 eq complete) and ../../../suite/family/node4/node5/183 eq complete) and ../../../suite/family/node4/node5/184 eq complete) and ../../../suite/family/node4/node5/185 eq complete) and ../../../suite/family/node4/node5/186 eq complete) and ../../../suite/family/node4/node5/187 eq complete) and ../../../suite/family/node4/node5/188 eq complete) and ../../../suite/family/node4/node5/189 eq complete) and ../../../suite/family/node4/node5/190 eq complete)))",
+      "expected": "((../../../suite/family:attrib1 > ../../../task:attrib1) or ((../../../suite/family:attrib1 == ../../../task:attrib1) and ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((../../../suite/family/node4/node5/001 == complete) and (../../../suite/family/node4/node5/002 == complete)) and (../../../suite/family/node4/node5/003 == complete)) and (../../../suite/family/node4/node5/004 == complete)) and (../../../suite/family/node4/node5/005 == complete)) and (../../../suite/family/node4/node5/006 == complete)) and (../../../suite/family/node4/node5/007 == complete)) and (../../../suite/family/node4/node5/008 == complete)) and (../../../suite/family/node4/node5/009 == complete)) and (../../../suite/family/node4/node5/010 == complete)) and (../../../suite/family/node4/node5/011 == complete)) and (../../../suite/family/node4/node5/012 == complete)) and (../../../suite/family/node4/node5/013 == complete)) and (../../../suite/family/node4/node5/014 == complete)) and (../../../suite/family/node4/node5/015 == complete)) and (../../../suite/family/node4/node5/016 == complete)) and (../../../suite/family/node4/node5/017 == complete)) and (../../../suite/family/node4/node5/018 == complete)) and (../../../suite/family/node4/node5/019 == complete)) and (../../../suite/family/node4/node5/020 == complete)) and (../../../suite/family/node4/node5/021 == complete)) and (../../../suite/family/node4/node5/022 == complete)) and (../../../suite/family/node4/node5/023 == complete)) and (../../../suite/family/node4/node5/024 == complete)) and (../../../suite/family/node4/node5/025 == complete)) and (../../../suite/family/node4/node5/026 == complete)) and (../../../suite/family/node4/node5/027 == complete)) and (../../../suite/family/node4/node5/028 == complete)) and (../../../suite/family/node4/node5/029 == complete)) and (../../../suite/family/node4/node5/030 == complete)) and (../../../suite/family/node4/node5/031 == complete)) and (../../../suite/family/node4/node5/032 == complete)) and (../../../suite/family/node4/node5/033 == complete)) and (../../../suite/family/node4/node5/034 == complete)) and (../../../suite/family/node4/node5/035 == complete)) and (../../../suite/family/node4/node5/036 == complete)) and (../../../suite/family/node4/node5/037 == complete)) and (../../../suite/family/node4/node5/038 == complete)) and (../../../suite/family/node4/node5/039 == complete)) and (../../../suite/family/node4/node5/040 == complete)) and (../../../suite/family/node4/node5/041 == complete)) and (../../../suite/family/node4/node5/042 == complete)) and (../../../suite/family/node4/node5/043 == complete)) and (../../../suite/family/node4/node5/044 == complete)) and (../../../suite/family/node4/node5/045 == complete)) and (../../../suite/family/node4/node5/046 == complete)) and (../../../suite/family/node4/node5/047 == complete)) and (../../../suite/family/node4/node5/048 == complete)) and (../../../suite/family/node4/node5/049 == complete)) and (../../../suite/family/node4/node5/050 == complete)) and (../../../suite/family/node4/node5/051 == complete)) and (../../../suite/family/node4/node5/052 == complete)) and (../../../suite/family/node4/node5/053 == complete)) and (../../../suite/family/node4/node5/054 == complete)) and (../../../suite/family/node4/node5/055 == complete)) and (../../../suite/family/node4/node5/056 == complete)) and (../../../suite/family/node4/node5/057 == complete)) and (../../../suite/family/node4/node5/058 == complete)) and (../../../suite/family/node4/node5/059 == complete)) and (../../../suite/family/node4/node5/060 == complete)) and (../../../suite/family/node4/node5/061 == complete)) and (../../../suite/family/node4/node5/062 == complete)) and (../../../suite/family/node4/node5/063 == complete)) and (../../../suite/family/node4/node5/064 == complete)) and (../../../suite/family/node4/node5/065 == complete)) and (../../../suite/family/node4/node5/066 == complete)) and (../../../suite/family/node4/node5/067 == complete)) and (../../../suite/family/node4/node5/068 == complete)) and (../../../suite/family/node4/node5/069 == complete)) and (../../../suite/family/node4/node5/070 == complete)) and (../../../suite/family/node4/node5/071 == complete)) and (../../../suite/family/node4/node5/072 == complete)) and (../../../suite/family/node4/node5/073 == complete)) and (../../../suite/family/node4/node5/074 == complete)) and (../../../suite/family/node4/node5/075 == complete)) and (../../../suite/family/node4/node5/076 == complete)) and (../../../suite/family/node4/node5/077 == complete)) and (../../../suite/family/node4/node5/078 == complete)) and (../../../suite/family/node4/node5/079 == complete)) and (../../../suite/family/node4/node5/080 == complete)) and (../../../suite/family/node4/node5/081 == complete)) and (../../../suite/family/node4/node5/082 == complete)) and (../../../suite/family/node4/node5/083 == complete)) and (../../../suite/family/node4/node5/084 == complete)) and (../../../suite/family/node4/node5/085 == complete)) and (../../../suite/family/node4/node5/086 == complete)) and (../../../suite/family/node4/node5/087 == complete)) and (../../../suite/family/node4/node5/088 == complete)) and (../../../suite/family/node4/node5/089 == complete)) and (../../../suite/family/node4/node5/090 == complete)) and (../../../suite/family/node4/node5/091 == complete)) and (../../../suite/family/node4/node5/092 == complete)) and (../../../suite/family/node4/node5/093 == complete)) and (../../../suite/family/node4/node5/094 == complete)) and (../../../suite/family/node4/node5/095 == complete)) and (../../../suite/family/node4/node5/096 == complete)) and (../../../suite/family/node4/node5/097 == complete)) and (../../../suite/family/node4/node5/098 == complete)) and (../../../suite/family/node4/node5/099 == complete)) and (../../../suite/family/node4/node5/100 == complete)) and (../../../suite/family/node4/node5/101 == complete)) and (../../../suite/family/node4/node5/102 == complete)) and (../../../suite/family/node4/node5/103 == complete)) and (../../../suite/family/node4/node5/104 == complete)) and (../../../suite/family/node4/node5/105 == complete)) and (../../../suite/family/node4/node5/106 == complete)) and (../../../suite/family/node4/node5/107 == complete)) and (../../../suite/family/node4/node5/108 == complete)) and (../../../suite/family/node4/node5/109 == complete)) and (../../../suite/family/node4/node5/110 == complete)) and (../../../suite/family/node4/node5/111 == complete)) and (../../../suite/family/node4/node5/112 == complete)) and (../../../suite/family/node4/node5/113 == complete)) and (../../../suite/family/node4/node5/114 == complete)) and (../../../suite/family/node4/node5/115 == complete)) and (../../../suite/family/node4/node5/116 == complete)) and (../../../suite/family/node4/node5/117 == complete)) and (../../../suite/family/node4/node5/118 == complete)) and (../../../suite/family/node4/node5/119 == complete)) and (../../../suite/family/node4/node5/120 == complete)) and (../../../suite/family/node4/node5/121 == complete)) and (../../../suite/family/node4/node5/122 == complete)) and (../../../suite/family/node4/node5/123 == complete)) and (../../../suite/family/node4/node5/124 == complete)) and (../../../suite/family/node4/node5/125 == complete)) and (../../../suite/family/node4/node5/126 == complete)) and (../../../suite/family/node4/node5/127 == complete)) and (../../../suite/family/node4/node5/128 == complete)) and (../../../suite/family/node4/node5/129 == complete)) and (../../../suite/family/node4/node5/130 == complete)) and (../../../suite/family/node4/node5/131 == complete)) and (../../../suite/family/node4/node5/132 == complete)) and (../../../suite/family/node4/node5/133 == complete)) and (../../../suite/family/node4/node5/134 == complete)) and (../../../suite/family/node4/node5/135 == complete)) and (../../../suite/family/node4/node5/136 == complete)) and (../../../suite/family/node4/node5/137 == complete)) and (../../../suite/family/node4/node5/138 == complete)) and (../../../suite/family/node4/node5/139 == complete)) and (../../../suite/family/node4/node5/140 == complete)) and (../../../suite/family/node4/node5/141 == complete)) and (../../../suite/family/node4/node5/142 == complete)) and (../../../suite/family/node4/node5/143 == complete)) and (../../../suite/family/node4/node5/144 == complete)) and (../../../suite/family/node4/node5/145 == complete)) and (../../../suite/family/node4/node5/146 == complete)) and (../../../suite/family/node4/node5/147 == complete)) and (../../../suite/family/node4/node5/148 == complete)) and (../../../suite/family/node4/node5/149 == complete)) and (../../../suite/family/node4/node5/150 == complete)) and (../../../suite/family/node4/node5/151 == complete)) and (../../../suite/family/node4/node5/152 == complete)) and (../../../suite/family/node4/node5/153 == complete)) and (../../../suite/family/node4/node5/154 == complete)) and (../../../suite/family/node4/node5/155 == complete)) and (../../../suite/family/node4/node5/156 == complete)) and (../../../suite/family/node4/node5/157 == complete)) and (../../../suite/family/node4/node5/158 == complete)) and (../../../suite/family/node4/node5/159 == complete)) and (../../../suite/family/node4/node5/160 == complete)) and (../../../suite/family/node4/node5/161 == complete)) and (../../../suite/family/node4/node5/162 == complete)) and (../../../suite/family/node4/node5/163 == complete)) and (../../../suite/family/node4/node5/164 == complete)) and (../../../suite/family/node4/node5/165 == complete)) and (../../../suite/family/node4/node5/166 == complete)) and (../../../suite/family/node4/node5/167 == complete)) and (../../../suite/family/node4/node5/168 == complete)) and (../../../suite/family/node4/node5/169 == complete)) and (../../../suite/family/node4/node5/170 == complete)) and (../../../suite/family/node4/node5/171 == complete)) and (../../../suite/family/node4/node5/172 == complete)) and (../../../suite/family/node4/node5/173 == complete)) and (../../../suite/family/node4/node5/174 == complete)) and (../../../suite/family/node4/node5/175 == complete)) and (../../../suite/family/node4/node5/176 == complete)) and (../../../suite/family/node4/node5/177 == complete)) and (../../../suite/family/node4/node5/178 == complete)) and (../../../suite/family/node4/node5/179 == complete)) and (../../../suite/family/node4/node5/180 == complete)) and (../../../suite/family/node4/node5/181 == complete)) and (../../../suite/family/node4/node5/182 == complete)) and (../../../suite/family/node4/node5/183 == complete)) and (../../../suite/family/node4/node5/184 == complete)) and (../../../suite/family/node4/node5/185 == complete)) and (../../../suite/family/node4/node5/186 == complete)) and (../../../suite/family/node4/node5/187 == complete)) and (../../../suite/family/node4/node5/188 == complete)) and (../../../suite/family/node4/node5/189 == complete)) and (../../../suite/family/node4/node5/190 == complete))))"
+    },
+    {
+      "expression": "(((../suite:attrib1 >= ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1-1) and ../suite/task == complete)) and node4 == complete)",
+      "expected": "(((../suite:attrib1 >= ../family:attrib1) or ((../suite:attrib1 == (../family:attrib1 - 1)) and (../suite/task == complete))) and (node4 == complete))"
+    },
+    {
+      "expression": "(((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and ../suite/task == complete)) and node4 == complete)",
+      "expected": "(((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and (../suite/task == complete))) and (node4 == complete))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 >= ./task:attrib1 AND ./task:attrib1 le (../node4/task:attrib1 + /node5/node6:attrib2))",
+      "expected": "((/suite/family:attrib1 >= ./task:attrib1) and (./task:attrib1 <= (../node4/task:attrib1 + /node5/node6:attrib2)))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 > ./task:attrib1 AND ./task:attrib1 le (../node4/task:attrib1 + /node5/node6:attrib2))",
+      "expected": "((/suite/family:attrib1 > ./task:attrib1) and (./task:attrib1 <= (../node4/task:attrib1 + /node5/node6:attrib2)))"
+    },
+    {
+      "expression": "(((../../suite:attrib1 / 100) lt (/family/task:attrib2 / 100)) and ((../../suite:attrib1 / 100) lt (/family/task:attrib2 / 100)))",
+      "expected": "(((../../suite:attrib1 / 100) < (/family/task:attrib2 / 100)) and ((../../suite:attrib1 / 100) < (/family/task:attrib2 / 100)))"
+    },
+    {
+      "expression": "((cal::date_to_julian(../../suite:attrib1) + 100) lt (:attrib2))",
+      "expected": "((date_to_julian(arg:0) = 0 + 100) < :attrib2)"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5:attrib1 ge 20250527) or (/suite/family/task/node4/node5 eq complete))",
+      "expected": "((/suite/family/task/node4/node5:attrib1 >= 20250527) or (/suite/family/task/node4/node5 == complete))"
+    },
+    {
+      "expression": "(((cal::date_to_julian(../../suite:attrib1) + 5) le cal::date_to_julian(/family/task:attrib2)) and ((cal::date_to_julian(../../suite:attrib1) + 5) le cal::date_to_julian(/family/node4:attrib2)))",
+      "expected": "(((date_to_julian(arg:0) = 0 + 5) <= date_to_julian(arg:0) = 0) and ((date_to_julian(arg:0) = 0 + 5) <= date_to_julian(arg:0) = 0))"
+    },
+    {
+      "expression": "(((cal::date_to_julian(../../suite:attrib1) + 5) le cal::date_to_julian(/family/task:attrib2)))",
+      "expected": "((date_to_julian(arg:0) = 0 + 5) <= date_to_julian(arg:0) = 0)"
+    },
+    {
+      "expression": "(((cal::date_to_julian(../../suite:attrib1) + 5) lt cal::date_to_julian(/family/task:attrib2)) and ((cal::date_to_julian(../../suite:attrib1) + 5) lt cal::date_to_julian(/family/node4:attrib2)))",
+      "expected": "(((date_to_julian(arg:0) = 0 + 5) < date_to_julian(arg:0) = 0) and ((date_to_julian(arg:0) = 0 + 5) < date_to_julian(arg:0) = 0))"
+    },
+    {
+      "expression": "(((suite:attrib1 gt family:attrib1 or (suite:attrib1 eq family:attrib1 and suite/task eq complete)) or suite eq complete))",
+      "expected": "(((suite:attrib1 > family:attrib1) or ((suite:attrib1 == family:attrib1) and (suite/task == complete))) or (suite == complete))"
+    },
+    {
+      "expression": "(((../../suite:attrib1 / 100) lt (/family/task:attrib2 / 100)))",
+      "expected": "((../../suite:attrib1 / 100) < (/family/task:attrib2 / 100))"
+    },
+    {
+      "expression": "((/suite/family/task/node4/node5 eq complete and /suite/family/task/node4/node5:attrib1 eq :attrib1) or (/suite/family/task/node4/node5:attrib1 gt :attrib1))",
+      "expected": "(((/suite/family/task/node4/node5 == complete) and (/suite/family/task/node4/node5:attrib1 == :attrib1)) or (/suite/family/task/node4/node5:attrib1 > :attrib1))"
+    },
+    {
+      "expression": "((suite eq complete and family eq complete) and ../task:attrib1 ge ../node4:attrib1)",
+      "expected": "(((suite == complete) and (family == complete)) and (../task:attrib1 >= ../node4:attrib1))"
+    },
+    {
+      "expression": "((../../../../../../suite:attrib1 / 100) % 100 eq 2 and ((../../../../../../suite:attrib1 / 10000) % 4 ne 0 or (../../../../../../suite:attrib1 / 10000) % 400 eq 0))",
+      "expected": "((((../../../../../../suite:attrib1 / 100) % 100) == 2) and ((((../../../../../../suite:attrib1 / 10000) % 4) != 0) or (((../../../../../../suite:attrib1 / 10000) % 400) == 0)))"
+    },
+    {
+      "expression": "((../suite:attrib1 le ../family:attrib1 or (../suite:attrib1 eq ../family:attrib1 + 1 and ../family/task eq complete)) or ../family eq complete)",
+      "expected": "(((../suite:attrib1 <= ../family:attrib1) or ((../suite:attrib1 == (../family:attrib1 + 1)) and (../family/task == complete))) or (../family == complete))"
+    },
+    {
+      "expression": "(../../../suite:attrib1 gt ../../../family:attrib1 or (../../../suite:attrib1 eq ../../../family:attrib1 and (../../../suite/task:attrib2 gt ../../task:attrib2 or (../../../suite/task:attrib2 eq ../../task:attrib2 and ((../../../suite/task/node4 eq complete and ../../../suite/task/node5 eq complete) and ../../../suite/task/node6 eq complete)))))",
+      "expected": "((../../../suite:attrib1 > ../../../family:attrib1) or ((../../../suite:attrib1 == ../../../family:attrib1) and ((../../../suite/task:attrib2 > ../../task:attrib2) or ((../../../suite/task:attrib2 == ../../task:attrib2) and (((../../../suite/task/node4 == complete) and (../../../suite/task/node5 == complete)) and (../../../suite/task/node6 == complete))))))"
+    },
+    {
+      "expression": "((../suite:attrib1 gt ../family:attrib1 or (../suite:attrib1 eq ../family:attrib1 and ../suite/task:attrib2 ge task:attrib2)) and ../node4/task:attrib2 ge task:attrib2)",
+      "expected": "(((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and (../suite/task:attrib2 >= task:attrib2))) and (../node4/task:attrib2 >= task:attrib2))"
+    },
+    {
+      "expression": "(((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and node6 eq complete) and node7 eq complete) and node8 eq complete) and node9 eq complete) and node10 eq complete) and node11 eq complete) and node12 eq complete) and node13 eq complete) and node14 eq complete) and node15 eq complete) and node16 eq complete) and node17 eq complete) and node18 eq complete) and node19 eq complete) and node20 eq complete) and node21 eq complete) and node22 eq complete) and node23 eq complete) and node24 eq complete) and node25 eq complete) and node26 eq complete) and node27 eq complete) and node28 eq complete) and node29 eq complete) and node30 eq complete) and node31 eq complete) and node32 eq complete) and node33 eq complete) and node34 eq complete) and node35 eq complete) and node36 eq complete) and node37 eq complete) and node38 eq complete) and node39 eq complete) and node40 eq complete) and node41 eq complete) and node42 eq complete) and node43 eq complete) and node44 eq complete) and node45 eq complete) and node46 eq complete) and node47 eq complete) and node48 eq complete) and node49 eq complete) and node50 eq complete) and node51 eq complete) and node52 eq complete) and node53 eq complete) and node54 eq complete) and node55 eq complete) and node56 eq complete) and node57 eq complete) and node58 eq complete) and node59 eq complete) and node60 eq complete) and node61 eq complete) and node62 eq complete) and node63 eq complete) and node64 eq complete) and node65 eq complete) and node66 eq complete) and node67 eq complete) and node68 eq complete) and node69 eq complete) and node70 eq complete) and node71 eq complete) and node72 eq complete) and node73 eq complete) and node74 eq complete) and node75 eq complete) and node76 eq complete) and node77 eq complete) and node78 eq complete) and node79 eq complete) and node80 eq complete) and node81 eq complete) and node82 eq complete) and node83 eq complete) and node84 eq complete) and node85 eq complete) and node86 eq complete) and node87 eq complete) and node88 eq complete) and node89 eq complete) and node90 eq complete) and node91 eq complete) and node92 eq complete) and node93 eq complete) and node94 eq complete) and node95 eq complete) and node96 eq complete) and node97 eq complete) and node98 eq complete) and node99 eq complete) and node100 eq complete)",
+      "expected": "((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)) and (node17 == complete)) and (node18 == complete)) and (node19 == complete)) and (node20 == complete)) and (node21 == complete)) and (node22 == complete)) and (node23 == complete)) and (node24 == complete)) and (node25 == complete)) and (node26 == complete)) and (node27 == complete)) and (node28 == complete)) and (node29 == complete)) and (node30 == complete)) and (node31 == complete)) and (node32 == complete)) and (node33 == complete)) and (node34 == complete)) and (node35 == complete)) and (node36 == complete)) and (node37 == complete)) and (node38 == complete)) and (node39 == complete)) and (node40 == complete)) and (node41 == complete)) and (node42 == complete)) and (node43 == complete)) and (node44 == complete)) and (node45 == complete)) and (node46 == complete)) and (node47 == complete)) and (node48 == complete)) and (node49 == complete)) and (node50 == complete)) and (node51 == complete)) and (node52 == complete)) and (node53 == complete)) and (node54 == complete)) and (node55 == complete)) and (node56 == complete)) and (node57 == complete)) and (node58 == complete)) and (node59 == complete)) and (node60 == complete)) and (node61 == complete)) and (node62 == complete)) and (node63 == complete)) and (node64 == complete)) and (node65 == complete)) and (node66 == complete)) and (node67 == complete)) and (node68 == complete)) and (node69 == complete)) and (node70 == complete)) and (node71 == complete)) and (node72 == complete)) and (node73 == complete)) and (node74 == complete)) and (node75 == complete)) and (node76 == complete)) and (node77 == complete)) and (node78 == complete)) and (node79 == complete)) and (node80 == complete)) and (node81 == complete)) and (node82 == complete)) and (node83 == complete)) and (node84 == complete)) and (node85 == complete)) and (node86 == complete)) and (node87 == complete)) and (node88 == complete)) and (node89 == complete)) and (node90 == complete)) and (node91 == complete)) and (node92 == complete)) and (node93 == complete)) and (node94 == complete)) and (node95 == complete)) and (node96 == complete)) and (node97 == complete)) and (node98 == complete)) and (node99 == complete)) and (node100 == complete))"
+    },
+    {
+      "expression": "(:attrib1 lt /suite/family/task/node4/node5:attrib1-10 or (/suite/family/task eq complete and :attrib1 eq 20250218))",
+      "expected": "((:attrib1 < (/suite/family/task/node4/node5:attrib1 - 10)) or ((/suite/family/task == complete) and (:attrib1 == 20250218)))"
+    },
+    {
+      "expression": "((../suite:attrib1 gt ../family:attrib1 or (../suite:attrib1 eq ../family:attrib1 and ../suite/task:attrib2 ge task:attrib2)) and (../node4/task:attrib2 gt task:attrib2 or (../node4/task:attrib2 eq task:attrib2 and ../node4 eq complete)))",
+      "expected": "(((../suite:attrib1 > ../family:attrib1) or ((../suite:attrib1 == ../family:attrib1) and (../suite/task:attrib2 >= task:attrib2))) and ((../node4/task:attrib2 > task:attrib2) or ((../node4/task:attrib2 == task:attrib2) and (../node4 == complete))))"
+    },
+    {
+      "expression": "(suite:attrib1 le family:attrib1 and suite/task:attrib2 le family/task:attrib2)",
+      "expected": "((suite:attrib1 <= family:attrib1) and (suite/task:attrib2 <= family/task:attrib2))"
+    },
+    {
+      "expression": "(((((((((((((((((((suite eq complete and family eq complete) and task eq complete) and node4 eq complete) and node5 eq complete) and node6 eq complete) and node7 eq complete) and node8 eq complete) and node9 eq complete) and node10 eq complete) and node11 eq complete) and node12 eq complete) and node13 eq complete) and node14 eq complete) and node15 eq complete) and node16 eq complete) and node17 eq complete) and node18 eq complete) and node19 eq complete) and node20 eq complete)",
+      "expected": "((((((((((((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete)) and (node11 == complete)) and (node12 == complete)) and (node13 == complete)) and (node14 == complete)) and (node15 == complete)) and (node16 == complete)) and (node17 == complete)) and (node18 == complete)) and (node19 == complete)) and (node20 == complete))"
+    },
+    {
+      "expression": "(../../suite:attrib1 gt ../../family:attrib1 or (../../suite:attrib1 eq ../../family:attrib1 and ((((((((((../../suite/task eq complete and ../../suite/node4 eq complete) and ../../suite/node5 eq complete) and ../../suite/node6 eq complete) and ../../suite/node7 eq complete) and ../../suite/node8 eq complete) and ../../suite/node9 eq complete) and ../../suite/node10 eq complete) and ../../suite/node11 eq complete) and ../../suite/node12 eq complete) and ../../suite/node13 eq complete)))",
+      "expected": "((../../suite:attrib1 > ../../family:attrib1) or ((../../suite:attrib1 == ../../family:attrib1) and (((((((((((../../suite/task == complete) and (../../suite/node4 == complete)) and (../../suite/node5 == complete)) and (../../suite/node6 == complete)) and (../../suite/node7 == complete)) and (../../suite/node8 == complete)) and (../../suite/node9 == complete)) and (../../suite/node10 == complete)) and (../../suite/node11 == complete)) and (../../suite/node12 == complete)) and (../../suite/node13 == complete))))"
+    },
+    {
+      "expression": "(suite eq complete and (../../family:attrib1 gt ../../task:attrib1 or (../../family:attrib1 eq ../../task:attrib1 and ((((((((((../../family/node4 eq complete and ../../family/node5 eq complete) and ../../family/node6 eq complete) and ../../family/node7 eq complete) and ../../family/node8 eq complete) and ../../family/node9 eq complete) and ../../family/node10 eq complete) and ../../family/node11 eq complete) and ../../family/node12 eq complete) and ../../family/node13 eq complete) and ../../family/node14 eq complete))))",
+      "expected": "((suite == complete) and ((../../family:attrib1 > ../../task:attrib1) or ((../../family:attrib1 == ../../task:attrib1) and (((((((((((../../family/node4 == complete) and (../../family/node5 == complete)) and (../../family/node6 == complete)) and (../../family/node7 == complete)) and (../../family/node8 == complete)) and (../../family/node9 == complete)) and (../../family/node10 == complete)) and (../../family/node11 == complete)) and (../../family/node12 == complete)) and (../../family/node13 == complete)) and (../../family/node14 == complete)))))"
+    },
+    {
+      "expression": "((suite eq complete and family:attrib1 le task:attrib1 + 4) and (/node4/node5/node6/task/node7/00:attrib1 gt family:attrib1) and (/node8/task/00/node6/node9 eq complete))",
+      "expected": "(((suite == complete) and (family:attrib1 <= (task:attrib1 + 4))) and ((/node4/node5/node6/task/node7/00:attrib1 > family:attrib1) and (/node8/task/00/node6/node9 == complete)))"
+    },
+    {
+      "expression": "(../suite eq complete and ./04 eq complete and (../family:attrib1 gt ../task:attrib1 or (../family:attrib1 eq ../task:attrib1 and ../family/05 eq complete)))",
+      "expected": "(((../suite == complete) and (./04 == complete)) and ((../family:attrib1 > ../task:attrib1) or ((../family:attrib1 == ../task:attrib1) and (../family/05 == complete))))"
+    },
+    {
+      "expression": "(suite/family/task/node4 == complete or ../node5:attrib1 == 19000101)",
+      "expected": "((suite/family/task/node4 == complete) or (../node5:attrib1 == 19000101))"
+    },
+    {
+      "expression": "(./suite == complete or family == complete or ../task == complete or ../../node4 == complete or ../../../node5 == aborted)",
+      "expected": "((./suite == complete) or ((family == complete) or ((../task == complete) or ((../../node4 == complete) or (../../../node5 == aborted)))))"
+    },
+    {
+      "expression": "(../../../../../suite == complete or  ../../../../../suite/family<flag>late)",
+      "expected": "((../../../../../suite == complete) or ../../../../../suite/family<flag>late)"
+    },
+    {
+      "expression": "(:attrib1 == 5 and :attrib2 == 0 and :attrib3 == 2)",
+      "expected": "(((:attrib1 == 5) and (:attrib2 == 0)) and (:attrib3 == 2))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 == set and /suite/family:attrib2 >= 6)",
+      "expected": "((/suite/family:attrib1 == set) and (/suite/family:attrib2 >= 6))"
+    },
+    {
+      "expression": "(/suite/family:attrib1 >= 20170801 and /suite/family:attrib2 == 0)",
+      "expected": "((/suite/family:attrib1 >= 20170801) and (/suite/family:attrib2 == 0))"
+    },
+    {
+      "expression": "(/suite/family/task/node4/node5:attrib1 - 1 == 19991229)",
+      "expected": "((/suite/family/task/node4/node5:attrib1 - 1) == 19991229)"
+    },
+    {
+      "expression": "(/suite/family/task/node4/node5:attrib1 > cal::date_to_julian(/suite/node6:attrib2))",
+      "expected": "(/suite/family/task/node4/node5:attrib1 > date_to_julian(arg:0) = 0)"
+    },
+    {
+      "expression": "(/suite:attrib1 < 5)",
+      "expected": "(/suite:attrib1 < 5)"
+    },
+    {
+      "expression": "(/suite/family<flag>late)",
+      "expected": "/suite/family<flag>late"
+    },
+    {
+      "expression": "(../suite/family/task:attrib1 > ../node4:attrib1 and ../node4:attrib1 <= ../node5:attrib1 + 2 and node6 == complete)",
+      "expected": "(((../suite/family/task:attrib1 > ../node4:attrib1) and (../node4:attrib1 <= (../node5:attrib1 + 2))) and (node6 == complete))"
+    },
+    {
+      "expression": "(../../suite:attrib1 > ../family:attrib2 and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete)",
+      "expected": "(((((((((../../suite:attrib1 > ../family:attrib2) and (task == complete)) and (node4 == complete)) and (node5 == complete)) and (node6 == complete)) and (node7 == complete)) and (node8 == complete)) and (node9 == complete)) and (node10 == complete))"
+    },
+    {
+      "expression": "((((((((((suite  == complete) and (family  == complete)) and (task  == complete)) and (node4  == complete)) and (node5  == complete)) or (node6  == complete)) or (node7  == complete)) or (node8  == complete)) or (node9  == complete)) or (node10  == complete))",
+      "expected": "((((((((((suite == complete) and (family == complete)) and (task == complete)) and (node4 == complete)) and (node5 == complete)) or (node6 == complete)) or (node7 == complete)) or (node8 == complete)) or (node9 == complete)) or (node10 == complete))"
+    },
+    {
+      "expression": "(./suite<flag>archived and ./family<flag>archived)",
+      "expected": "(./suite<flag>archived and ./family<flag>archived)"
+    },
+    {
+      "expression": "(/suite/family/task/node4/node5:attrib1 == set)",
+      "expected": "(/suite/family/task/node4/node5:attrib1 == set)"
+    },
+    {
+      "expression": "(:attrib1le /suite/family/task:attrib2)",
+      "expected": "(:attrib1le / suite/family/task:attrib2)"
+    },
+    {
+      "expression": "(/suite:attrib1gt /suite/family:attrib2 and /suite:attrib3 ge 1600 and ../task ne complete)",
+      "expected": "(../task != complete)"
+    },
+    {
+      "expression": "((/suite/family:attrib1gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 ))",
+      "expected": "((/suite/family:attrib1gt / suite/task:attrib1) or (/suite/family:attrib1 == /suite/task:attrib1))"
+    },
+    {
+      "expression": "((/suite/family:attrib1gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete))",
+      "expected": "((/suite/family:attrib1gt / suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/12/node4/node5 == complete)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete) and /suite/task/node5/12/node6 eq complete)",
+      "expected": "((/suite/family:attrib1gt / suite/task:attrib1) or (((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/12/node4 == complete)) and (/suite/task/node5/12/node6 == complete)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete and /suite/family/12/node5==complete))",
+      "expected": "((/suite/family:attrib1gt / suite/task:attrib1) or (((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/12/node4 == complete)) and (/suite/family/12/node5 == complete)))"
+    },
+    {
+      "expression": "((/suite/family:attrib1gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete) AND (/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node6==complete and /suite/family/12/node6==complete))",
+      "expected": "((/suite/family:attrib1gt / suite/task:attrib1) or (((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/12/node4/node5 == complete)) and ((/suite/family:attrib1 > /suite/task:attrib1) or (((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/12/node6 == complete)) and (/suite/family/12/node6 == complete)))))"
+    },
+    {
+      "expression": "(((/suite/family:attrib1gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/task/node4/node5/node6==complete)) and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/node5/node7/node8==complete)))",
+      "expected": "(((/suite/family:attrib1gt / suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/task/node4/node5/node6 == complete))) and ((/suite/family:attrib1 > /suite/task:attrib1) or ((/suite/family:attrib1 == /suite/task:attrib1) and (/suite/family/node5/node7/node8 == complete))))"
+    },
+    {
+      "expression": "(/suite/family:attrib1gt /suite/task:attrib1 and ./12==complete and ./node4==complete and ./00==complete and ./node5==complete)",
+      "expected": "(./node5 == complete)"
+    },
+    {
+      "expression": "((/suite/family:attrib1lt /task/family:attrib1) or (/suite/family:attrib1==/task/family:attrib1 and /task/family/12==complete))",
+      "expected": "((/suite/family:attrib1lt / task/family:attrib1) or ((/suite/family:attrib1 == /task/family:attrib1) and (/task/family/12 == complete)))"
+    }
+  ],
+  "invalid_expressions": [
+    {
+      "expression": "((:attrib1 == 20230101T000000)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(:attrib1 == 20230101T000000))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": ":attrib1 == 20230101T000000)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(:attrib1 == 20230101T000000) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(:attrib1 == 20230101T000000) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(:attrib1 == 20230101T000000) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(:attrib1 == 20230101T000000) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (:attrib1 == 20230101T000000)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (:attrib1 == 20230101T000000)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(:attrib1 == == 20230101T000000)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(:attrib1 == 20230101T000000) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(:attrib1 == 20230101T000000) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(:attrib1 == 20230101T000000) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "((:attrib1 >= 20230101T000000)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(:attrib1 >= 20230101T000000))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": ":attrib1 >= 20230101T000000)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(:attrib1 >= 20230101T000000) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(:attrib1 >= 20230101T000000) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(:attrib1 >= 20230101T000000) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(:attrib1 >= 20230101T000000) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (:attrib1 >= 20230101T000000)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (:attrib1 >= 20230101T000000)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(:attrib1 >= 20230101T000000) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(:attrib1 >= 20230101T000000) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(:attrib1 >= 20230101T000000) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "((:attrib1 <= 20230101T000000)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(:attrib1 <= 20230101T000000))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": ":attrib1 <= 20230101T000000)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(:attrib1 <= 20230101T000000) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(:attrib1 <= 20230101T000000) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(:attrib1 <= 20230101T000000) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(:attrib1 <= 20230101T000000) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (:attrib1 <= 20230101T000000)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (:attrib1 <= 20230101T000000)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(:attrib1 <= 20230101T000000) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(:attrib1 <= 20230101T000000) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(:attrib1 <= 20230101T000000) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "((:attrib1 + 3 <= 19700101T000000)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(:attrib1 + 3 <= 19700101T000000))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": ":attrib1 + 3 <= 19700101T000000)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(:attrib1 + 3 <= 19700101T000000) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(:attrib1 + 3 <= 19700101T000000) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(:attrib1 + 3 <= 19700101T000000) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(:attrib1 + 3 <= 19700101T000000) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (:attrib1 + 3 <= 19700101T000000)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (:attrib1 + 3 <= 19700101T000000)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(:attrib1 + 3 <= 19700101T000000) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(:attrib1 + 3 <= 19700101T000000) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(:attrib1 + 3 <= 19700101T000000) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "((:attrib1 <= 19700101T000000 + 3)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(:attrib1 <= 19700101T000000 + 3))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": ":attrib1 <= 19700101T000000 + 3)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(:attrib1 <= 19700101T000000 + 3) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(:attrib1 <= 19700101T000000 + 3) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(:attrib1 <= 19700101T000000 + 3) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(:attrib1 <= 19700101T000000 + 3) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (:attrib1 <= 19700101T000000 + 3)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (:attrib1 <= 19700101T000000 + 3)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(:attrib1 <= 19700101T000000 + 3) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(:attrib1 <= 19700101T000000 + 3) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(:attrib1 <= 19700101T000000 + 3) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "((:attrib1 >= 19700101T000000 + 3)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(:attrib1 >= 19700101T000000 + 3))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": ":attrib1 >= 19700101T000000 + 3)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(:attrib1 >= 19700101T000000 + 3) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(:attrib1 >= 19700101T000000 + 3) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(:attrib1 >= 19700101T000000 + 3) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(:attrib1 >= 19700101T000000 + 3) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (:attrib1 >= 19700101T000000 + 3)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (:attrib1 >= 19700101T000000 + 3)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(:attrib1 >= 19700101T000000 + 3) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(:attrib1 >= 19700101T000000 + 3) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(:attrib1 >= 19700101T000000 + 3) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(((:attrib1 + 1) == (19700101T000000 + 1))",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "((:attrib1 + 1) == (19700101T000000 + 1)))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "(:attrib1 + 1) == (19700101T000000 + 1))",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "((:attrib1 + 1) == (19700101T000000 + 1)) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "((:attrib1 + 1) == (19700101T000000 + 1)) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "((:attrib1 + 1) == (19700101T000000 + 1)) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "((:attrib1 + 1) == (19700101T000000 + 1)) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and ((:attrib1 + 1) == (19700101T000000 + 1))",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== ((:attrib1 + 1) == (19700101T000000 + 1))",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "((:attrib1 + 1) == == (19700101T000000 + 1))",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "((:attrib1 + 1) == (19700101T000000 + 1)) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "((:attrib1 + 1) == (19700101T000000 + 1)) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "((:attrib1 + 1) == (19700101T000000 + 1)) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "((20240101T060000 == :attrib1)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(20240101T060000 == :attrib1))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "20240101T060000 == :attrib1)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(20240101T060000 == :attrib1) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(20240101T060000 == :attrib1) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(20240101T060000 == :attrib1) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(20240101T060000 == :attrib1) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (20240101T060000 == :attrib1)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (20240101T060000 == :attrib1)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(20240101T060000 == == :attrib1)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(20240101T060000 == :attrib1) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(20240101T060000 == :attrib1) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(20240101T060000 == :attrib1) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "((:attrib1 == 19700101T123456 and suite == complete)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(:attrib1 == 19700101T123456 and suite == complete))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": ":attrib1 == 19700101T123456 and suite == complete)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(:attrib1 == 19700101T123456 and suite == complete) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(:attrib1 == 19700101T123456 and suite == complete) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(:attrib1 == 19700101T123456 and suite == complete) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(:attrib1 == 19700101T123456 and suite == complete) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (:attrib1 == 19700101T123456 and suite == complete)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (:attrib1 == 19700101T123456 and suite == complete)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(:attrib1 == == 19700101T123456 and suite == complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(:attrib1 == 19700101T123456 and suite == complete) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(:attrib1 == 19700101T123456 and suite == complete) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(:attrib1 == 19700101T123456 and suite == complete) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(:attrib1 == 19700101T123456 and suite < complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(:attrib1 == 19700101T123456and suite == complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "((((suite == complete) and (family == complete)) or (task == complete))",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(((suite == complete) and (family == complete)) or (task == complete)))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "((suite == complete) and (family == complete)) or (task == complete))",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(((suite == complete) and (family == complete)) or (task == complete)) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(((suite == complete) and (family == complete)) or (task == complete)) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(((suite == complete) and (family == complete)) or (task == complete)) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(((suite == complete) and (family == complete)) or (task == complete)) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (((suite == complete) and (family == complete)) or (task == complete))",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (((suite == complete) and (family == complete)) or (task == complete))",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(((suite == == complete) and (family == complete)) or (task == complete))",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(((suite == complete) and (family == complete)) or (task == complete)) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(((suite == complete) and (family == complete)) or (task == complete)) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(((suite == complete) and (family == complete)) or (task == complete)) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(((suite < complete) and (family == complete)) or (task == complete))",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "((1==0)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(1==0))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "1==0)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(1==0) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(1==0) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(1==0) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(1==0) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (1==0)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (1==0)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(1==0) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(1==0) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(1==0) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "((/suite/family/task/node4/00 == queued)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(/suite/family/task/node4/00 == queued))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "/suite/family/task/node4/00 == queued)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(/suite/family/task/node4/00 == queued) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(/suite/family/task/node4/00 == queued) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(/suite/family/task/node4/00 == queued) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(/suite/family/task/node4/00 == queued) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (/suite/family/task/node4/00 == queued)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (/suite/family/task/node4/00 == queued)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(/suite/family/task/node4/00 == == queued)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(/suite/family/task/node4/00 == queued) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(/suite/family/task/node4/00 == queued) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(/suite/family/task/node4/00 == queued) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(/suite/family/task/node4/00 < queued)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "((suite==complete or suite==aborted)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(suite==complete or suite==aborted))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "suite==complete or suite==aborted)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(suite==complete or suite==aborted) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(suite==complete or suite==aborted) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(suite==complete or suite==aborted) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(suite==complete or suite==aborted) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (suite==complete or suite==aborted)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (suite==complete or suite==aborted)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(suite==complete or suite==aborted) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(suite==complete or suite==aborted) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(suite==complete or suite==aborted) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(suite==completeor suite==aborted)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(suite==complete orsuite==aborted)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((suite == complete and family == complete)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(suite == complete and family == complete))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "suite == complete and family == complete)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(suite == complete and family == complete) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(suite == complete and family == complete) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(suite == complete and family == complete) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(suite == complete and family == complete) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (suite == complete and family == complete)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (suite == complete and family == complete)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(suite == == complete and family == complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(suite == complete and family == complete) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(suite == complete and family == complete) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(suite == complete and family == complete) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(suite < complete and family == complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(((suite == complete) and (family == complete))",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "((suite == complete) and (family == complete)))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "(suite == complete) and (family == complete))",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "((suite == complete) and (family == complete)) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "((suite == complete) and (family == complete)) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "((suite == complete) and (family == complete)) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "((suite == complete) and (family == complete)) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and ((suite == complete) and (family == complete))",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== ((suite == complete) and (family == complete))",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "((suite == == complete) and (family == complete))",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "((suite == complete) and (family == complete)) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "((suite == complete) and (family == complete)) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "((suite == complete) and (family == complete)) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "((suite < complete) and (family == complete))",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "((suite == complete and family == complete and task/000/node4 == complete and node5 == complete)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task/000/node4 == complete and node5 == complete))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "suite == complete and family == complete and task/000/node4 == complete and node5 == complete)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task/000/node4 == complete and node5 == complete) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task/000/node4 == complete and node5 == complete) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task/000/node4 == complete and node5 == complete) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task/000/node4 == complete and node5 == complete) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (suite == complete and family == complete and task/000/node4 == complete and node5 == complete)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (suite == complete and family == complete and task/000/node4 == complete and node5 == complete)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(suite == == complete and family == complete and task/000/node4 == complete and node5 == complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task/000/node4 == complete and node5 == complete) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task/000/node4 == complete and node5 == complete) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task/000/node4 == complete and node5 == complete) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(suite < complete and family == complete and task/000/node4 == complete and node5 == complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(suite == completeand family == complete and task/000/node4 == complete and node5 == complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(suite == complete andfamily == complete and task/000/node4 == complete and node5 == complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((/suite/family/task/00/node4:attrib1)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(/suite/family/task/00/node4:attrib1))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "/suite/family/task/00/node4:attrib1)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(/suite/family/task/00/node4:attrib1) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(/suite/family/task/00/node4:attrib1) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(/suite/family/task/00/node4:attrib1) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(/suite/family/task/00/node4:attrib1) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (/suite/family/task/00/node4:attrib1)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (/suite/family/task/00/node4:attrib1)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(/suite/family/task/00/node4:attrib1) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(/suite/family/task/00/node4:attrib1) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(/suite/family/task/00/node4:attrib1) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(((suite eq complete or suite/family:attrib1) and (task eq complete or task/family:attrib1) and (node4==complete or node4:attrib2))",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "((suite eq complete or suite/family:attrib1) and (task eq complete or task/family:attrib1) and (node4==complete or node4:attrib2)))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "(suite eq complete or suite/family:attrib1) and (task eq complete or task/family:attrib1) and (node4==complete or node4:attrib2))",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "((suite eq complete or suite/family:attrib1) and (task eq complete or task/family:attrib1) and (node4==complete or node4:attrib2)) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "((suite eq complete or suite/family:attrib1) and (task eq complete or task/family:attrib1) and (node4==complete or node4:attrib2)) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "((suite eq complete or suite/family:attrib1) and (task eq complete or task/family:attrib1) and (node4==complete or node4:attrib2)) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "((suite eq complete or suite/family:attrib1) and (task eq complete or task/family:attrib1) and (node4==complete or node4:attrib2)) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and ((suite eq complete or suite/family:attrib1) and (task eq complete or task/family:attrib1) and (node4==complete or node4:attrib2))",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== ((suite eq complete or suite/family:attrib1) and (task eq complete or task/family:attrib1) and (node4==complete or node4:attrib2))",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "((suite eq complete or suite/family:attrib1) and (task eq complete or task/family:attrib1) and (node4==complete or node4:attrib2)) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "((suite eq complete or suite/family:attrib1) and (task eq complete or task/family:attrib1) and (node4==complete or node4:attrib2)) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "((suite eq complete or suite/family:attrib1) and (task eq complete or task/family:attrib1) and (node4==complete or node4:attrib2)) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "((suite < complete or suite/family:attrib1) and (task eq complete or task/family:attrib1) and (node4==complete or node4:attrib2))",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "((suiteeq complete or suite/family:attrib1) and (task eq complete or task/family:attrib1) and (node4==complete or node4:attrib2))",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "((suite eqcomplete or suite/family:attrib1) and (task eq complete or task/family:attrib1) and (node4==complete or node4:attrib2))",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(((suite==complete or suite:attrib1) and family==complete)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "((suite==complete or suite:attrib1) and family==complete))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "(suite==complete or suite:attrib1) and family==complete)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "((suite==complete or suite:attrib1) and family==complete) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "((suite==complete or suite:attrib1) and family==complete) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "((suite==complete or suite:attrib1) and family==complete) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "((suite==complete or suite:attrib1) and family==complete) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and ((suite==complete or suite:attrib1) and family==complete)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== ((suite==complete or suite:attrib1) and family==complete)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "((suite==complete or suite:attrib1) and family==complete) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "((suite==complete or suite:attrib1) and family==complete) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "((suite==complete or suite:attrib1) and family==complete) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "((suite==completeor suite:attrib1) and family==complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "((suite==complete orsuite:attrib1) and family==complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(suite == == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(suite < complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(suite == completeand family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(suite == complete andfamily == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and node8 == complete and node9 == complete and node10 == complete and node11 == complete and node12 == complete and node13 == complete and node14 == complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((suite == complete and family == complete and task == complete and node4 eq complete)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 eq complete))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "suite == complete and family == complete and task == complete and node4 eq complete)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 eq complete) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 eq complete) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 eq complete) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 eq complete) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (suite == complete and family == complete and task == complete and node4 eq complete)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (suite == complete and family == complete and task == complete and node4 eq complete)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(suite == == complete and family == complete and task == complete and node4 eq complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 eq complete) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 eq complete) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 eq complete) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(suite < complete and family == complete and task == complete and node4 eq complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(suite == completeand family == complete and task == complete and node4 eq complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(suite == complete andfamily == complete and task == complete and node4 eq complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((./024 eq complete)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(./024 eq complete))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "./024 eq complete)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(./024 eq complete) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(./024 eq complete) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(./024 eq complete) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(./024 eq complete) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (./024 eq complete)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (./024 eq complete)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(./024 eq complete) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(./024 eq complete) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(./024 eq complete) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(./024eq complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(./024 eqcomplete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((suite == complete and family == complete and task == complete)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "suite == complete and family == complete and task == complete)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (suite == complete and family == complete and task == complete)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (suite == complete and family == complete and task == complete)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(suite == == complete and family == complete and task == complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(suite < complete and family == complete and task == complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(suite == completeand family == complete and task == complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(suite == complete andfamily == complete and task == complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((suite == complete and family == complete and task == complete and node4 == complete and node5 == complete)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "suite == complete and family == complete and task == complete and node4 == complete and node5 == complete)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (suite == complete and family == complete and task == complete and node4 == complete and node5 == complete)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (suite == complete and family == complete and task == complete and node4 == complete and node5 == complete)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(suite == == complete and family == complete and task == complete and node4 == complete and node5 == complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and node4 == complete and node5 == complete) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(suite < complete and family == complete and task == complete and node4 == complete and node5 == complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(suite == completeand family == complete and task == complete and node4 == complete and node5 == complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(suite == complete andfamily == complete and task == complete and node4 == complete and node5 == complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((suite eq complete and family eq complete)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(suite eq complete and family eq complete))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "suite eq complete and family eq complete)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(suite eq complete and family eq complete) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(suite eq complete and family eq complete) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(suite eq complete and family eq complete) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(suite eq complete and family eq complete) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (suite eq complete and family eq complete)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (suite eq complete and family eq complete)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(suite eq complete and family eq complete) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(suite eq complete and family eq complete) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(suite eq complete and family eq complete) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(suite < complete and family eq complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(suiteeq complete and family eq complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(suite eqcomplete and family eq complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((../suite == complete and /family/task/00/node4 eq complete and :attrib1 eq 4)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(../suite == complete and /family/task/00/node4 eq complete and :attrib1 eq 4))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "../suite == complete and /family/task/00/node4 eq complete and :attrib1 eq 4)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(../suite == complete and /family/task/00/node4 eq complete and :attrib1 eq 4) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(../suite == complete and /family/task/00/node4 eq complete and :attrib1 eq 4) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(../suite == complete and /family/task/00/node4 eq complete and :attrib1 eq 4) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(../suite == complete and /family/task/00/node4 eq complete and :attrib1 eq 4) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (../suite == complete and /family/task/00/node4 eq complete and :attrib1 eq 4)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (../suite == complete and /family/task/00/node4 eq complete and :attrib1 eq 4)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(../suite == == complete and /family/task/00/node4 eq complete and :attrib1 eq 4)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(../suite == complete and /family/task/00/node4 eq complete and :attrib1 eq 4) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(../suite == complete and /family/task/00/node4 eq complete and :attrib1 eq 4) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(../suite == complete and /family/task/00/node4 eq complete and :attrib1 eq 4) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(../suite < complete and /family/task/00/node4 eq complete and :attrib1 eq 4)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(../suite == completeand /family/task/00/node4 eq complete and :attrib1 eq 4)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(../suite == complete and /family/task/00/node4 eqcomplete and :attrib1 eq 4)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((suite:1 or suite eq complete)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(suite:1 or suite eq complete))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "suite:1 or suite eq complete)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(suite:1 or suite eq complete) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(suite:1 or suite eq complete) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(suite:1 or suite eq complete) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(suite:1 or suite eq complete) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (suite:1 or suite eq complete)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (suite:1 or suite eq complete)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(suite:1 or suite eq complete) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(suite:1 or suite eq complete) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(suite:1 or suite eq complete) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(suite:1 or suite < complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(suite:1or suite eq complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "((suite == complete and family eq complete)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(suite == complete and family eq complete))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "suite == complete and family eq complete)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(suite == complete and family eq complete) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(suite == complete and family eq complete) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(suite == complete and family eq complete) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(suite == complete and family eq complete) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (suite == complete and family eq complete)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (suite == complete and family eq complete)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(suite == == complete and family eq complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(suite == complete and family eq complete) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(suite == complete and family eq complete) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(suite == complete and family eq complete) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(suite == completeand family eq complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(suite == complete andfamily eq complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((/suite/family/task:attrib1 gt :attrib2 or (/suite/family/task:attrib1 eq :attrib2 and (/suite/family/task/node4:attrib3 gt :attrib4 or (/suite/family/task/node4:attrib3 eq :attrib4 and /suite/family/task/node4/node5:attrib5 gt :attrib6))))",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 or (/suite/family/task:attrib1 eq :attrib2 and (/suite/family/task/node4:attrib3 gt :attrib4 or (/suite/family/task/node4:attrib3 eq :attrib4 and /suite/family/task/node4/node5:attrib5 gt :attrib6)))))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "/suite/family/task:attrib1 gt :attrib2 or (/suite/family/task:attrib1 eq :attrib2 and (/suite/family/task/node4:attrib3 gt :attrib4 or (/suite/family/task/node4:attrib3 eq :attrib4 and /suite/family/task/node4/node5:attrib5 gt :attrib6))))",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 or (/suite/family/task:attrib1 eq :attrib2 and (/suite/family/task/node4:attrib3 gt :attrib4 or (/suite/family/task/node4:attrib3 eq :attrib4 and /suite/family/task/node4/node5:attrib5 gt :attrib6)))) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 or (/suite/family/task:attrib1 eq :attrib2 and (/suite/family/task/node4:attrib3 gt :attrib4 or (/suite/family/task/node4:attrib3 eq :attrib4 and /suite/family/task/node4/node5:attrib5 gt :attrib6)))) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 or (/suite/family/task:attrib1 eq :attrib2 and (/suite/family/task/node4:attrib3 gt :attrib4 or (/suite/family/task/node4:attrib3 eq :attrib4 and /suite/family/task/node4/node5:attrib5 gt :attrib6)))) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 or (/suite/family/task:attrib1 eq :attrib2 and (/suite/family/task/node4:attrib3 gt :attrib4 or (/suite/family/task/node4:attrib3 eq :attrib4 and /suite/family/task/node4/node5:attrib5 gt :attrib6)))) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (/suite/family/task:attrib1 gt :attrib2 or (/suite/family/task:attrib1 eq :attrib2 and (/suite/family/task/node4:attrib3 gt :attrib4 or (/suite/family/task/node4:attrib3 eq :attrib4 and /suite/family/task/node4/node5:attrib5 gt :attrib6))))",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (/suite/family/task:attrib1 gt :attrib2 or (/suite/family/task:attrib1 eq :attrib2 and (/suite/family/task/node4:attrib3 gt :attrib4 or (/suite/family/task/node4:attrib3 eq :attrib4 and /suite/family/task/node4/node5:attrib5 gt :attrib6))))",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 or (/suite/family/task:attrib1 eq :attrib2 and (/suite/family/task/node4:attrib3 gt :attrib4 or (/suite/family/task/node4:attrib3 eq :attrib4 and /suite/family/task/node4/node5:attrib5 gt :attrib6)))) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 or (/suite/family/task:attrib1 eq :attrib2 and (/suite/family/task/node4:attrib3 gt :attrib4 or (/suite/family/task/node4:attrib3 eq :attrib4 and /suite/family/task/node4/node5:attrib5 gt :attrib6)))) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 or (/suite/family/task:attrib1 eq :attrib2 and (/suite/family/task/node4:attrib3 gt :attrib4 or (/suite/family/task/node4:attrib3 eq :attrib4 and /suite/family/task/node4/node5:attrib5 gt :attrib6)))) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1gt :attrib2 or (/suite/family/task:attrib1 eq :attrib2 and (/suite/family/task/node4:attrib3 gt :attrib4 or (/suite/family/task/node4:attrib3 eq :attrib4 and /suite/family/task/node4/node5:attrib5 gt :attrib6))))",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "((/suite/family/task:attrib1 gt :attrib2 / 10000 or (/suite/family/task:attrib1 eq :attrib2 / 10000 and (/suite/family/task/node4:attrib3 gt (:attrib2 / 100 % 100) or (/suite/family/task/node4:attrib3 eq (:attrib2 / 100 % 100) and /suite/family/task/node4/node5:attrib4 gt :attrib2 % 100))))",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 / 10000 or (/suite/family/task:attrib1 eq :attrib2 / 10000 and (/suite/family/task/node4:attrib3 gt (:attrib2 / 100 % 100) or (/suite/family/task/node4:attrib3 eq (:attrib2 / 100 % 100) and /suite/family/task/node4/node5:attrib4 gt :attrib2 % 100)))))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "/suite/family/task:attrib1 gt :attrib2 / 10000 or (/suite/family/task:attrib1 eq :attrib2 / 10000 and (/suite/family/task/node4:attrib3 gt (:attrib2 / 100 % 100) or (/suite/family/task/node4:attrib3 eq (:attrib2 / 100 % 100) and /suite/family/task/node4/node5:attrib4 gt :attrib2 % 100))))",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 / 10000 or (/suite/family/task:attrib1 eq :attrib2 / 10000 and (/suite/family/task/node4:attrib3 gt (:attrib2 / 100 % 100) or (/suite/family/task/node4:attrib3 eq (:attrib2 / 100 % 100) and /suite/family/task/node4/node5:attrib4 gt :attrib2 % 100)))) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 / 10000 or (/suite/family/task:attrib1 eq :attrib2 / 10000 and (/suite/family/task/node4:attrib3 gt (:attrib2 / 100 % 100) or (/suite/family/task/node4:attrib3 eq (:attrib2 / 100 % 100) and /suite/family/task/node4/node5:attrib4 gt :attrib2 % 100)))) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 / 10000 or (/suite/family/task:attrib1 eq :attrib2 / 10000 and (/suite/family/task/node4:attrib3 gt (:attrib2 / 100 % 100) or (/suite/family/task/node4:attrib3 eq (:attrib2 / 100 % 100) and /suite/family/task/node4/node5:attrib4 gt :attrib2 % 100)))) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 / 10000 or (/suite/family/task:attrib1 eq :attrib2 / 10000 and (/suite/family/task/node4:attrib3 gt (:attrib2 / 100 % 100) or (/suite/family/task/node4:attrib3 eq (:attrib2 / 100 % 100) and /suite/family/task/node4/node5:attrib4 gt :attrib2 % 100)))) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (/suite/family/task:attrib1 gt :attrib2 / 10000 or (/suite/family/task:attrib1 eq :attrib2 / 10000 and (/suite/family/task/node4:attrib3 gt (:attrib2 / 100 % 100) or (/suite/family/task/node4:attrib3 eq (:attrib2 / 100 % 100) and /suite/family/task/node4/node5:attrib4 gt :attrib2 % 100))))",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (/suite/family/task:attrib1 gt :attrib2 / 10000 or (/suite/family/task:attrib1 eq :attrib2 / 10000 and (/suite/family/task/node4:attrib3 gt (:attrib2 / 100 % 100) or (/suite/family/task/node4:attrib3 eq (:attrib2 / 100 % 100) and /suite/family/task/node4/node5:attrib4 gt :attrib2 % 100))))",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 / 10000 or (/suite/family/task:attrib1 eq :attrib2 / 10000 and (/suite/family/task/node4:attrib3 gt (:attrib2 / 100 % 100) or (/suite/family/task/node4:attrib3 eq (:attrib2 / 100 % 100) and /suite/family/task/node4/node5:attrib4 gt :attrib2 % 100)))) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 / 10000 or (/suite/family/task:attrib1 eq :attrib2 / 10000 and (/suite/family/task/node4:attrib3 gt (:attrib2 / 100 % 100) or (/suite/family/task/node4:attrib3 eq (:attrib2 / 100 % 100) and /suite/family/task/node4/node5:attrib4 gt :attrib2 % 100)))) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1 gt :attrib2 / 10000 or (/suite/family/task:attrib1 eq :attrib2 / 10000 and (/suite/family/task/node4:attrib3 gt (:attrib2 / 100 % 100) or (/suite/family/task/node4:attrib3 eq (:attrib2 / 100 % 100) and /suite/family/task/node4/node5:attrib4 gt :attrib2 % 100)))) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(/suite/family/task:attrib1gt :attrib2 / 10000 or (/suite/family/task:attrib1 eq :attrib2 / 10000 and (/suite/family/task/node4:attrib3 gt (:attrib2 / 100 % 100) or (/suite/family/task/node4:attrib3 eq (:attrib2 / 100 % 100) and /suite/family/task/node4/node5:attrib4 gt :attrib2 % 100))))",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "((../suite == complete and ../family eq complete and :attrib1 eq 1 and /task/node4/00/node5 eq complete)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(../suite == complete and ../family eq complete and :attrib1 eq 1 and /task/node4/00/node5 eq complete))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "../suite == complete and ../family eq complete and :attrib1 eq 1 and /task/node4/00/node5 eq complete)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(../suite == complete and ../family eq complete and :attrib1 eq 1 and /task/node4/00/node5 eq complete) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(../suite == complete and ../family eq complete and :attrib1 eq 1 and /task/node4/00/node5 eq complete) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(../suite == complete and ../family eq complete and :attrib1 eq 1 and /task/node4/00/node5 eq complete) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(../suite == complete and ../family eq complete and :attrib1 eq 1 and /task/node4/00/node5 eq complete) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (../suite == complete and ../family eq complete and :attrib1 eq 1 and /task/node4/00/node5 eq complete)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (../suite == complete and ../family eq complete and :attrib1 eq 1 and /task/node4/00/node5 eq complete)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(../suite == == complete and ../family eq complete and :attrib1 eq 1 and /task/node4/00/node5 eq complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(../suite == complete and ../family eq complete and :attrib1 eq 1 and /task/node4/00/node5 eq complete) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(../suite == complete and ../family eq complete and :attrib1 eq 1 and /task/node4/00/node5 eq complete) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(../suite == complete and ../family eq complete and :attrib1 eq 1 and /task/node4/00/node5 eq complete) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(../suite < complete and ../family eq complete and :attrib1 eq 1 and /task/node4/00/node5 eq complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(../suite == completeand ../family eq complete and :attrib1 eq 1 and /task/node4/00/node5 eq complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(../suite == complete and../family eq complete and :attrib1 eq 1 and /task/node4/00/node5 eq complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(((:attrib1 * 100 + :attrib2) == 229)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "((:attrib1 * 100 + :attrib2) == 229))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "(:attrib1 * 100 + :attrib2) == 229)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "((:attrib1 * 100 + :attrib2) == 229) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "((:attrib1 * 100 + :attrib2) == 229) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "((:attrib1 * 100 + :attrib2) == 229) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "((:attrib1 * 100 + :attrib2) == 229) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and ((:attrib1 * 100 + :attrib2) == 229)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== ((:attrib1 * 100 + :attrib2) == 229)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "((:attrib1 * 100 + :attrib2) == == 229)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "((:attrib1 * 100 + :attrib2) == 229) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "((:attrib1 * 100 + :attrib2) == 229) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "((:attrib1 * 100 + :attrib2) == 229) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "((:attrib1 eq 1 or /suite/family/00/task/node4/node5 != active and /suite/node6/node7/node8:attrib2 ge :attrib2 and /suite/node6/node7/node8/node9:attrib3 ge :attrib3 or /suite/node6/node7/node8/node9 eq aborted or /suite/node6/node7/node8/node9/node10 eq complete or /suite/node6/node7/node8/node9/node10 eq queued)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(:attrib1 eq 1 or /suite/family/00/task/node4/node5 != active and /suite/node6/node7/node8:attrib2 ge :attrib2 and /suite/node6/node7/node8/node9:attrib3 ge :attrib3 or /suite/node6/node7/node8/node9 eq aborted or /suite/node6/node7/node8/node9/node10 eq complete or /suite/node6/node7/node8/node9/node10 eq queued))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": ":attrib1 eq 1 or /suite/family/00/task/node4/node5 != active and /suite/node6/node7/node8:attrib2 ge :attrib2 and /suite/node6/node7/node8/node9:attrib3 ge :attrib3 or /suite/node6/node7/node8/node9 eq aborted or /suite/node6/node7/node8/node9/node10 eq complete or /suite/node6/node7/node8/node9/node10 eq queued)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(:attrib1 eq 1 or /suite/family/00/task/node4/node5 != active and /suite/node6/node7/node8:attrib2 ge :attrib2 and /suite/node6/node7/node8/node9:attrib3 ge :attrib3 or /suite/node6/node7/node8/node9 eq aborted or /suite/node6/node7/node8/node9/node10 eq complete or /suite/node6/node7/node8/node9/node10 eq queued) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(:attrib1 eq 1 or /suite/family/00/task/node4/node5 != active and /suite/node6/node7/node8:attrib2 ge :attrib2 and /suite/node6/node7/node8/node9:attrib3 ge :attrib3 or /suite/node6/node7/node8/node9 eq aborted or /suite/node6/node7/node8/node9/node10 eq complete or /suite/node6/node7/node8/node9/node10 eq queued) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(:attrib1 eq 1 or /suite/family/00/task/node4/node5 != active and /suite/node6/node7/node8:attrib2 ge :attrib2 and /suite/node6/node7/node8/node9:attrib3 ge :attrib3 or /suite/node6/node7/node8/node9 eq aborted or /suite/node6/node7/node8/node9/node10 eq complete or /suite/node6/node7/node8/node9/node10 eq queued) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(:attrib1 eq 1 or /suite/family/00/task/node4/node5 != active and /suite/node6/node7/node8:attrib2 ge :attrib2 and /suite/node6/node7/node8/node9:attrib3 ge :attrib3 or /suite/node6/node7/node8/node9 eq aborted or /suite/node6/node7/node8/node9/node10 eq complete or /suite/node6/node7/node8/node9/node10 eq queued) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (:attrib1 eq 1 or /suite/family/00/task/node4/node5 != active and /suite/node6/node7/node8:attrib2 ge :attrib2 and /suite/node6/node7/node8/node9:attrib3 ge :attrib3 or /suite/node6/node7/node8/node9 eq aborted or /suite/node6/node7/node8/node9/node10 eq complete or /suite/node6/node7/node8/node9/node10 eq queued)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (:attrib1 eq 1 or /suite/family/00/task/node4/node5 != active and /suite/node6/node7/node8:attrib2 ge :attrib2 and /suite/node6/node7/node8/node9:attrib3 ge :attrib3 or /suite/node6/node7/node8/node9 eq aborted or /suite/node6/node7/node8/node9/node10 eq complete or /suite/node6/node7/node8/node9/node10 eq queued)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(:attrib1 eq 1 or /suite/family/00/task/node4/node5 != active and /suite/node6/node7/node8:attrib2 ge :attrib2 and /suite/node6/node7/node8/node9:attrib3 ge :attrib3 or /suite/node6/node7/node8/node9 eq aborted or /suite/node6/node7/node8/node9/node10 eq complete or /suite/node6/node7/node8/node9/node10 eq queued) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(:attrib1 eq 1 or /suite/family/00/task/node4/node5 != active and /suite/node6/node7/node8:attrib2 ge :attrib2 and /suite/node6/node7/node8/node9:attrib3 ge :attrib3 or /suite/node6/node7/node8/node9 eq aborted or /suite/node6/node7/node8/node9/node10 eq complete or /suite/node6/node7/node8/node9/node10 eq queued) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(:attrib1 eq 1 or /suite/family/00/task/node4/node5 != active and /suite/node6/node7/node8:attrib2 ge :attrib2 and /suite/node6/node7/node8/node9:attrib3 ge :attrib3 or /suite/node6/node7/node8/node9 eq aborted or /suite/node6/node7/node8/node9/node10 eq complete or /suite/node6/node7/node8/node9/node10 eq queued) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(:attrib1 eq 1 or /suite/family/00/task/node4/node5 < active and /suite/node6/node7/node8:attrib2 ge :attrib2 and /suite/node6/node7/node8/node9:attrib3 ge :attrib3 or /suite/node6/node7/node8/node9 eq aborted or /suite/node6/node7/node8/node9/node10 eq complete or /suite/node6/node7/node8/node9/node10 eq queued)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(:attrib1eq 1 or /suite/family/00/task/node4/node5 != active and /suite/node6/node7/node8:attrib2 ge :attrib2 and /suite/node6/node7/node8/node9:attrib3 ge :attrib3 or /suite/node6/node7/node8/node9 eq aborted or /suite/node6/node7/node8/node9/node10 eq complete or /suite/node6/node7/node8/node9/node10 eq queued)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(:attrib1 eq1 or /suite/family/00/task/node4/node5 != active and /suite/node6/node7/node8:attrib2 ge :attrib2 and /suite/node6/node7/node8/node9:attrib3 ge :attrib3 or /suite/node6/node7/node8/node9 eq aborted or /suite/node6/node7/node8/node9/node10 eq complete or /suite/node6/node7/node8/node9/node10 eq queued)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((suite == complete and family == complete and task == complete and (/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 17)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and (/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 17))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "suite == complete and family == complete and task == complete and (/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 17)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and (/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 17) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and (/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 17) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and (/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 17) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and (/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 17) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (suite == complete and family == complete and task == complete and (/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 17)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (suite == complete and family == complete and task == complete and (/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 17)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(suite == == complete and family == complete and task == complete and (/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 17)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and (/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 17) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and (/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 17) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(suite == complete and family == complete and task == complete and (/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 17) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(suite < complete and family == complete and task == complete and (/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 17)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(suite == completeand family == complete and task == complete and (/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 17)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(suite == complete andfamily == complete and task == complete and (/node4/node5/node6:attrib1 - /node4/node7:attrib1) < 17)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((:attrib1 == 1 or suite == complete AND family == complete and suite == complete)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(:attrib1 == 1 or suite == complete AND family == complete and suite == complete))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": ":attrib1 == 1 or suite == complete AND family == complete and suite == complete)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(:attrib1 == 1 or suite == complete AND family == complete and suite == complete) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(:attrib1 == 1 or suite == complete AND family == complete and suite == complete) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(:attrib1 == 1 or suite == complete AND family == complete and suite == complete) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(:attrib1 == 1 or suite == complete AND family == complete and suite == complete) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (:attrib1 == 1 or suite == complete AND family == complete and suite == complete)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (:attrib1 == 1 or suite == complete AND family == complete and suite == complete)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(:attrib1 == == 1 or suite == complete AND family == complete and suite == complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(:attrib1 == 1 or suite == complete AND family == complete and suite == complete) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(:attrib1 == 1 or suite == complete AND family == complete and suite == complete) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(:attrib1 == 1 or suite == complete AND family == complete and suite == complete) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(:attrib1 == 1 or suite < complete AND family == complete and suite == complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(:attrib1 == 1or suite == complete AND family == complete and suite == complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "((suite == complete and family == complete and ../../task/node4 eq complete)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(suite == complete and family == complete and ../../task/node4 eq complete))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "suite == complete and family == complete and ../../task/node4 eq complete)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(suite == complete and family == complete and ../../task/node4 eq complete) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(suite == complete and family == complete and ../../task/node4 eq complete) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(suite == complete and family == complete and ../../task/node4 eq complete) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(suite == complete and family == complete and ../../task/node4 eq complete) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (suite == complete and family == complete and ../../task/node4 eq complete)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (suite == complete and family == complete and ../../task/node4 eq complete)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(suite == == complete and family == complete and ../../task/node4 eq complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(suite == complete and family == complete and ../../task/node4 eq complete) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(suite == complete and family == complete and ../../task/node4 eq complete) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(suite == complete and family == complete and ../../task/node4 eq complete) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(suite < complete and family == complete and ../../task/node4 eq complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(suite == completeand family == complete and ../../task/node4 eq complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(suite == complete andfamily == complete and ../../task/node4 eq complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((:attrib1 le /suite/family/task:attrib2)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(:attrib1 le /suite/family/task:attrib2))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": ":attrib1 le /suite/family/task:attrib2)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(:attrib1 le /suite/family/task:attrib2) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(:attrib1 le /suite/family/task:attrib2) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(:attrib1 le /suite/family/task:attrib2) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(:attrib1 le /suite/family/task:attrib2) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (:attrib1 le /suite/family/task:attrib2)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (:attrib1 le /suite/family/task:attrib2)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(:attrib1 le /suite/family/task:attrib2) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(:attrib1 le /suite/family/task:attrib2) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(:attrib1 le /suite/family/task:attrib2) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "((:attrib1 lt /suite/family:attrib1)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(:attrib1 lt /suite/family:attrib1))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": ":attrib1 lt /suite/family:attrib1)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(:attrib1 lt /suite/family:attrib1) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(:attrib1 lt /suite/family:attrib1) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(:attrib1 lt /suite/family:attrib1) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(:attrib1 lt /suite/family:attrib1) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (:attrib1 lt /suite/family:attrib1)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (:attrib1 lt /suite/family:attrib1)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(:attrib1 lt /suite/family:attrib1) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(:attrib1 lt /suite/family:attrib1) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(:attrib1 lt /suite/family:attrib1) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt :attrib1)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt :attrib1))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "/suite/family:attrib1 gt :attrib1)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt :attrib1) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt :attrib1) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt :attrib1) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt :attrib1) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (/suite/family:attrib1 gt :attrib1)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (/suite/family:attrib1 gt :attrib1)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt :attrib1) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt :attrib1) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt :attrib1) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(/suite/family:attrib1gt :attrib1)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "((/suite:attrib1 gt /suite/family:attrib2 and /suite:attrib3 ge 1600 and ../task ne complete)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(/suite:attrib1 gt /suite/family:attrib2 and /suite:attrib3 ge 1600 and ../task ne complete))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "/suite:attrib1 gt /suite/family:attrib2 and /suite:attrib3 ge 1600 and ../task ne complete)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(/suite:attrib1 gt /suite/family:attrib2 and /suite:attrib3 ge 1600 and ../task ne complete) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(/suite:attrib1 gt /suite/family:attrib2 and /suite:attrib3 ge 1600 and ../task ne complete) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(/suite:attrib1 gt /suite/family:attrib2 and /suite:attrib3 ge 1600 and ../task ne complete) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(/suite:attrib1 gt /suite/family:attrib2 and /suite:attrib3 ge 1600 and ../task ne complete) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (/suite:attrib1 gt /suite/family:attrib2 and /suite:attrib3 ge 1600 and ../task ne complete)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (/suite:attrib1 gt /suite/family:attrib2 and /suite:attrib3 ge 1600 and ../task ne complete)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(/suite:attrib1 gt /suite/family:attrib2 and /suite:attrib3 ge 1600 and ../task ne complete) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(/suite:attrib1 gt /suite/family:attrib2 and /suite:attrib3 ge 1600 and ../task ne complete) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(/suite:attrib1 gt /suite/family:attrib2 and /suite:attrib3 ge 1600 and ../task ne complete) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(/suite:attrib1 gt /suite/family:attrib2 and /suite:attrib3 ge 1600 and ../task < complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(/suite:attrib1 gt /suite/family:attrib2 and /suite:attrib3 ge1600 and ../task ne complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 ))",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 )))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 ))",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 )) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 )) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 )) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 )) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 ))",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 ))",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 )) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 )) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 )) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete))",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete)))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete))",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete)) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete)) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete)) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete)) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete))",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete))",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete)) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete)) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete)) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete) and /suite/task/node5/12/node6 eq complete)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete) and /suite/task/node5/12/node6 eq complete))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete) and /suite/task/node5/12/node6 eq complete)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete) and /suite/task/node5/12/node6 eq complete) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete) and /suite/task/node5/12/node6 eq complete) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete) and /suite/task/node5/12/node6 eq complete) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete) and /suite/task/node5/12/node6 eq complete) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete) and /suite/task/node5/12/node6 eq complete)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete) and /suite/task/node5/12/node6 eq complete)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete) and /suite/task/node5/12/node6 eq complete) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete) and /suite/task/node5/12/node6 eq complete) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete) and /suite/task/node5/12/node6 eq complete) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete) and /suite/task/node5/12/node6 < complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete) and /suite/task/node5/12/node6 eqcomplete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete and /suite/family/12/node5==complete))",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete and /suite/family/12/node5==complete)))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete and /suite/family/12/node5==complete))",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete and /suite/family/12/node5==complete)) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete and /suite/family/12/node5==complete)) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete and /suite/family/12/node5==complete)) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete and /suite/family/12/node5==complete)) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete and /suite/family/12/node5==complete))",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete and /suite/family/12/node5==complete))",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete and /suite/family/12/node5==complete)) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete and /suite/family/12/node5==complete)) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4==complete and /suite/family/12/node5==complete)) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete) AND (/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node6==complete and /suite/family/12/node6==complete))",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete) AND (/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node6==complete and /suite/family/12/node6==complete)))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete) AND (/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node6==complete and /suite/family/12/node6==complete))",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete) AND (/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node6==complete and /suite/family/12/node6==complete)) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete) AND (/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node6==complete and /suite/family/12/node6==complete)) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete) AND (/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node6==complete and /suite/family/12/node6==complete)) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete) AND (/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node6==complete and /suite/family/12/node6==complete)) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete) AND (/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node6==complete and /suite/family/12/node6==complete))",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete) AND (/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node6==complete and /suite/family/12/node6==complete))",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete) AND (/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node6==complete and /suite/family/12/node6==complete)) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete) AND (/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node6==complete and /suite/family/12/node6==complete)) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node4/node5==complete) AND (/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/12/node6==complete and /suite/family/12/node6==complete)) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "((((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/task/node4/node5/node6==complete)) and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/node5/node7/node8==complete)))",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/task/node4/node5/node6==complete)) and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/node5/node7/node8==complete))))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/task/node4/node5/node6==complete)) and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/node5/node7/node8==complete)))",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/task/node4/node5/node6==complete)) and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/node5/node7/node8==complete))) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/task/node4/node5/node6==complete)) and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/node5/node7/node8==complete))) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/task/node4/node5/node6==complete)) and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/node5/node7/node8==complete))) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/task/node4/node5/node6==complete)) and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/node5/node7/node8==complete))) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/task/node4/node5/node6==complete)) and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/node5/node7/node8==complete)))",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/task/node4/node5/node6==complete)) and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/node5/node7/node8==complete)))",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/task/node4/node5/node6==complete)) and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/node5/node7/node8==complete))) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/task/node4/node5/node6==complete)) and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/node5/node7/node8==complete))) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/task/node4/node5/node6==complete)) and ((/suite/family:attrib1 gt /suite/task:attrib1) or (/suite/family:attrib1 eq /suite/task:attrib1 and /suite/family/node5/node7/node8==complete))) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "((1 != :attrib1 % 4)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(1 != :attrib1 % 4))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "1 != :attrib1 % 4)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(1 != :attrib1 % 4) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(1 != :attrib1 % 4) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(1 != :attrib1 % 4) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(1 != :attrib1 % 4) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (1 != :attrib1 % 4)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (1 != :attrib1 % 4)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(1 != :attrib1 % 4) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(1 != :attrib1 % 4) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(1 != :attrib1 % 4) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt /suite/task:attrib1 and ./12==complete and ./node4==complete and ./00==complete and ./node5==complete)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt /suite/task:attrib1 and ./12==complete and ./node4==complete and ./00==complete and ./node5==complete))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "/suite/family:attrib1 gt /suite/task:attrib1 and ./12==complete and ./node4==complete and ./00==complete and ./node5==complete)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt /suite/task:attrib1 and ./12==complete and ./node4==complete and ./00==complete and ./node5==complete) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt /suite/task:attrib1 and ./12==complete and ./node4==complete and ./00==complete and ./node5==complete) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt /suite/task:attrib1 and ./12==complete and ./node4==complete and ./00==complete and ./node5==complete) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt /suite/task:attrib1 and ./12==complete and ./node4==complete and ./00==complete and ./node5==complete) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (/suite/family:attrib1 gt /suite/task:attrib1 and ./12==complete and ./node4==complete and ./00==complete and ./node5==complete)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (/suite/family:attrib1 gt /suite/task:attrib1 and ./12==complete and ./node4==complete and ./00==complete and ./node5==complete)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt /suite/task:attrib1 and ./12==complete and ./node4==complete and ./00==complete and ./node5==complete) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt /suite/task:attrib1 and ./12==complete and ./node4==complete and ./00==complete and ./node5==complete) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt /suite/task:attrib1 and ./12==complete and ./node4==complete and ./00==complete and ./node5==complete) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(/suite/family:attrib1 gt /suite/task:attrib1 and./12==complete and ./node4==complete and ./00==complete and ./node5==complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((:attrib1 ge 1715)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(:attrib1 ge 1715))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": ":attrib1 ge 1715)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(:attrib1 ge 1715) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(:attrib1 ge 1715) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(:attrib1 ge 1715) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(:attrib1 ge 1715) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (:attrib1 ge 1715)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (:attrib1 ge 1715)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(:attrib1 ge 1715) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(:attrib1 ge 1715) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(:attrib1 ge 1715) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(:attrib1ge 1715)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(:attrib1 ge1715)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((suite:attrib1 ge 0 or suite:attrib2 ge 0 or suite:attrib3 gt 48 or /family/task/12/node4/node5/node6/050/node7:attrib4 gt 24)",
+      "mutation": "unbalanced_open"
+    },
+    {
+      "expression": "(suite:attrib1 ge 0 or suite:attrib2 ge 0 or suite:attrib3 gt 48 or /family/task/12/node4/node5/node6/050/node7:attrib4 gt 24))",
+      "mutation": "unbalanced_close"
+    },
+    {
+      "expression": "suite:attrib1 ge 0 or suite:attrib2 ge 0 or suite:attrib3 gt 48 or /family/task/12/node4/node5/node6/050/node7:attrib4 gt 24)",
+      "mutation": "drop_open_bracket"
+    },
+    {
+      "expression": "(suite:attrib1 ge 0 or suite:attrib2 ge 0 or suite:attrib3 gt 48 or /family/task/12/node4/node5/node6/050/node7:attrib4 gt 24) and",
+      "mutation": "dangling_and"
+    },
+    {
+      "expression": "(suite:attrib1 ge 0 or suite:attrib2 ge 0 or suite:attrib3 gt 48 or /family/task/12/node4/node5/node6/050/node7:attrib4 gt 24) or",
+      "mutation": "dangling_or"
+    },
+    {
+      "expression": "(suite:attrib1 ge 0 or suite:attrib2 ge 0 or suite:attrib3 gt 48 or /family/task/12/node4/node5/node6/050/node7:attrib4 gt 24) ==",
+      "mutation": "dangling_eq"
+    },
+    {
+      "expression": "(suite:attrib1 ge 0 or suite:attrib2 ge 0 or suite:attrib3 gt 48 or /family/task/12/node4/node5/node6/050/node7:attrib4 gt 24) +",
+      "mutation": "dangling_plus"
+    },
+    {
+      "expression": "and (suite:attrib1 ge 0 or suite:attrib2 ge 0 or suite:attrib3 gt 48 or /family/task/12/node4/node5/node6/050/node7:attrib4 gt 24)",
+      "mutation": "leading_and"
+    },
+    {
+      "expression": "== (suite:attrib1 ge 0 or suite:attrib2 ge 0 or suite:attrib3 gt 48 or /family/task/12/node4/node5/node6/050/node7:attrib4 gt 24)",
+      "mutation": "leading_eq"
+    },
+    {
+      "expression": "(suite:attrib1 ge 0 or suite:attrib2 ge 0 or suite:attrib3 gt 48 or /family/task/12/node4/node5/node6/050/node7:attrib4 gt 24) @",
+      "mutation": "garbage_token"
+    },
+    {
+      "expression": "(suite:attrib1 ge 0 or suite:attrib2 ge 0 or suite:attrib3 gt 48 or /family/task/12/node4/node5/node6/050/node7:attrib4 gt 24) complete",
+      "mutation": "trailing_state"
+    },
+    {
+      "expression": "(suite:attrib1 ge 0 or suite:attrib2 ge 0 or suite:attrib3 gt 48 or /family/task/12/node4/node5/node6/050/node7:attrib4 gt 24) zz",
+      "mutation": "trailing_token"
+    },
+    {
+      "expression": "(suite:attrib1ge 0 or suite:attrib2 ge 0 or suite:attrib3 gt 48 or /family/task/12/node4/node5/node6/050/node7:attrib4 gt 24)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(suite:attrib1 ge0 or suite:attrib2 ge 0 or suite:attrib3 gt 48 or /family/task/12/node4/node5/node6/050/node7:attrib4 gt 24)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4/node5/050/node6:attrib1 gt 0 or /suite/family/12/task/node4/node5 < complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4/node5/050/node6:attrib1gt 0 or /suite/family/12/task/node4/node5 eq complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4/node5/050/node6:attrib1 gt0 or /suite/family/12/task/node4/node5 eq complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(/suite/family/task==completeand (/suite/family:attrib1 eq /node4/family:attrib1))",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4:attrib1 ge ./node5:attrib2 or /suite/family/12/task/node6:attrib1 ge ./node5:attrib2 or /suite/family/12/task/node4 < complete or /suite/family/12/task/node4 eq aborted))",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4:attrib1ge ./node5:attrib2 or /suite/family/12/task/node6:attrib1 ge ./node5:attrib2 or /suite/family/12/task/node4 eq complete or /suite/family/12/task/node4 eq aborted))",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4/node5 == == active or /suite/family/12/task/node4/node5 == complete) and (/suite/family/12/task/node6/node7 eq active or /suite/family/12/task/node6/node7 eq complete))",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4/node5 < active or /suite/family/12/task/node4/node5 == complete) and (/suite/family/12/task/node6/node7 eq active or /suite/family/12/task/node6/node7 eq complete))",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4/node5 == activeor /suite/family/12/task/node4/node5 == complete) and (/suite/family/12/task/node6/node7 eq active or /suite/family/12/task/node6/node7 eq complete))",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4/node5 == active or /suite/family/12/task/node4/node5 == complete) and (/suite/family/12/task/node6/node7 eqactive or /suite/family/12/task/node6/node7 eq complete))",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(../suite/family < complete or (1==0 and (../task:attrib1 gt 16 or (../task:attrib1 gt 16 or ../task:attrib1 gt 16 or ../node4:attrib2 gt 16 or ../node4:attrib2 gt 16 or ../node4:attrib2 gt 16 or (../task eq complete and ../node4 eq complete)))))",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(../suite/familyeq complete or (1==0 and (../task:attrib1 gt 16 or (../task:attrib1 gt 16 or ../task:attrib1 gt 16 or ../node4:attrib2 gt 16 or ../node4:attrib2 gt 16 or ../node4:attrib2 gt 16 or (../task eq complete and ../node4 eq complete)))))",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(../suite/family eqcomplete or (1==0 and (../task:attrib1 gt 16 or (../task:attrib1 gt 16 or ../task:attrib1 gt 16 or ../node4:attrib2 gt 16 or ../node4:attrib2 gt 16 or ../node4:attrib2 gt 16 or (../task eq complete and ../node4 eq complete)))))",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(../suite:attrib1 gt 3 or ../family:attrib2 gt 3 or (../suite < complete and ../family eq complete))",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(../suite:attrib1gt 3 or ../family:attrib2 gt 3 or (../suite eq complete and ../family eq complete))",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(../suite:attrib1 gt3 or ../family:attrib2 gt 3 or (../suite eq complete and ../family eq complete))",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(/suite/family/12/task:attrib1gt 240 or /suite/family/12//node4/node5==complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(/suite/family/12/task:attrib1 gt240 or /suite/family/12//node4/node5==complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(../suite/family < complete or 1==1)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(../suite/familyeq complete or 1==1)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(../suite/family eqcomplete or 1==1)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(((/suite/family/12/task/node4/node5==completeor /suite/family/12/node6:attrib1 ge 240 or /suite/family/12/node7:attrib2 ge 240)) and (( 20300101 gt /suite/family:attrib3 -1) or ( 20300101 eq /suite/family:attrib3) and (1==1)))",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(((/suite/family/12/task/node4/node5==complete or /suite/family/12/node6:attrib1 ge240 or /suite/family/12/node7:attrib2 ge 240)) and (( 20300101 gt /suite/family:attrib3 -1) or ( 20300101 eq /suite/family:attrib3) and (1==1)))",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4==complete and (/node5/family/12//node6/task==complete or /node5/family/12/node7:attrib1 ge 240 or /node5/family/12/node8:attrib2 ge 240)) and (node9 == == complete))",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4==complete and (/node5/family/12//node6/task==complete or /node5/family/12/node7:attrib1 ge 240 or /node5/family/12/node8:attrib2 ge 240)) and (node9 < complete))",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4==completeand (/node5/family/12//node6/task==complete or /node5/family/12/node7:attrib1 ge 240 or /node5/family/12/node8:attrib2 ge 240)) and (node9 == complete))",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4==complete and (/node5/family/12//node6/task==complete or /node5/family/12/node7:attrib1 ge240 or /node5/family/12/node8:attrib2 ge 240)) and (node9 == complete))",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(../suite < active or ../suite eq complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(../suiteeq active or ../suite eq complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(../suite eqactive or ../suite eq complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt :attrib1 or /suite/family/12/task/node4 eq complete) and (/node5/family/12//node6/task==complete or /node5/family/12/node7:attrib2 ge 240 or /node5/family/12/node8:attrib3 ge 240) AND node9 == == complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt :attrib1 or /suite/family/12/task/node4 < complete) and (/node5/family/12//node6/task==complete or /node5/family/12/node7:attrib2 ge 240 or /node5/family/12/node8:attrib3 ge 240) AND node9 == complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "((/suite/family:attrib1gt :attrib1 or /suite/family/12/task/node4 eq complete) and (/node5/family/12//node6/task==complete or /node5/family/12/node7:attrib2 ge 240 or /node5/family/12/node8:attrib3 ge 240) AND node9 == complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt :attrib1 or /suite/family/12/task/node4 eqcomplete) and (/node5/family/12//node6/task==complete or /node5/family/12/node7:attrib2 ge 240 or /node5/family/12/node8:attrib3 ge 240) AND node9 == complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4 eq complete and (/suite/family/12//node5/node6==complete or /suite/family/12/node7:attrib1 ge 360 or /suite/family/12/node8:attrib2 ge 360) AND node9 == == complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4 < complete and (/suite/family/12//node5/node6==complete or /suite/family/12/node7:attrib1 ge 360 or /suite/family/12/node8:attrib2 ge 360) AND node9 == complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4eq complete and (/suite/family/12//node5/node6==complete or /suite/family/12/node7:attrib1 ge 360 or /suite/family/12/node8:attrib2 ge 360) AND node9 == complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4 eqcomplete and (/suite/family/12//node5/node6==complete or /suite/family/12/node7:attrib1 ge 360 or /suite/family/12/node8:attrib2 ge 360) AND node9 == complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(/suite/family/12/task/240/node4==complete and (/suite/family/12/task/360/node4==complete) AND node5 == == complete and /suite/family/12/node6==complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(/suite/family/12/task/240/node4==complete and (/suite/family/12/task/360/node4==complete) AND node5 < complete and /suite/family/12/node6==complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(/suite/family/12/task/240/node4==completeand (/suite/family/12/task/360/node4==complete) AND node5 == complete and /suite/family/12/node6==complete)",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(/suite/family/12/task/240/node4==complete and (/suite/family/12/task/360/node4==complete) ANDnode5 == complete and /suite/family/12/node6==complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(((/suite/family/12/task/node4==completeor /suite/family/12/node5:attrib1 ge 0) and /suite/family/12/node6/240==complete and /suite/family/12/node7/node8==complete))",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "(((/suite/family/12/task/node4==complete or /suite/family/12/node5:attrib1 ge0) and /suite/family/12/node6/240==complete and /suite/family/12/node7/node8==complete))",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4==completeor /suite/family/12/node5:attrib1 ge 240))",
+      "mutation": "glue_operand_operator"
+    },
+    {
+      "expression": "((/suite/family/12/task/node4==complete or /suite/family/12/node5:attrib1 ge240))",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(/suite/family:attrib1 eq :attrib1 and /suite/family/12/task/node4 == == complete or /suite/family:attrib1 gt :attrib1 or ../../node5/node6 eq complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(/suite/family:attrib1 eq :attrib1 and /suite/family/12/task/node4 < complete or /suite/family:attrib1 gt :attrib1 or ../../node5/node6 eq complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(/suite/family:attrib1 eq :attrib1 and /suite/family/12/task/node4 == complete or /suite/family:attrib1 gt :attrib1 or../../node5/node6 eq complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((/suite/family/12/task:attrib1 ge 240 OR /suite/family/12/node4:attrib2 ge 240) OR /suite/family/12/node5 < complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "((/suite/family/12/task:attrib1 ge240 OR /suite/family/12/node4:attrib2 ge 240) OR /suite/family/12/node5 eq complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(./240/suite:attrib1 AND ((/family/task/12/node4 < complete AND /family/task/12/node5 eq complete) AND /family/task/12/node6 eq complete))",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(./240/suite:attrib1 AND ((/family/task/12/node4 eqcomplete AND /family/task/12/node5 eq complete) AND /family/task/12/node6 eq complete))",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "((/suite/family/12/task < complete AND /suite/family/12/node4 eq complete) AND /suite/family/12/node5 eq complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "((/suite/family/12/task eqcomplete AND /suite/family/12/node4 eq complete) AND /suite/family/12/node5 eq complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(../suite:attrib1 gt 0 or ../family:attrib2 gt 0 or ../task < complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(../suite:attrib1 gt0 or ../family:attrib2 gt 0 or ../task eq complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(suite/family < complete and not suite/family:0 and not suite/family:120)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(suite/family eqcomplete and not suite/family:0 and not suite/family:120)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(../suite/family:0 OR ../suite/family < complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(suite < active OR suite eq complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(suite eqactive OR suite eq complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4:attrib1 gt0)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(suite==complete ANDfamily==complete AND 1940 lt :attrib1)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(suite==complete ANDfamily==complete AND task==complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(/suite/family/12/task:attrib1 ge 240 or /suite/family/12/node4:attrib2 ge 240 or /suite/family/12//node5/node6 < complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(/suite/family/12/task:attrib1 ge240 or /suite/family/12/node4:attrib2 ge 240 or /suite/family/12//node5/node6 eq complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(./suite == == complete and family == complete and task == complete and ./node4 == complete and ./12 == complete and ./24 == complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(./suite < complete and family == complete and task == complete and ./node4 == complete and ./12 == complete and ./24 == complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(./suite == complete andfamily == complete and task == complete and ./node4 == complete and ./12 == complete and ./24 == complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(suite == == complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and ./node8 == complete and ./node9 == complete and ./node10 == complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(suite < complete and family == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and ./node8 == complete and ./node9 == complete and ./node10 == complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(suite == complete andfamily == complete and task == complete and node4 == complete and node5 == complete and node6 == complete and node7 == complete and ./node8 == complete and ./node9 == complete and ./node10 == complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(suite == == complete and family == complete and task == complete and node4 == complete and node5 == complete and ./node6 == complete and ./node7 == complete and ./node8 == complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(suite < complete and family == complete and task == complete and node4 == complete and node5 == complete and ./node6 == complete and ./node7 == complete and ./node8 == complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(suite == complete andfamily == complete and task == complete and node4 == complete and node5 == complete and ./node6 == complete and ./node7 == complete and ./node8 == complete)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4 == == complete or /suite/family/12/node5:attrib1 ge 240 or /suite/family/12/node6:attrib2 ge 240)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4 < complete or /suite/family/12/node5:attrib1 ge 240 or /suite/family/12/node6:attrib2 ge 240)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4 == complete or /suite/family/12/node5:attrib1 ge240 or /suite/family/12/node6:attrib2 ge 240)",
+      "mutation": "glue_operator_operand"
+    },
+    {
+      "expression": "(/suite/family/12/task:attrib1 ge 36 or /suite/family/12//node4:attrib2 ge 36 or ../node5 == == complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(suite == == complete and family == complete and suite == complete and family == complete and ../../task/node4 eq complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(suite < complete and family == complete and suite == complete and family == complete and ../../task/node4 eq complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4 == == complete and node5 == complete and /suite/family/12/node6/240/node7:1)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(/suite/family/12/task/node4 < complete and node5 == complete and /suite/family/12/node6/240/node7:1)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(suite == == complete and family == complete and ../../task/node4 eq complete and ../../240/node4 eq complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(suite < complete and family == complete and ../../task/node4 eq complete and ../../240/node4 eq complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "((suite:1 and suite==complete) and (../family == == complete))",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "((suite:1 and suite==complete) and (../family < complete))",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "(./240/suite:attrib1 AND /family/task/12/node4/node5 < complete)",
+      "mutation": "relational_state"
+    },
+    {
+      "expression": "((/suite/family:attrib1 gt :attrib1 or /suite/family/00/task/node4==complete) and (/node5/family/00//node6/task==complete or /node5/family/00/node7:attrib2 ge 240 or /node5/family/00/node8:attrib3 ge 240) AND node9 == == complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(/suite/family/00/task/node4 == == complete and (/suite/family/00//node5/node6==complete or /suite/family/00/node7:attrib1 ge 360 or /suite/family/00/node8:attrib2 ge 360) AND node9 == complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "((/suite/family/00/task/node4 == == complete and /suite/family:attrib1 eq :attrib1) or /suite/family:attrib1 gt :attrib1 or ../../node5/node6 eq complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(../suite == == complete and ../family eq complete and ../task eq complete and ../../../node4/node5/node6 eq complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(/suite/family/task/node4/node5 == == complete or /suite/family:attrib1 gt :attrib1)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "((:attrib1 * 100 + :attrib2) == == 229 or (:attrib1 * 100 + :attrib2) == 231 or (:attrib1 * 100 + :attrib2) == 431 or (:attrib1 * 100 + :attrib2) == 631 or (:attrib1 * 100 + :attrib2) == 931 or (:attrib1 * 100 + :attrib2) == 1131)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(suite == == complete AND family == complete and task/node4 eq complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "((/suite/family:attrib1 eq :attrib1 and /suite/family/00/task/node4 == == complete) or ../../node5/node6 eq complete or /suite/family:attrib1 gt :attrib1)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(/suite/family/00/task/node4/node5 != active and node6 == == complete and node7 == complete and node8 == complete and node9 == complete and /suite/family/00/node10/node11 == complete and (/suite/family/00/task/node4/node5 eq complete or 1 == 1 ))",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(suite == == complete and family == complete and task == complete and node4 == complete and node5 == complete and ./node6 == complete and ./node7 == complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(1==1 or suite == == complete and family == complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(suite == == complete and family eq complete and ../../../task/node4 eq complete)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(suite/family == == complete or 1==1)",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "(:attrib1 % 2 == == 1 and (:attrib1 % 100 ne 1 and :attrib2 ne 0))",
+      "mutation": "double_eq"
+    },
+    {
+      "expression": "((1==1) and (suite == == complete))",
+      "mutation": "double_eq"
+    }
+  ]
+}

--- a/libs/node/test/expressions/extract_expressions
+++ b/libs/node/test/expressions/extract_expressions
@@ -1,0 +1,670 @@
+#!/usr/bin/env python3
+#
+# Copyright 2009- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+"""
+
+This script extracts a *golden corpus* of trigger/complete expressions from provided
+ecFlow definition (``.def``) and checkpoint (``.check``) files.
+
+Responsibilities of this script:
+
+  1. Extract every ``trigger``/``complete`` expression from the input files.
+
+  2. Textually combine multi-part expressions (``-a`` / ``-o`` continuation
+     lines) into a single expression, reproducing the server's left-associative
+     fold (see ``Expression::createAST`` in the C++ sources).
+
+  3. Deduplicate by *AST structure* (not by literal text): two expressions that
+     differ only in their operand *values* (node paths, attribute names,
+     integers, datetimes, states, events, flags) collapse to a single entry,
+     while any difference in operators / grouping / keyword spelling is kept.
+
+  4. Emit a JSON corpus whose ``valid_expressions`` carry an ``expression`` (and
+     a null ``expected`` slot).
+
+  5. As a final step, automatically derive ``invalid_expressions`` candidates by
+     applying structure-breaking mutations to the valid corpus; the recording step
+     enforces rejection of those the parser refuses and moves any it accepts into
+     ``valid_expressions`` (a mutation may coincidentally yield a valid expression).
+
+Usage:
+    extract_expressions --in <file> [--in <file> ...] --out <corpus.json>
+
+"""
+
+import argparse
+import datetime
+import json
+import os
+import re
+import sys
+
+#
+# Line-level extraction
+#
+
+# A trigger/complete attribute line. Captures the type, the optional -a/-o modifier
+# and the remainder (the expression, possibly followed by a trailing '# comment').
+_ATTR_RE = re.compile(r"^\s*(trigger|complete)\b(.*)$")
+_MODIFIER_RE = re.compile(r"^\s*(-[ao])\b\s*(.*)$")
+
+
+def _strip_comment(expr: str) -> str:
+    """
+    Remove any trailing ' # comment' (definition-file style) from an expression.
+
+    The '#' is not part of the expression grammar (node/attribute names only use
+    word characters and '.'), so the first '#' preceded by whitespace, or a '#'
+    at the start, safely delimits a comment.
+    """
+    # A '#' that starts a comment is either at the beginning or preceded by ws.
+    m = re.search(r"(?:^|\s)#", expr)
+    if m:
+        expr = expr[: m.start()]
+    return expr.strip()
+
+
+def _iter_expression_parts(path: str):
+    """
+    Yield (kind, modifier, expression, origin) tuples for each attribute line.
+
+    ``kind`` is 'trigger' or 'complete'; ``modifier`` is None (FIRST), 'and' or 'or'.
+    """
+    with open(path, encoding="latin-1") as file:
+        for lineno, raw in enumerate(file, start=1):
+            line = raw.rstrip("\n")
+            m = _ATTR_RE.match(line)
+            if not m:
+                continue
+            kind = m.group(1)
+            rest = m.group(2)
+
+            # The keyword must be followed by whitespace (attribute line), otherwise
+            # this is something else (e.g. a node/edit whose text starts differently).
+            if rest and not rest[0].isspace():
+                continue
+
+            modifier = None
+            mod_match = _MODIFIER_RE.match(rest)
+            if mod_match:
+                modifier = "and" if mod_match.group(1) == "-a" else "or"
+                rest = mod_match.group(2)
+
+            expr = _strip_comment(rest)
+            if not expr:
+                continue
+            origin = "{}:{}".format(os.path.basename(path), lineno)
+            yield kind, modifier, expr, origin
+
+
+def _combine(parts):
+    """
+    Combine multi-part expression fragments into one string.
+
+    Reproduces ``Expression::createAST``: a strict left-associative fold where the
+    accumulated expression is the LEFT child and the new part is the RIGHT child,
+    the operator being chosen by the *new* part's modifier. Each fragment and the
+    running accumulator are parenthesised so the parsed AST matches the server's
+    combined AST regardless of operator precedence.
+
+    ``parts`` is a list of (modifier, expression); the first must be FIRST (None).
+    """
+    combined = None
+    for modifier, expr in parts:
+        if combined is None:
+            combined = "({})".format(expr)
+        else:
+            op = modifier if modifier else "and"  # defensive: a stray FIRST becomes AND
+            combined = "({} {} ({}))".format(combined, op, expr)
+    return combined
+
+
+def extract_from_file(path: str):
+    """
+    Return a list of (expression, origin) from a single .def/.check file.
+    """
+    results = []
+
+    # Group contiguous parts of the same kind. In DEFS output every part of a
+    # node's trigger/complete is written consecutively, so a FIRST part starts a
+    # fresh group and following -a/-o parts extend it.
+    current_kind = None
+    current_parts = []
+    current_origin = None
+
+    def flush():
+        if current_parts:
+            combined = _combine(current_parts)
+            if combined is not None:
+                results.append((combined, current_origin))
+
+    for kind, modifier, expr, origin in _iter_expression_parts(path):
+        if modifier is None:
+            # A new FIRST part: close any open group and start a new one.
+            flush()
+            current_kind = kind
+            current_parts = [(None, expr)]
+            current_origin = origin
+        else:
+            # Continuation (-a/-o). Attach to the open group of the same kind;
+            # if there is none (unexpected), start one treating it as FIRST.
+            if current_parts and current_kind == kind:
+                current_parts.append((modifier, expr))
+            else:
+                flush()
+                current_kind = kind
+                current_parts = [(None, expr)]
+                current_origin = origin
+    flush()
+    return results
+
+
+def coverage_expressions():
+    """
+    Yield (expression, origin) for the embedded coverage expressions.
+    """
+
+    #
+    # A list of handcrafted upplementary expressions covering specific grammar features.
+    #
+    # Some grammar features, notably ``YYYYMMDDThhmmss`` datetime instants and a multi-part
+    # -a/-o combination, were found to be missing in real suites.
+    #
+    # To ensure they are conveniently test, they are embedded here -- rather than supplied
+    # via an external definition file -- so the generated corpus is self-contained. Each item
+    # is a list of (modifier, expression) parts, combined exactly like a multi-line trigger
+    # (see _combine).
+    #
+
+    _COVERAGE_PARTS = [
+        [(None, ":YYYYMMDDThhmmss == 20230101T000000")],
+        [(None, ":YYYYMMDDThhmmss >= 20230101T000000")],
+        [(None, ":YYYYMMDDThhmmss <= 20230101T000000")],
+        [(None, ":YYYYMMDDThhmmss + 3 <= 19700101T000000")],
+        [(None, ":YYYYMMDDThhmmss <= 19700101T000000 + 3")],
+        [(None, ":YYYYMMDDThhmmss >= 19700101T000000 + 3")],
+        [(None, "(:YYYYMMDDThhmmss + 1) == (19700101T000000 + 1)")],
+        [(None, "20240101T060000 == :when")],
+        [(None, ":VARIABLE == 19700101T123456 and b == complete")],
+        [(None, "a == complete"), ("and", "b == complete"), ("or", "c == complete")],
+    ]
+
+    for parts in _COVERAGE_PARTS:
+        combined = _combine(parts)
+        if combined is not None:
+            yield combined, "coverage"
+
+
+#
+# Structural signature (AST-shape proxy) for deduplication
+#
+
+_STATES = {"complete", "aborted", "queued", "submitted", "active", "unknown"}
+_EVENTS = {"set", "clear"}
+_FLAGNAMES = {"late", "zombie", "archived"}
+_WORD_OPS = {"and", "AND", "or", "OR", "not", "eq", "ne", "lt", "le", "gt", "ge"}
+_CAL_FUNCS = ("cal::date_to_julian", "cal::julian_to_date")
+
+_NAME_CHARS = set(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_."
+)
+_DATETIME_RE = re.compile(r"^\d{8}T\d{6}$")
+_INT_RE = re.compile(r"^\d+$")
+
+
+def _tokenize(expr: str):
+    """Return a list of (kind, text) tokens.
+
+    kinds: NAME, INT, DATETIME, STATE, EVENT, FLAGNAME, WORDOP, CALD, CALJ,
+           FLAG ('<flag>'), SLASH, COLON, LPAREN, RPAREN, OP (symbolic operator).
+    """
+    tokens = []
+    i = 0
+    n = len(expr)
+    while i < n:
+        c = expr[i]
+        if c.isspace():
+            i += 1
+            continue
+
+        # Calendar functions (must be checked before generic name scanning).
+        matched_cal = False
+        for func in _CAL_FUNCS:
+            if expr.startswith(func, i):
+                tokens.append(("CALD" if func.endswith("date_to_julian") else "CALJ", func))
+                i += len(func)
+                matched_cal = True
+                break
+        if matched_cal:
+            continue
+
+        # Flag delimiter.
+        if expr.startswith("<flag>", i):
+            tokens.append(("FLAG", "<flag>"))
+            i += len("<flag>")
+            continue
+
+        # Name-shaped run (letters, digits, '_', '.'): integers, datetimes,
+        # states, events, keywords and generic names all take this shape.
+        if c in _NAME_CHARS:
+            j = i
+            while j < n and expr[j] in _NAME_CHARS:
+                j += 1
+            text = expr[i:j]
+            i = j
+            if _DATETIME_RE.match(text):
+                kind = "DATETIME"
+            elif _INT_RE.match(text):
+                kind = "INT"
+            elif text in _STATES:
+                kind = "STATE"
+            elif text in _EVENTS:
+                kind = "EVENT"
+            elif text in _WORD_OPS:
+                kind = "WORDOP"
+            elif text in _FLAGNAMES:
+                kind = "FLAGNAME"
+            else:
+                kind = "NAME"
+            tokens.append((kind, text))
+            continue
+
+        # Two-character symbolic operators.
+        two = expr[i: i + 2]
+        if two in ("==", "!=", ">=", "<=", "&&", "||"):
+            tokens.append(("OP", two))
+            i += 2
+            continue
+
+        if c == "/":
+            tokens.append(("SLASH", c))
+            i += 1
+            continue
+        if c == ":":
+            tokens.append(("COLON", c))
+            i += 1
+            continue
+        if c == "(":
+            tokens.append(("LPAREN", c))
+            i += 1
+            continue
+        if c == ")":
+            tokens.append(("RPAREN", c))
+            i += 1
+            continue
+        if c in "<>+-*%":
+            tokens.append(("OP", c))
+            i += 1
+            continue
+
+        # Anything else (unexpected): keep verbatim so distinct inputs stay distinct.
+        tokens.append(("OTHER", c))
+        i += 1
+    return tokens
+
+
+# Token kinds that can form part of a path/operand run.
+_PATHISH = {"NAME", "INT", "DATETIME"}
+
+
+def signature(expr: str) -> str:
+    """
+    Return a structural signature abstracting operand *values*.
+
+    Since the goal is to support deduplication by comparing signatures:
+     - the operands are collapsed to placeholders (<node>, <attr>, <pattr>,
+       <int>, <datetime>, <state>, <event>, <flag>)
+     - operators are preserved verbatim
+     - parentheses are preserved verbatim
+     - keyword spellings are preserved verbatim
+     - calendar-function identities are preserved verbatim
+
+    Examples:
+     a) '/path/a == complete' and '/other/b == queued' share the signature '<node> == <state>'
+     b) 'a == b' and 'a eq b' do not share the same signature.
+    """
+    tokens = _tokenize(expr)
+    out = []
+    i = 0
+    n = len(tokens)
+    while i < n:
+        kind, text = tokens[i]
+
+        # Try to consume a path/operand run starting here.
+        if kind in _PATHISH or kind == "SLASH":
+            j = i
+            run = []
+            while j < n and tokens[j][0] in _PATHISH | {"SLASH"}:
+                run.append(tokens[j])
+                j += 1
+
+            has_slash = any(t[0] == "SLASH" for t in run)
+
+            # attribute:  <path> : <name>
+            if j + 1 < n and tokens[j][0] == "COLON" and tokens[j + 1][0] in ("NAME", "STATE", "EVENT", "WORDOP",
+                                                                              "FLAGNAME", "INT"):
+                out.append("<attr>")
+                i = j + 2
+                continue
+            # flag_ref:  <path> <flag> <flagname>
+            if j + 1 < n and tokens[j][0] == "FLAG" and tokens[j + 1][0] == "FLAGNAME":
+                out.append("<flag>")
+                i = j + 2
+                continue
+            # bare integer literal (single INT token, not a path)
+            if len(run) == 1 and run[0][0] == "INT":
+                out.append("<int>")
+                i = j
+                continue
+            # bare datetime literal
+            if len(run) == 1 and run[0][0] == "DATETIME":
+                out.append("<datetime>")
+                i = j
+                continue
+            # otherwise a node path (bare name, relative/absolute path)
+            out.append("<node>")
+            i = j
+            continue
+
+        # root-path flag_ref:  '/' <flag> <flagname>   (e.g. '/<flag>late')
+        if kind == "SLASH" and i + 2 < n and tokens[i + 1][0] == "FLAG":
+            out.append("<flag>")
+            i += 3
+            continue
+
+        # parent attribute:  ':' <name>
+        if kind == "COLON" and i + 1 < n and tokens[i + 1][0] in ("NAME", "STATE", "EVENT", "WORDOP", "FLAGNAME"):
+            out.append("<pattr>")
+            i += 2
+            continue
+
+        if kind == "DATETIME":
+            out.append("<datetime>")
+            i += 1
+            continue
+        if kind == "INT":
+            out.append("<int>")
+            i += 1
+            continue
+        if kind == "STATE":
+            out.append("<state>")
+            i += 1
+            continue
+        if kind == "EVENT":
+            out.append("<event>")
+            i += 1
+            continue
+
+        # Operators, parentheses, keyword spellings, cal:: functions: verbatim.
+        out.append(text)
+        i += 1
+
+    return " ".join(out)
+
+
+#
+# Invalid-expression generation
+#
+
+#
+# Rejection candidates are *automatically* generated from the valid corpus by applying
+# deterministic, structure-breaking mutations.
+#
+# A mutation is designed to yield an expression the grammar cannot accept (unbalanced brackets,
+# dangling or leading operators, stray tokens, an illegal relational-against-state comparison, ...).
+#
+# Because a mutation is not *guaranteed* to break every input, the candidates are only proposals.
+#
+# The C++ recording step (ECF_GOLDEN_CORPUS=1) parses each one with the current parser and keeps
+# only those actually rejected, so the committed rejection corpus is always verified against the
+# real parser.
+#
+
+_STATE_WORDS = "|".join(sorted(_STATES))
+_EQ_STATE_RE = re.compile(r"\s(==|eq|!=|ne)\s+(" + _STATE_WORDS + r")\b")
+
+#
+# Word-form operators/keywords must be whitespace-separated from name-shaped tokens (states and node/attribute names).
+#
+# Removing that separation makes the lexer read a single, longer :token:`name` (greedy longest-match),
+# so the keyword disappears and the expression is rejected.
+#
+# These regexes glue an operand and a word-form operator together on the left (``node eq`` -> ``nodeeq``)
+# or on the right (``eq complete`` -> ``eqcomplete``, ``complete and`` -> ``completeand``).
+#
+_WORD_OP_ALT = "and|not|AND|eq|ne|lt|le|gt|ge|or|OR"
+_GLUE_LEFT_RE = re.compile(r"([\w.])[ \t]+(" + _WORD_OP_ALT + r")\b")
+_GLUE_RIGHT_RE = re.compile(r"\b(" + _WORD_OP_ALT + r")[ \t]+([\w.])")
+
+
+def _mutations(expr):
+    """Yield (mutation, mutated_expression) proposals derived from a valid expression."""
+    yield "unbalanced_open", "(" + expr
+    yield "unbalanced_close", expr + ")"
+    yield "drop_open_bracket", expr.replace("(", "", 1) if "(" in expr else None
+    yield "dangling_and", expr + " and"
+    yield "dangling_or", expr + " or"
+    yield "dangling_eq", expr + " =="
+    yield "dangling_plus", expr + " +"
+    yield "leading_and", "and " + expr
+    yield "leading_eq", "== " + expr
+    yield "double_eq", expr.replace(" == ", " == == ", 1) if " == " in expr else None
+    yield "garbage_token", expr + " @"
+    yield "trailing_state", expr + " complete"
+    yield "trailing_token", expr + " zz"
+    # Relational operator against a node/event state is illegal (e.g. 'a < complete').
+    yield "relational_state", _EQ_STATE_RE.sub(r" < \2", expr, count=1) if _EQ_STATE_RE.search(expr) else None
+    # Word-form operator glued to an adjacent operand (missing mandatory whitespace).
+    yield "glue_operand_operator", _GLUE_LEFT_RE.sub(r"\1\2", expr, count=1) if _GLUE_LEFT_RE.search(expr) else None
+    yield "glue_operator_operand", _GLUE_RIGHT_RE.sub(r"\1\2", expr, count=1) if _GLUE_RIGHT_RE.search(expr) else None
+
+
+def build_rejections(valid_expressions, max_per_mutation=50):
+    """
+    Return a deduplicated list of invalid-expression candidates.
+
+    Candidates are generated from the given valid expressions.
+
+    Duplicates (by AST structural signature) are collapsed and each mutation
+    kind is capped at ``max_per_mutation`` distinct shapes, so the set stays small
+    yet diverse across both malformations and underlying structures.
+    """
+    seen = set()
+    per_mutation = {}
+    order = []
+    for expr in valid_expressions:
+        for mutation, candidate in _mutations(expr):
+            if not candidate or candidate == expr:
+                continue
+            if per_mutation.get(mutation, 0) >= max_per_mutation:
+                continue
+            try:
+                sig = "REJ:" + signature(candidate)
+            except Exception:  # pragma: no cover - defensive
+                sig = "REJ-RAW:" + candidate
+            if sig in seen:
+                continue
+            seen.add(sig)
+            per_mutation[mutation] = per_mutation.get(mutation, 0) + 1
+            order.append({"expression": candidate, "mutation": mutation})
+    return order
+
+
+#
+# Name anonymisation
+#
+# Real definitions expose node and variable names that can reveal internal host/server/release identifiers.
+#
+# To keep the corpus safe to publish, every identifier is rewritten to a generic placeholder,consistently
+# within each expression:
+#   - node-path *segment* names -> '/suite/family/task/nodeN' (path structure preserved);
+#   - attribute/parent-variable names (the identifier after ':') -> 'attribN'.
+#
+# The following are preserved (structural or literal, never an identifier):
+#   - integers,
+#   - datetimes,
+#   - node/event states,
+#   - flags,
+#   - operators,
+#   - keywords,
+#   - the 'cal::' function names
+#   - the '<flag>' literal,
+#   - plus, the path shape itself (depth, absolute '/', relative './'/'../').
+#
+# Only identifier strings change, so the parsed AST keeps the same structure while
+# carrying no revealing names.
+#
+
+_CAL_NAMES = {"cal", "date_to_julian", "julian_to_date"}
+# 'flag' is the literal inside the '<flag>' flag-reference delimiter and must be kept.
+_KEEP_WORDS = _STATES | _EVENTS | _FLAGNAMES | _WORD_OPS | _CAL_NAMES | {"flag"}
+_NAME_TOKEN_RE = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_.]*")
+_GENERIC_NAMES = ("suite", "family", "task")
+
+
+def _generic_name(index):
+    if index < len(_GENERIC_NAMES):
+        return _GENERIC_NAMES[index]
+    return "node{}".format(index + 1)
+
+
+def anonymise(expression):
+    """Rewrite node-path and attribute names to generic placeholders (see header)."""
+    path_map = {}
+    attr_map = {}
+
+    def repl(match):
+        token = match.group()
+        start = match.start()
+        prev = expression[start - 1] if start > 0 else ""
+        # Literals and keywords are never identifiers: keep them verbatim.
+        if _INT_RE.match(token) or _DATETIME_RE.match(token) or token in _KEEP_WORDS:
+            return token
+        # A name right after ':' is an attribute / parent-variable name.
+        if prev == ":":
+            return attr_map.setdefault(token, "attrib{}".format(len(attr_map) + 1))
+        # Otherwise it is a node-path segment name.
+        return path_map.setdefault(token, _generic_name(len(path_map)))
+
+    return _NAME_TOKEN_RE.sub(repl, expression)
+
+
+#
+# Driver
+#
+
+
+def build_corpus(inputs, checkpoint_origin=None):
+    seen = {}
+    order = []
+    total = 0
+
+    def consume(expression, origin):
+        nonlocal total
+        expression = anonymise(expression)
+        total += 1
+        try:
+            sig = signature(expression)
+        except Exception as exc:  # pragma: no cover - defensive
+            sys.stderr.write(
+                "warning: could not compute signature for {!r}: {}\n".format(expression, exc)
+            )
+            sig = "RAW:" + expression
+        if sig in seen:
+            return
+        seen[sig] = expression
+        order.append((expression, sig, origin))
+
+    # Embedded coverage expressions first, so they become the representatives for the
+    # grammar features they exercise.
+    for expression, origin in coverage_expressions():
+        consume(expression, origin)
+
+    for path in inputs:
+        for expression, origin in extract_from_file(path):
+            consume(expression, origin)
+
+    entries = [
+        {"expression": expression, "expected": None}
+        for (expression, sig, origin) in order
+    ]
+
+    rejections = build_rejections(expression for (expression, sig, origin) in order)
+
+    metadata = {
+        "generated": datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat(),
+        "generator": "extract_expressions",
+        "extracted": total,
+        "unique": len(entries),
+        "rejection_candidates": len(rejections),
+    }
+    if checkpoint_origin:
+        metadata["checkpoint_origin"] = checkpoint_origin
+
+    return {
+        "metadata": metadata,
+        "valid_expressions": entries,
+        "invalid_expressions": rejections,
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Extract a golden corpus of trigger/complete expressions."
+    )
+    parser.add_argument(
+        "--in",
+        dest="inputs",
+        action="append",
+        required=True,
+        metavar="FILE",
+        help="input .def or .check file (repeatable)",
+    )
+    parser.add_argument(
+        "--out",
+        dest="output",
+        required=True,
+        metavar="FILE",
+        help="output corpus JSON file",
+    )
+    parser.add_argument(
+        "--checkpoint-origin",
+        dest="checkpoint_origin",
+        default=None,
+        help="optional label recording where the checkpoints came from",
+    )
+    args = parser.parse_args(argv)
+
+    missing = [p for p in args.inputs if not os.path.isfile(p)]
+    if missing:
+        parser.error("input file(s) not found: " + ", ".join(missing))
+
+    corpus = build_corpus(args.inputs, args.checkpoint_origin)
+
+    with open(args.output, "w", encoding="utf-8") as handle:
+        json.dump(corpus, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+
+    sys.stderr.write(
+        "extracted {} expression(s), {} unique structure(s), {} rejection candidate(s) -> {}\n".format(
+            corpus["metadata"]["extracted"],
+            corpus["metadata"]["unique"],
+            corpus["metadata"]["rejection_candidates"],
+            args.output,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Description

- Add a proper trigger/complete expression specification
- Detect and reject invalid expressions (e.g. `/p/n1 == completeand /p/n2 == complete`)

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-397
<!-- PREVIEW-URL_END -->