### PR TITLE
fix flaky test that fails between 16:00 and 16:01

### DIFF
--- a/libs/base/test/TestRequeueNodeCmd.cpp
+++ b/libs/base/test/TestRequeueNodeCmd.cpp
@@ -187,7 +187,12 @@ BOOST_AUTO_TEST_CASE(test_ecflow_359) {
 
     defs_ptr the_defs = Defs::create();
     suite_ptr suite   = the_defs->add_suite("s1");
-    family_ptr f1     = suite->add_family("f1");
+    // A fixed clock, so that the time dependency below always holds, whatever the real time of day
+    ClockAttr clockAttr(15, 12, 2010, false);
+    clockAttr.set_gain(9 /*hour*/, 30 /*minutes*/); // start at 09:30
+    suite->addClock(clockAttr);
+
+    family_ptr f1 = suite->add_family("f1");
     f1->addRepeat(RepeatDate("YMD", 20090916, 20090928, 1));
 
     family_ptr parent = f1->add_family("parent");


### PR DESCRIPTION
### Description

This is a crucial fix, otherwise there can be a time of day, where this test fails

With the help of an AI agent I used the rocky8 image and set its system clock to different times and deterministically reproduced a failure
```
2026-09-04 09:59:59  u_base_unfixed   PASS
  2026-09-04 09:59:59  u_base_fixed     PASS
  2026-09-04 15:59:59  u_base_unfixed   PASS
  2026-09-04 15:59:59  u_base_fixed     PASS
  2026-09-04 16:00:00  u_base_unfixed   FAIL (4 assertion errors)
  2026-09-04 16:00:00  u_base_fixed     PASS
  2026-09-04 16:00:30  u_base_unfixed   FAIL (4 assertion errors)
  2026-09-04 16:00:30  u_base_fixed     PASS
  2026-09-04 16:00:59  u_base_unfixed   FAIL (4 assertion errors)
  2026-09-04 16:00:59  u_base_fixed     PASS
  2026-09-04 16:01:00  u_base_unfixed   PASS
  2026-09-04 16:01:00  u_base_fixed     PASS
  2026-09-04 23:59:59  u_base_unfixed   PASS
  2026-09-04 23:59:59  u_base_fixed     PASS

  The failure window is exactly [16:00:00, 16:00:59] UTC — one minute wide, closing at 16:01:00,
```


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-430
<!-- PREVIEW-URL_END -->