### PR TITLE
Name jobs from _resolved.job-name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
 
   build:
     needs: [ci-approval, resolve]
-    name: build+test (${{ matrix.platform }}, ${{ matrix.cxx-compiler }})
+    name: build+test (${{ matrix._resolved['job-name'] }})
     runs-on: ${{ matrix['runs-on'] }}
     container:
       image: ${{ matrix.container || '' }}
@@ -136,7 +136,7 @@ jobs:
 
   build-hpc:
     needs: [ci-approval, resolve]
-    name: build-hpc (${{ matrix.platform }})
+    name: build-hpc (${{ matrix._resolved['job-name'] }})
     runs-on: ${{ matrix['runs-on'] }}
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/cross-repo-trigger-hpc.yml
+++ b/.github/workflows/cross-repo-trigger-hpc.yml
@@ -115,7 +115,7 @@ jobs:
     needs:
     - resolve
     if: contains(fromJSON(inputs.from-jobs), 'ecbuild/build-hpc') || contains(fromJSON(inputs.from-jobs), 'stack-deps/build-hpc') || inputs.rebuild-request
-    name: ecflow/build-hpc (${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }})
+    name: ecflow/build-hpc (${{ matrix._resolved['job-name'] }})
     runs-on: ${{ matrix['runs-on'] }}
     container:
       image: ${{ matrix.container || '' }}
@@ -139,7 +139,7 @@ jobs:
         token: ${{ steps.mint.outputs.token }}
         head-repo: ${{ inputs.from-repo }}
         head-sha: ${{ inputs.from-sha }}
-        name: ecflow/build-hpc (${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }})
+        name: ecflow/build-hpc (${{ matrix._resolved['job-name'] }})
         details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         phase: start
     - name: Announce image
@@ -203,7 +203,7 @@ jobs:
         token: ${{ steps.mint.outputs.token }}
         head-repo: ${{ inputs.from-repo }}
         head-sha: ${{ inputs.from-sha }}
-        name: ecflow/build-hpc (${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }})
+        name: ecflow/build-hpc (${{ matrix._resolved['job-name'] }})
         details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         phase: finish
         conclusion: ${{ job.status }}

--- a/.github/workflows/cross-repo-trigger.yml
+++ b/.github/workflows/cross-repo-trigger.yml
@@ -115,7 +115,7 @@ jobs:
     needs:
     - resolve
     if: contains(fromJSON(inputs.from-jobs), 'ecbuild/build') || contains(fromJSON(inputs.from-jobs), 'stack-deps/build') || inputs.rebuild-request
-    name: ecflow/build (${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }})
+    name: ecflow/build (${{ matrix._resolved['job-name'] }})
     runs-on: ${{ matrix['runs-on'] }}
     container:
       image: ${{ matrix.container || '' }}
@@ -136,7 +136,7 @@ jobs:
         token: ${{ steps.mint.outputs.token }}
         head-repo: ${{ inputs.from-repo }}
         head-sha: ${{ inputs.from-sha }}
-        name: ecflow/build (${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }})
+        name: ecflow/build (${{ matrix._resolved['job-name'] }})
         details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         phase: start
     - name: Announce image
@@ -205,7 +205,7 @@ jobs:
         token: ${{ steps.mint.outputs.token }}
         head-repo: ${{ inputs.from-repo }}
         head-sha: ${{ inputs.from-sha }}
-        name: ecflow/build (${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }})
+        name: ecflow/build (${{ matrix._resolved['job-name'] }})
         details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         phase: finish
         conclusion: ${{ job.status }}


### PR DESCRIPTION
### Why

The hand-written `ci.yml` and the generated `cross-repo-trigger*.yml` had drifted:
all four HPC legs vary `cxx-compiler`, yet `ci.yml` titled them
`build-hpc (${{ matrix.platform }})` — distinguishable only because the platform
slug happens to be hand-encoded as `hpc-atos-gnu`/`-intel`/`-aocc`/`-nvidia`.
### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.

<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/ecflow/pull-requests/PR-431
<!-- PREVIEW-URL_END -->