### PR TITLE
Give each REST API test its own certificate directory

### DIFF
--- a/libs/rest/CMakeLists.txt
+++ b/libs/rest/CMakeLists.txt
@@ -119,6 +119,12 @@ if (ENABLE_HTTP AND ENABLE_SERVER)
       test/TestHttp_main.cpp # test entry point
     )
 
+    #
+    # Each test provisions a SSL certificate on start-up, and uses ECF_RESTAPI_CERT_DIRECTORY to hold it.
+    # The tests below are allowed to run concurrently, and therefore must be given directories of their own.
+    # Sharing a directory causes a race condition between the tests that overwrite each other's certificate.
+    #
+
     ecbuild_add_test(
       TARGET
         s_http
@@ -126,6 +132,8 @@ if (ENABLE_HTTP AND ENABLE_SERVER)
         integration nightly slow
       SOURCES
         ${test_srcs}
+      ENVIRONMENT
+        "ECF_RESTAPI_CERT_DIRECTORY=${CMAKE_CURRENT_BINARY_DIR}/ssl.using_tcpip_backend"
       LIBS
         libhttp
         ecflow_all
@@ -153,6 +161,8 @@ if (ENABLE_HTTP AND ENABLE_SERVER)
         ${test_srcs}
       DEFINITIONS
         ECF_TEST_HTTP_BACKEND
+      ENVIRONMENT
+        "ECF_RESTAPI_CERT_DIRECTORY=${CMAKE_CURRENT_BINARY_DIR}/ssl.using_http_backend"
       LIBS
         libhttp
         ecflow_all

--- a/libs/rest/src/ecflow/http/HttpServer.cpp
+++ b/libs/rest/src/ecflow/http/HttpServer.cpp
@@ -214,6 +214,17 @@ void start_server(httplib::Server& http_server, const HttpServer::BoundCallback&
     const std::string proto = (opts.no_ssl ? "http" : "https");
 
     try {
+        // An unusable server declines to bind, without ever attempting to acquire the port. This is checked
+        // separately, since otherwise the failure is indistinguishable from a port already in use -- and, in
+        // the SSL case, the cause (a certificate that cannot be loaded) is unrelated to the port.
+        if (http_server.is_valid() == false) {
+            std::string reason = "Server is not in a usable state, and is unable to accept connections";
+            if (opts.no_ssl == false) {
+                reason += " (unable to load the certificate and private key found in " + opts.cert_directory + ")";
+            }
+            throw std::runtime_error(reason);
+        }
+
         // The port is acquired separately from the accept loop, so that a failure to bind is detected before
         // the server announces itself as listening, and is reported to the caller instead of being ignored.
         if (http_server.bind_to_port("0.0.0.0", opts.port) == false) {

--- a/libs/rest/src/ecflow/http/HttpServer.hpp
+++ b/libs/rest/src/ecflow/http/HttpServer.hpp
@@ -31,7 +31,8 @@ public:
     ///
     /// @param[in] on_bound Notification issued once the port has been acquired; not called if the port
     /// cannot be acquired. May be empty, in which case no notification is issued.
-    /// @throws std::runtime_error if the port cannot be acquired, or if the server stops unexpectedly.
+    /// @throws std::runtime_error if the server cannot be brought into a usable state (e.g., when the certificate and
+    /// private key cannot be loaded), if the port cannot be acquired, or if the server stops unexpectedly.
     ///
     void run(const BoundCallback& on_bound = {}) const;
 

--- a/libs/rest/test/TestApiV1.cpp
+++ b/libs/rest/test/TestApiV1.cpp
@@ -112,25 +112,41 @@ const std::string& api_port_str() {
     return port;
 }
 
+///
+/// @brief Provisions the certificate used by the REST API server under test.
+///
+/// The certificate is provisioned in the directory given by ECF_RESTAPI_CERT_DIRECTORY, as defined by the
+/// build system, and is removed once the test completes. The same variable directs the server under test
+/// to the certificate.
+///
+/// The ECF_RESTAPI_CERT_DIRECTORY must be provided, and be specific for the test. The sharing of this
+/// directory between multiple tests causes a race condition, where certificates can potentially be overwritten.
+/// Two concurrent provisions write server.key and server.crt in turn, and an interleaving of those writes
+/// leaves behind a certificate and a private key that do not belong together. The server is then unable to
+/// create an SSL context, and reports that as an inability to acquire the port, since bind_to_port() declines
+/// to bind a server that is not in a usable state.
+///
+/// @return The provisioned Certificate, which removes the certificate files once destroyed
+/// @throws std::runtime_error if ECF_RESTAPI_CERT_DIRECTORY is undefined or empty
+///
 std::unique_ptr<Certificate> create_certificate() {
-    auto cert_dir = ecf::environment::fetch("ECF_API_CERT_DIRECTORY");
+    auto configured = ecf::environment::fetch("ECF_RESTAPI_CERT_DIRECTORY");
 
-    const std::string path_to_cert = (cert_dir) ? cert_dir.value() : ecf::environment::get("HOME") + "/.ecflowrc/ssl/";
+    if (!configured || configured.value().empty()) {
+        throw std::runtime_error("No valid ECF_RESTAPI_CERT_DIRECTORY provided. A certificate directory is required "
+                                 "for this test, typically provided by the build system; falling back to a "
+                                 "default/shared directory would cause a race condition with tests overwriting each "
+                                 "other's certificate.");
+    }
 
-    std::unique_ptr<Certificate> cert;
+    const std::string path_to_cert = configured.value();
+
+    fs::create_directories(path_to_cert);
+
+    auto cert = std::make_unique<Certificate>(path_to_cert);
 
     BOOST_TEST_MESSAGE("Certificates at " << path_to_cert);
 
-    if (fs::exists(path_to_cert + "/server.crt") == false || fs::exists(path_to_cert + "/server.key") == false) {
-        if (fs::exists(path_to_cert) == false) {
-            fs::create_directories(path_to_cert);
-        }
-
-        cert = std::make_unique<Certificate>(path_to_cert);
-
-        setenv("ECF_API_CERT_DIRECTORY", path_to_cert.c_str(), 1);
-        return cert;
-    }
     return cert;
 }
 


### PR DESCRIPTION
### Description

As per PR title; see commit messages for details.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-408
<!-- PREVIEW-URL_END -->